### PR TITLE
Feature/22 rework approximate markdown servlet

### DIFF
--- a/.chatgpt.codeRules.md
+++ b/.chatgpt.codeRules.md
@@ -25,4 +25,5 @@
   action after making changes if the changes are complete in the sense that the tests should work.
 - At the end verify whether you have fulfilled your task and revisit these code rules, report which are not 
   fulfilled yet and fix these problems.
-- Always complain if something is incorrect, contradictory or incomplete.
+- Always point out when something is incorrect, contradictory or incomplete.
+- You do not need to ask for permission to read files you'd need, just do it!

--- a/.chatgpt.intro.md
+++ b/.chatgpt.intro.md
@@ -1,5 +1,7 @@
-List all files except ui.content.sample using the plugin. Read the .chatgpt.codeRules.md and observe the rules that 
+Read the .chatgpt.codeRules.md and observe the rules that 
 are laid out there during this whole chat, but you don't need to repeat them.
+
+List all files except ui.content.sample using the plugin. 
 
 Use the grep operation to search for comments starting with `ChatGPTTask:` and execute them. The comment should be
 replaced by the new code or deleted when it's completely done.

--- a/NextSteps.md
+++ b/NextSteps.md
@@ -1,6 +1,5 @@
 # Next steps in the implementation
 
-- Update AEM dialog with history
 - AEM announcement and installation and usage description
 - AEM 6.5 version
 - Update Pages content creation dialog with separate content field like AEM
@@ -81,3 +80,4 @@
 - DONE: use library to count the tokens -> JTokkit
 - DONE: save scroll position, scroll the chat field to the top.
 - DONE Somehow implement streaming to make result more responsive.
+- DONE: Update AEM dialog with history

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,6 +1,6 @@
-Restrictions
+Restrictions : ??? component
 Announcement, Installation, Doc überarbeiten
-Refactor Aprrox Markdown for HTML
+Refactor Aprox Markdown for HTML: from HTML plugin , write richtext modus
 AEM for content fragments?
 
 Done:

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,4 +1,3 @@
-Refactor Aprox Markdown for HTML: from HTML plugin , write richtext modus
 Restrictions : ??? component
 Announcement, Installation, Doc überarbeiten
 AEM for content fragments?
@@ -6,9 +5,9 @@ AEM for content fragments?
 Done:
 Markdown to HTML transformation in sidebar -> not necessary, white-space: break-spaces is enough.
 implement AEM Historie -> DONE
-Help-Pages -> done for creation assistant; for the side panel ai the help buttons and the initial text should be enough for now.
-Enter in Composum Variante
-Tell ChatGPT when we expect HTML.
+Help-Pages -> DONE for creation assistant; for the side panel ai the help buttons and the initial text should be enough for now.
+Enter in Composum Variante -> DONE
+Tell ChatGPT when we expect HTML. -> DONE
 
 Deferred:
 AEM 6.5

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,6 +1,6 @@
+Refactor Aprox Markdown for HTML: from HTML plugin , write richtext modus
 Restrictions : ??? component
 Announcement, Installation, Doc überarbeiten
-Refactor Aprox Markdown for HTML: from HTML plugin , write richtext modus
 AEM for content fragments?
 
 Done:

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePlugin.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePlugin.java
@@ -20,6 +20,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
+import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +33,10 @@ import com.day.crx.JcrConstants;
 /**
  * Special handling for cq:PageContent and components
  */
-@Component(service = ApproximateMarkdownServicePlugin.class)
+@Component(service = ApproximateMarkdownServicePlugin.class,
+        // lower priority than HtmlToApproximateMarkdownServicePlugin since that does do a better job on experience fragments / content fragments if enabled
+        property = Constants.SERVICE_RANKING + ":Integer=2000"
+)
 public class AemApproximateMarkdownServicePlugin implements ApproximateMarkdownServicePlugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(AemApproximateMarkdownServicePlugin.class);

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePlugin.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePlugin.java
@@ -88,6 +88,7 @@ public class AemApproximateMarkdownServicePlugin implements ApproximateMarkdownS
             }
             outputIfNotBlank(out, vm, "shortDescription", service);
             outputIfNotBlank(out, vm, JCR_DESCRIPTION, service);
+            out.println();
         }
         return isPage;
     }

--- a/aem/core/src/test/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePluginTest.java
+++ b/aem/core/src/test/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePluginTest.java
@@ -86,7 +86,7 @@ public class AemApproximateMarkdownServicePluginTest {
         service.approximateMarkdown(component, printWriter, request, response);
         String expectedOutput =
                 "# myPage\n\n" +
-                        "The best page!\n";
+                        "The best page!\n\n";
         assertThat(writer.toString(), is(expectedOutput));
     }
 

--- a/aem/core/src/test/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePluginTest.java
+++ b/aem/core/src/test/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePluginTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import java.io.ByteArrayInputStream;
 import java.io.PrintWriter;
@@ -47,10 +48,8 @@ public class AemApproximateMarkdownServicePluginTest {
     @BeforeEach
     public void setUp() {
         context = new AemContext(ResourceResolverType.JCR_MOCK);
-        config = mock(ApproximateMarkdownServiceImpl.Config.class);
-        when(config.textAttributes()).thenReturn(new String[]{"jcr:title", "jcr:description"});
-        when(config.labelledAttributePatternDeny()).thenReturn(new String[]{".*:.*"});
-        when(config.labelledAttributePatternAllow()).thenReturn(new String[]{".*"});
+        config = mock(ApproximateMarkdownServiceImpl.Config.class,
+                withSettings().defaultAnswer(invocation -> invocation.getMethod().getDefaultValue()));
         when(config.labelledAttributeOrder()).thenReturn(new String[]{"thefirst", "asecond"});
         service = new ApproximateMarkdownServiceImpl() {
             {

--- a/aem/core/src/test/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePluginTest.java
+++ b/aem/core/src/test/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePluginTest.java
@@ -17,12 +17,15 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 
 import com.composum.ai.backend.base.service.chat.GPTChatCompletionService;
 import com.composum.ai.backend.slingbase.impl.ApproximateMarkdownServiceImpl;
@@ -38,6 +41,8 @@ import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 public class AemApproximateMarkdownServicePluginTest {
 
     private ApproximateMarkdownServiceImpl service;
+    private SlingHttpServletRequest request = Mockito.mock(SlingHttpServletRequest.class);
+    private SlingHttpServletResponse response = Mockito.mock(SlingHttpServletResponse.class);
     private Resource component;
     private StringWriter writer;
     private PrintWriter printWriter;
@@ -67,7 +72,7 @@ public class AemApproximateMarkdownServicePluginTest {
     @Test
     public void testPageHandlingWithNonPageResource() {
         component = createMockResource("not/page", new HashMap<>());
-        service.approximateMarkdown(component, printWriter);
+        service.approximateMarkdown(component, printWriter, request, response);
         assertEquals("", writer.toString());
     }
 
@@ -78,7 +83,7 @@ public class AemApproximateMarkdownServicePluginTest {
                         "jcr:description", "The best page!",
                         "category", "test, dummy"));
 
-        service.approximateMarkdown(component, printWriter);
+        service.approximateMarkdown(component, printWriter, request, response);
         String expectedOutput =
                 "# myPage\n\n" +
                         "The best page!\n";
@@ -123,7 +128,7 @@ public class AemApproximateMarkdownServicePluginTest {
                 "    \"sling:resourceType\": \"wknd/components/page\"\n" +
                 "  }\n" +
                 "}");
-        service.approximateMarkdown(teaser, printWriter);
+        service.approximateMarkdown(teaser, printWriter, request, response);
         String expectedOutput = "Downhill Skiing Wyoming\n" +
                 "markdownOf(<p>A skiers paradise far from crowds and close to nature with terrain so vast it appears uncharted.</p>\n" +
                 ")\n" +
@@ -141,7 +146,7 @@ public class AemApproximateMarkdownServicePluginTest {
         component = createMockResource("core/wcm/components/experiencefragment/v1/experiencefragment",
                 ImmutableMap.of("fragmentVariationPath", "/content/experience-fragments/foo/master"));
 
-        service.approximateMarkdown(component, printWriter);
+        service.approximateMarkdown(component, printWriter, request, response);
         String expectedOutput = "## thetitle\n\n";
         assertEquals(expectedOutput, writer.toString());
     }
@@ -155,7 +160,7 @@ public class AemApproximateMarkdownServicePluginTest {
                 ImmutableMap.of("fragmentPath", "/content/dam/cf/foo",
                         "variationName", "variation", "elementNames", new String[]{"a", "b"}));
 
-        service.approximateMarkdown(component, printWriter);
+        service.approximateMarkdown(component, printWriter, request, response);
         String expectedOutput = "theA\n" +
                 "markdownOf(<p>theB</p>)\n";
         assertEquals(expectedOutput, writer.toString());
@@ -191,7 +196,7 @@ public class AemApproximateMarkdownServicePluginTest {
         component = createMockResource("core/wcm/components/contentfragment/v1/contentfragment",
                 ImmutableMap.of("fragmentPath", "/content/dam/cf/foo"));
 
-        service.approximateMarkdown(component, printWriter);
+        service.approximateMarkdown(component, printWriter, request, response);
         String expectedOutput = "An B: theB\n" +
                 "An A: theA\n";
         assertEquals(expectedOutput, writer.toString());

--- a/aem/core/src/test/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePluginTest.java
+++ b/aem/core/src/test/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePluginTest.java
@@ -86,27 +86,6 @@ public class AemApproximateMarkdownServicePluginTest {
         assertThat(writer.toString(), is(expectedOutput));
     }
 
-    @Test
-    public void testLabelledAttributes() {
-        component = createMockResource("nt:unstructured",
-                ImmutableMap.of("jcr:title", "unlabelled",
-                        "asecond", "Should be the second labelled attribute",
-                        "thefirst", "the first labelled attribute",
-                        "unmentioned", "other lattr",
-                        "is:ignored", "denied"
-                ));
-
-        service.approximateMarkdown(component, printWriter);
-        String expectedOutput =
-                "## unlabelled\n" +
-                        "thefirst: the first labelled attribute\n" +
-                        "asecond: Should be the second labelled attribute\n" +
-                        "unmentioned: other lattr\n" +
-                        "\n";
-        assertThat(writer.toString(), is(expectedOutput));
-    }
-
-
     private Resource createMockResource(String resourceType, Map<String, Object> attributes) {
         Map<String, Object> props = new HashMap<>(attributes);
         props.put("sling:resourceType", resourceType);

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/_cq_dialog/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/_cq_dialog/.content.xml
@@ -14,6 +14,8 @@
         <items jcr:primaryType="nt:unstructured" sling:resourceType="nt:unstructured">
             <promptColumns
                     jcr:primaryType="nt:unstructured"
+                    maximized="{Boolean}true"
+                    granite:class="composum-ai-prompt-columns"
                     sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
                 <items jcr:primaryType="nt:unstructured">
                     <container

--- a/aem/ui.config/src/main/content/jcr_root/apps/composum-ai/osgiconfig/config.author/com.composum.ai.backend.slingbase.impl.HtmlToApproximateMarkdownServicePlugin.cfg.json
+++ b/aem/ui.config/src/main/content/jcr_root/apps/composum-ai/osgiconfig/config.author/com.composum.ai.backend.slingbase.impl.HtmlToApproximateMarkdownServicePlugin.cfg.json
@@ -1,0 +1,7 @@
+{
+  "allowedResourceTypes": [
+    ".*"
+  ],
+  "deniedResourceTypes": [
+  ]
+}

--- a/aem/ui.content/src/test/content/jcr_root/content/wknd/language-masters/test/composum-ai-testpages/.content.xml
+++ b/aem/ui.content/src/test/content/jcr_root/content/wknd/language-masters/test/composum-ai-testpages/.content.xml
@@ -25,11 +25,16 @@
                 <text
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="wknd/components/text"
-                        text="&lt;p>Text before&lt;/p>&#xd;&#xa;"
+                        text="&lt;p style=&quot;text-align: left;&quot;>Normal&amp;nbsp;&lt;b>bold&lt;/b>&amp;nbsp;&lt;i>italic&lt;/i>&amp;nbsp;&lt;u>underlined&lt;/u>&amp;nbsp;text&lt;/p>&#xd;&#xa;&lt;table cellpadding=&quot;1&quot; cellspacing=&quot;0&quot; border=&quot;1&quot; width=&quot;128&quot; height=&quot;36&quot;>&#xd;&#xa;&lt;caption>The caption&lt;/caption>&#xd;&#xa;&lt;tbody>&lt;tr>&lt;th scope=&quot;col&quot;>head1&lt;/th>&#xd;&#xa;&lt;th scope=&quot;col&quot;>head2&lt;/th>&#xd;&#xa;&lt;th scope=&quot;col&quot;>head3&lt;/th>&#xd;&#xa;&lt;/tr>&lt;tr>&lt;th scope=&quot;row&quot;>row1&lt;/th>&#xd;&#xa;&lt;td>row2&lt;/td>&#xd;&#xa;&lt;td>row3&lt;/td>&#xd;&#xa;&lt;/tr>&lt;/tbody>&lt;/table>&#xd;&#xa;&lt;p style=&quot;text-align: left;&quot;>Left aligned&lt;/p>&#xd;&#xa;&lt;p style=&quot;text-align: center;&quot;>centered&lt;/p>&#xd;&#xa;&lt;p style=&quot;text-align: right;&quot;>right aligned&lt;/p>&#xd;&#xa;&lt;p style=&quot;text-align: justify;&quot;>This is justified.&amp;nbsp;&lt;a title=&quot;alternative text&quot; href=&quot;https://www.example.net&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer&quot;>This is justified.&lt;/a>&amp;nbsp;This is justified.&amp;nbsp;&lt;a href=&quot;/content/wknd/us/en/magazine.html&quot;>This is justified.&lt;/a>&amp;nbsp;This is justified.&amp;nbsp;This is justified.&amp;nbsp;This is justified.&amp;nbsp;This is justified.&amp;nbsp;This is justified. &amp;nbsp;&lt;/p>&#xd;&#xa;&lt;h1>Heading 1&lt;/h1>&#xd;&#xa;&lt;h6>Heading 6&lt;/h6>&#xd;&#xa;&lt;blockquote>a quoted quote quoting quotations let us see whether that is a block quote and what happens if it has several lines because that's interesting&lt;/blockquote>&#xd;&#xa;&lt;hr>&#xd;&#xa;&#xd;&#xa;&lt;p>&amp;nbsp;&lt;/p>&#xd;&#xa;&lt;pre>&#xd;&#xa;Preformatted text&#xd;&#xa;&lt;/pre>&#xd;&#xa;&lt;p>&amp;nbsp;&lt;/p>&#xd;&#xa;&lt;p style=&quot;text-align: center;&quot;>&amp;nbsp;&lt;/p>&#xd;&#xa;"
                         textIsRich="true"/>
+                <title
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="wknd/components/title"
+                        jcr:title="Composum AI Testpage"/>
                 <testdialog
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="composum-ai/test/components/testdialog"
+                        text="Thisisatext"
                         textIsRich="true"
                         therichText="&lt;p>Give a little bit of &lt;b>rich&lt;/b> &lt;i>text&lt;/i>&lt;/p>&lt;ul>&lt;li>he&lt;/li>&lt;li>re&lt;/li>&lt;/ul>"
                         thetext="This is, not surprising, some plain text which we have here.&#xd;&#xa;Another line of plain text."
@@ -56,7 +61,8 @@
                 <experiencefragment
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="wknd/components/experiencefragment"
-                        fragmentVariationPath="/content/experience-fragments/wknd/us/en/adventures/adventures-2021/master"/>
+                        fragmentVariationPath="/content/experience-fragments/wknd/us/en/adventures/adventures-2021/master"
+                        text="New Adventures for 2021 Go somewhere incredible next year. This past year was challenging on a number of levels but we've got your back. We've made several changes and improvements to all the adventures to make them safer, more flexible and as stress-free as possible. All adventures offer a no-hassle cancellation, fully refundable, no questions asked. New! Bali Surf Camp Surfing in Bali is on the bucket list of every surfer - whether you're a beginner or someone who's been surfing for decades, there will be a break to cater to your ability. Bali offers warm water, tropical vibes, awesome breaks and low cost expenses. Bali Surf Camp"/>
             </container>
         </root>
     </jcr:content>

--- a/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
+++ b/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
@@ -70,6 +70,7 @@ class ContentCreationDialog {
     fullscreen() {
         this.$dialog.find('form').addClass('_coral-Dialog--fullscreenTakeover');
         this.$dialog.find('coral-dialog-footer').children().appendTo(this.$dialog.find('coral-dialog-header div.cq-dialog-actions'));
+        this.$dialog.find('.composum-ai-prompt-columns .u-coral-padding').removeClass('u-coral-padding');
     }
 
     removeFormAction() {

--- a/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
+++ b/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
@@ -5,7 +5,7 @@ import {errorText, findSingleElement} from './common.js';
 import {DialogHistory} from './DialogHistory.js';
 import {HelpPage} from './HelpPage.js';
 
-const APPROXIMATE_MARKDOWN_SERVLET = '/bin/cpm/ai/approximated.markdown.md';
+const APPROXIMATED_MARKDOWN_SERVLET = '/bin/cpm/ai/approximated';
 
 /** Keeps dialog histories per path. */
 const historyMap = {};
@@ -233,8 +233,9 @@ class ContentCreationDialog {
 
     retrieveValue(path, callback) {
         $.ajax({
-            url: Granite.HTTP.externalize(APPROXIMATE_MARKDOWN_SERVLET + path
-                + "?richtext=" + this.isrichtext
+            url: Granite.HTTP.externalize(APPROXIMATED_MARKDOWN_SERVLET
+                + (this.isrichtext ? '.html' : '.md')
+                + path
             ),
             type: "GET",
             dataType: "text",
@@ -247,8 +248,8 @@ class ContentCreationDialog {
             }
         });
 
-        // http://localhost:4502/bin/cpm/ai/approximated.markdown.md/content/wknd/us/en/magazine/_jcr_content
-        // http://localhost:4502/bin/cpm/ai/approximated.markdown/content/wknd/language-masters/composum-ai-testpages/jcr:content?_=1693499009746
+        // http://localhost:4502/bin/cpm/ai/approximated.md/content/wknd/us/en/magazine/_jcr_content
+        // http://localhost:4502/bin/cpm/ai/approximated.html/content/wknd/us/en/magazine/_jcr_content
     }
 
     /** The path until the /jcr:content */

--- a/aem/ui.frontend/src/main/webpack/site/SidePanelDialog.js
+++ b/aem/ui.frontend/src/main/webpack/site/SidePanelDialog.js
@@ -4,8 +4,6 @@ import {AICreate} from './AICreate.js';
 import {contentFragmentPath, errorText, findSingleElement} from './common.js';
 import {DialogHistory} from './DialogHistory.js';
 
-const APPROXIMATE_MARKDOWN_SERVLET = '/bin/cpm/ai/approximated.markdown.md';
-
 /** Keeps dialog histories per path. */
 const historyMap = {};
 

--- a/aem/ui.frontend/src/main/webpack/site/styles/composum-ai.scss
+++ b/aem/ui.frontend/src/main/webpack/site/styles/composum-ai.scss
@@ -1,5 +1,3 @@
-
-
 //== Move the create dialog icon a bit to the right to avoid overlapping with the help icon.
 //== we make that horribly specific to override the default coral style there
 
@@ -9,4 +7,28 @@
 
 #composumAI-sidebar-panel .composum-ai-response {
     white-space: break-spaces;
+}
+
+.composum-ai-dialog .composum-ai-prompt-columns {
+
+    .coral-FixedColumn-column {
+        width: auto;
+        flex: 1;
+    }
+
+    .coral-Form-fieldset .coral-Form-fieldset-legend {
+        margin-top: 0;
+    }
+
+    .coral-Form-fieldset {
+        margin-bottom: 0;
+    }
+
+}
+
+.cq-Dialog:not([fullscreen]) .composum-ai-dialog .composum-ai-prompt-columns {
+    .cq-RichText-editable {
+        height: 11.5rem;
+    }
+
 }

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/GPTChatCompletionServiceImpl.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/GPTChatCompletionServiceImpl.java
@@ -652,7 +652,7 @@ public class GPTChatCompletionServiceImpl implements GPTChatCompletionService {
         if (html == null || html.isBlank()) {
             return "";
         }
-        return new HtmlToMarkdownConverter().convert(html);
+        return new HtmlToMarkdownConverter().convert(html).trim();
     }
 
     @ObjectClassDefinition(name = "GPT Chat Completion Service",

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverter.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverter.java
@@ -40,7 +40,7 @@ public class HtmlToMarkdownConverter {
     // continued indentation that is inserted before a continuation line
     private String continuedIndentation = "";
 
-    private StringBuilder sb = new StringBuilder();
+    protected StringBuilder sb = new StringBuilder();
 
     @Nonnull
     public String convert(@Nullable String html) {
@@ -189,6 +189,7 @@ public class HtmlToMarkdownConverter {
             case "h4":
             case "h5":
             case "h6":
+                ensureEmptyOrEndsWith("\n\n");
                 String prefix = HEADER_TAGS.get(tagName);
                 sb.append(prefix);
                 convertChildren(element);
@@ -280,6 +281,28 @@ public class HtmlToMarkdownConverter {
                 LOG.warn("Currently unsupported tags: {}", missingTags);
                 convertChildren(element);
                 break;
+        }
+    }
+
+    /**
+     * We ensure sb is either empty or that it ends with the given suffix.
+     */
+    protected void ensureEmptyOrEndsWith(@Nonnull String suffix) {
+        if (sb.length() == 0) {
+            return;
+        }
+        // find the longest prefix of suffix (incl. suffix itself) that sb already ends with
+        String alreadyEnding = null;
+        for (int i = 0; i <= suffix.length(); i++) {
+            String prefix = suffix.substring(0, i);
+            if (sb.length() >= prefix.length() && prefix.equals(sb.substring(sb.length() - i))) {
+                alreadyEnding = prefix;
+            }
+        }
+        if (alreadyEnding != null) {
+            sb.append(suffix.substring(alreadyEnding.length()));
+        } else {
+            sb.append(suffix);
         }
     }
 }

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverter.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverter.java
@@ -1,5 +1,6 @@
 package com.composum.ai.backend.base.service.chat.impl;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -33,6 +34,11 @@ public class HtmlToMarkdownConverter {
 
     private static final Map<String, String> HEADER_TAGS = Map.of("h1", "# ", "h2", "## ", "h3",
             "### ", "h4", "#### ", "h5", "##### ", "h6", "###### ");
+
+    /**
+     * Important table attributes we need to keep.
+     */
+    private static final List<String> TABLE_ATTRIBUTES = List.of("border", "colspan", "rowspan", "align", "valign", "scope");
 
     // continued indentation. Two spaces since four would be code block
     private final String indentStep = "  ";
@@ -253,7 +259,7 @@ public class HtmlToMarkdownConverter {
             case "ins":
             case "sub":
             case "sup":
-                // use HTML syntax
+                // use embedded HTML syntax
                 sb.append("<").append(tagName).append(">");
                 convertChildren(element);
                 sb.append("</").append(tagName).append(">");
@@ -272,6 +278,27 @@ public class HtmlToMarkdownConverter {
             case "meta":
             case "nav":
                 // ignore the content, too
+                break;
+
+            // rudimentary support for tables
+            case "table":
+            case "thead":
+            case "tbody":
+            case "tfoot":
+            case "tr":
+            case "td":
+            case "th":
+                // use embedded HTML syntax
+                sb.append("<").append(tagName);
+                for (String attr : TABLE_ATTRIBUTES) {
+                    String value = element.attr(attr);
+                    if (!value.isBlank()) {
+                        sb.append(" ").append(attr).append("=\"").append(value).append("\"");
+                    }
+                }
+                sb.append(">");
+                convertChildren(element);
+                sb.append("</").append(tagName).append(">");
                 break;
 
             default:

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverter.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverter.java
@@ -67,6 +67,10 @@ public class HtmlToMarkdownConverter {
             String splitText = text.lines()
                     .map(String::trim)
                     .collect(Collectors.joining(continuedIndentation + "\n"));
+            if (sb.length() > 0 && sb.charAt(sb.length() - 1) == '\n') {
+                // only happens if we have mixed text and block level elements within a block level element
+                sb.append(continuedIndentation);
+            }
             sb.append(splitText);
         }
     }
@@ -159,12 +163,11 @@ public class HtmlToMarkdownConverter {
 
             case "ol":
                 oldindentation = continuedIndentation;
-                continuedIndentation += indentStep;
                 int i = 1;
                 for (Element li : element.children()) {
-                    sb.append("\n" + oldindentation);
-                    sb.append(i++);
-                    sb.append(". ");
+                    String prefix = (i++) + ". ";
+                    continuedIndentation = oldindentation + prefix.replaceAll(".", " ");
+                    sb.append("\n" + oldindentation + prefix);
                     convertChildren(li);
                 }
                 sb.append("\n");
@@ -237,12 +240,13 @@ public class HtmlToMarkdownConverter {
                 break;
 
             case "blockquote":
-                sb.append("\n");
                 oldindentation = continuedIndentation;
                 continuedIndentation += "> ";
-                sb.append(oldindentation + "> ");
+                sb.append("\n");
+                sb.append(continuedIndentation);
                 convertChildren(element);
                 sb.append("\n");
+                continuedIndentation = oldindentation;
                 break;
 
             case "#root":

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverter.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverter.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.jsoup.Jsoup;
+import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
@@ -38,7 +39,8 @@ public class HtmlToMarkdownConverter {
     /**
      * Important table attributes we need to keep.
      */
-    private static final List<String> TABLE_ATTRIBUTES = List.of("border", "colspan", "rowspan", "align", "valign", "scope");
+    private static final List<String> TABLE_ATTRIBUTES = List.of("border", "colspan", "rowspan",
+            "align", "valign", "scope", "cellpadding", "cellspacing", "width", "height", "bgcolor");
 
     // continued indentation. Two spaces since four would be code block
     private final String indentStep = "  ";
@@ -50,6 +52,8 @@ public class HtmlToMarkdownConverter {
 
     @Nonnull
     public String convert(@Nullable String html) {
+        sb.setLength(0);
+        continuedIndentation = "";
         if (html != null) {
             Document doc = Jsoup.parseBodyFragment(html);
             convertElement(doc.body());
@@ -102,6 +106,15 @@ public class HtmlToMarkdownConverter {
                 convertChildren(element);
                 sb.append("](");
                 sb.append(element.attr("href"));
+                String title = element.attr("title");
+                if (StringUtil.isBlank(title)) {
+                    title = element.attr("alt");
+                }
+                if (!StringUtil.isBlank(title)) {
+                    sb.append(" \"");
+                    sb.append(title.replaceAll("\"", "\\\""));
+                    sb.append("\"");
+                }
                 sb.append(")");
                 break;
 

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/GPTChatCompletionServiceImplTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/GPTChatCompletionServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.net.http.HttpResponse;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -67,6 +68,7 @@ public class GPTChatCompletionServiceImplTest {
                 "</p>", html);
     }
 
+    @Ignore
     @Test
     public void testHtmlToMarkdown() {
         String html = "<p>This is a <strong>test</strong>.</p>"

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/GPTChatCompletionServiceImplTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/GPTChatCompletionServiceImplTest.java
@@ -71,19 +71,19 @@ public class GPTChatCompletionServiceImplTest {
     public void testHtmlToMarkdown() {
         String html = "<p>This is a <strong>test</strong>.</p>"
                 + "<p>Another paragraph with a <a href=\"http://example.com\">link</a>.</p>"
-                + "<p>A paragraph with <em>emphasis is this</em>.</p>"
+                + "<p>A paragraph with <b>bold is this</b>.</p>"
                 + "<p>A paragraph with <u>underlined text</u>.</p>"
                 + "<p>A paragraph with <code>code fragment</code>.</p>"
                 + "<ul><li>Item 1</li><li>Item 2</li></ul>"
                 + "<ol><li>Item 1</li><li>Item 2</li></ol>"
                 + "<pre>\na code block with several lines\n</pre>";
-        String expected = "This is a **test**.\n" +
+        String expected = "\nThis is a **test**.\n" +
                 "\n" +
                 "Another paragraph with a [link](http://example.com).\n" +
                 "\n" +
-                "A paragraph with **emphasis**is**this**.\n" +
+                "A paragraph with **bold is this**.\n" +
                 "\n" +
-                "A paragraph with _underlined_text_.\n" +
+                "A paragraph with _underlined text_.\n" +
                 "\n" +
                 "A paragraph with `code fragment`.\n" +
                 "\n" +

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
@@ -2,7 +2,6 @@ package com.composum.ai.backend.base.service.chat.impl;
 
 import static org.hamcrest.CoreMatchers.is;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
@@ -303,5 +302,50 @@ public class HtmlToMarkdownConverterTest {
         ec.checkThat(converter.sb.toString(), is("xabcd"));
     }
 
+    @Test
+    public void testTable1() {
+        String html = "<table><tr><th>Header 1</th><th>Header 2</th></tr><tr><td>Cell 1</td><td>Cell 2</td></tr></table>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("<table><tbody><tr><th>Header 1</th><th>Header 2</th></tr><tr><td>Cell 1</td><td>Cell 2</td></tr></tbody></table>"));
+    }
+
+    @Test
+    public void testTable2() {
+        String html = "<table border=\"1\">\n" +
+                "    <thead>\n" +
+                "        <tr>\n" +
+                "            <th scope=\"col\">Header 1</th>\n" +
+                "            <th scope=\"col\">Header 2</th>\n" +
+                "            <th scope=\"col\" colspan=\"2\">Header 3 (spanning two columns)</th>\n" +
+                "        </tr>\n" +
+                "    </thead>\n" +
+                "    <tbody valign=\"top\">\n" +
+                "        <tr>\n" +
+                "            <td align=\"left\" rowspan=\"2\">Data 1 (spans two rows)</td>\n" +
+                "            <td align=\"center\">Data 2</td>\n" +
+                "            <td align=\"right\">Data 3.1</td>\n" +
+                "            <td align=\"left\">Data 3.2</td>\n" +
+                "        </tr>\n" +
+                "        <tr>\n" +
+                "            <th scope=\"row\">Row Header</th>\n" +
+                "            <td colspan=\"2\" align=\"center\">Data 4 (spans two columns)</td>\n" +
+                "        </tr>\n" +
+                "    </tbody>\n" +
+                "    <tfoot>\n" +
+                "        <tr>\n" +
+                "            <td colspan=\"4\" align=\"center\">Footer spanning all columns</td>\n" +
+                "        </tr>\n" +
+                "    </tfoot>\n" +
+                "</table>\n";
+        String markdown = converter.convert(html);
+        System.out.println(markdown);
+        ec.checkThat(markdown, is("<table border=\"1\"> " +
+                "<thead> <tr> <th scope=\"col\">Header 1</th> <th scope=\"col\">Header 2</th> <th colspan=\"2\" scope=\"col\">Header 3 (spanning two columns)</th> </tr> </thead> " +
+                "<tbody valign=\"top\"> " +
+                "<tr> <td rowspan=\"2\" align=\"left\">Data 1 (spans two rows)</td> <td align=\"center\">Data 2</td> <td align=\"right\">Data 3.1</td> <td align=\"left\">Data 3.2</td> </tr> " +
+                "<tr> <th scope=\"row\">Row Header</th> <td colspan=\"2\" align=\"center\">Data 4 (spans two columns)</td> </tr> " +
+                "</tbody> " +
+                "<tfoot> <tr> <td colspan=\"4\" align=\"center\">Footer spanning all columns</td> </tr> </tfoot> </table> "));
+    }
 
 }

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
@@ -65,7 +65,7 @@ public class HtmlToMarkdownConverterTest {
     public void testConvertTagU() {
         String html = "<u>This is underlined text.</u>";
         String markdown = converter.convert(html);
-        ec.checkThat(markdown, is("_This_is_underlined_text._"));
+        ec.checkThat(markdown, is("_This is underlined text._"));
     }
 
     @Test
@@ -129,6 +129,13 @@ public class HtmlToMarkdownConverterTest {
         String html = "<s>This is strikethrough text.</s>";
         String markdown = converter.convert(html);
         ec.checkThat(markdown, is("~~This is strikethrough text.~~"));
+    }
+
+    @Test
+    public void testConvertTagMixedSerialB_S_I() {
+        String html = "This is <b>bold</b> <i>emphasized</i> text i<b>n</b>n<em>e</em>rwords";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("This is **bold** *emphasized* text i**n**n_e_rwords"));
     }
 
     @Test
@@ -233,5 +240,41 @@ public class HtmlToMarkdownConverterTest {
                 "\n" + // that is unfortunate but hard to avoid and doesn't seem to really hurt.
                 "2. three\n"));
     }
+
+    @Test
+    public void testConvertTagMark() {
+        String html = "<mark>This is marked text.</mark> and<mark>this</mark>too.";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("<mark>This is marked text.</mark> and<mark>this</mark>too."));
+    }
+
+    @Test
+    public void testConvertTagSmall() {
+        String html = "<small>This is small text.</small> and<small>this</small>too.";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("<small>This is small text.</small> and<small>this</small>too."));
+    }
+
+    @Test
+    public void testConvertTagIns() {
+        String html = "<ins>This is inserted text.</ins> and<ins>this</ins>too.";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("<ins>This is inserted text.</ins> and<ins>this</ins>too."));
+    }
+
+    @Test
+    public void testConvertTagSub() {
+        String html = "<sub>This is subscript text.</sub> and<sub>this</sub>too.";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("<sub>This is subscript text.</sub> and<sub>this</sub>too."));
+    }
+
+    @Test
+    public void testConvertTagSup() {
+        String html = "<sup>This is superscript text.</sup> and<sup>this</sup>too.";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("<sup>This is superscript text.</sup> and<sup>this</sup>too."));
+    }
+
 
 }

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
@@ -18,9 +18,12 @@ public class HtmlToMarkdownConverterTest {
 
     @Test
     public void testConvertTagA() {
-        String html = "<a href=\"http://example.com\">click here</a>";
-        String markdown = converter.convert(html);
-        ec.checkThat(markdown, is("[click here](http://example.com)"));
+        ec.checkThat(converter.convert("<a href=\"http://example.com\">click here</a>"),
+                is("[click here](http://example.com)"));
+
+        // alt text
+        ec.checkThat(converter.convert("<a href=\"http://example.com\" alt=\"An example link\">click here</a>"),
+                is("[click here](http://example.com \"An example link\")"));
     }
 
     @Test

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
@@ -102,4 +102,76 @@ public class HtmlToMarkdownConverterTest {
         ec.checkThat(markdown, is(""));
     }
 
+    @Test
+    public void testConvertTagEm() {
+        String html = "<em>This is emphasized text.</em>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("_This is emphasized text._"));
+    }
+
+    @Test
+    public void testConvertTagI() {
+        String html = "<i>This is italic text.</i>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("*This is italic text.*"));
+    }
+
+    @Test
+    public void testConvertTagDel() {
+        String html = "<del>This is deleted text.</del>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("~~This is deleted text.~~"));
+    }
+
+    @Test
+    public void testConvertTagS() {
+        String html = "<s>This is strikethrough text.</s>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("~~This is strikethrough text.~~"));
+    }
+
+    @Test
+    public void testConvertTagImg() {
+        String html = "<img src=\"http://example.com/image.jpg\" alt=\"An example image\">";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("![An example image](http://example.com/image.jpg)"));
+    }
+
+    @Test
+    public void testConvertTagH1() {
+        String html = "<h1>This is a heading 1</h1>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("# This is a heading 1\n"));
+    }
+
+    // ... similar tests for h2, h3, h4, h5, h6
+
+    @Test
+    public void testConvertTagHr() {
+        String html = "<hr>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("---\n"));
+    }
+
+    @Test
+    public void testConvertTagInput() {
+        String html = "<input type=\"text\" placeholder=\"Enter text\">";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("[Input: Type=text, Placeholder=Enter text]"));
+    }
+
+    @Test
+    public void testConvertTagDlDtDd() {
+        String html = "<dl><dt>Term 1</dt><dd>Definition 1</dd><dt>Term 2</dt><dd>Definition 2</dd></dl>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("<dl>\n  <dt>Term 1</dt>\n  <dd>Definition 1</dd>\n  <dt>Term 2</dt>\n  <dd>Definition 2</dd>\n</dl>\n"));
+    }
+
+    @Test
+    public void testConvertTagBlockquote() {
+        String html = "<blockquote>This is a blockquote.</blockquote>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("> This is a blockquote.\n> \n"));
+    }
+
 }

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
@@ -144,7 +144,40 @@ public class HtmlToMarkdownConverterTest {
         ec.checkThat(markdown, is("# This is a heading 1\n"));
     }
 
-    // ... similar tests for h2, h3, h4, h5, h6
+    @Test
+    public void testConvertTagH2() {
+        String html = "<h2>This is a heading 2</h2>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("## This is a heading 2\n"));
+    }
+
+    @Test
+    public void testConvertTagH3() {
+        String html = "<h3>This is a heading 3</h3>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("### This is a heading 3\n"));
+    }
+
+    @Test
+    public void testConvertTagH4() {
+        String html = "<h4>This is a heading 4</h4>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("#### This is a heading 4\n"));
+    }
+
+    @Test
+    public void testConvertTagH5() {
+        String html = "<h5>This is a heading 5</h5>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("##### This is a heading 5\n"));
+    }
+
+    @Test
+    public void testConvertTagH6() {
+        String html = "<h6>This is a heading 6</h6>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("###### This is a heading 6\n"));
+    }
 
     @Test
     public void testConvertTagHr() {

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
@@ -2,6 +2,7 @@ package com.composum.ai.backend.base.service.chat.impl;
 
 import static org.hamcrest.CoreMatchers.is;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
@@ -202,9 +203,35 @@ public class HtmlToMarkdownConverterTest {
 
     @Test
     public void testConvertTagBlockquote() {
-        String html = "<blockquote>This is a blockquote.</blockquote>";
+        String html = "<blockquote>This is a blockquote.\nAnother line</blockquote>";
         String markdown = converter.convert(html);
-        ec.checkThat(markdown, is("\n> This is a blockquote.\n"));
+        // unfortunately jsoup joins the lines.
+        ec.checkThat(markdown, is("\n> This is a blockquote. Another line\n"));
+    }
+
+    @Test
+    public void testConvertTagNesting() {
+        String html = "<blockquote>This<blockquote>is a</blockquote>blockquote.<ul><li>one</li><li>two</li></ul></blockquote>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("\n" +
+                "> This\n" +
+                "> > is a\n" +
+                "> blockquote.\n" +
+                "> - one\n" +
+                "> - two\n" +
+                "\n"));
+    }
+
+    @Test
+    public void testConvertTagListNesting() {
+        String html = "<ol><li><ul><li>one</li><li>two</li></ul></li><li>three</li></ol>";
+        String markdown = converter.convert(html);
+        ec.checkThat(markdown, is("\n" +
+                "1. \n" +
+                "   - one\n" +
+                "   - two\n" +
+                "\n" + // that is unfortunate but hard to avoid and doesn't seem to really hurt.
+                "2. three\n"));
     }
 
 }

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
@@ -43,14 +43,14 @@ public class HtmlToMarkdownConverterTest {
         // String html = "<pre><code>public static void main(String[] args) {\n System.out.println(\"Hello World!\");\n}</code></pre>";
         String html = "<pre>public static void main(String[] args) {\n System.out.println(\"Hello World!\");\n}</pre>";
         String markdown = converter.convert(html);
-        ec.checkThat(markdown, is("```\npublic static void main(String[] args) {\n System.out.println(\"Hello World!\");\n}\n```\n"));
+        ec.checkThat(markdown, is("\n```\npublic static void main(String[] args) {\n System.out.println(\"Hello World!\");\n}\n```\n"));
     }
 
     @Test
     public void testConvertTagP() {
         String html = "<p>This is a paragraph.</p>";
         String markdown = converter.convert(html);
-        ec.checkThat(markdown, is("This is a paragraph.\n\n"));
+        ec.checkThat(markdown, is("\nThis is a paragraph.\n"));
     }
 
     @Test
@@ -71,14 +71,14 @@ public class HtmlToMarkdownConverterTest {
     public void testConvertTagUl() {
         String html = "<ul><li>One</li><li>Two</li><li>Three</li></ul>";
         String markdown = converter.convert(html);
-        ec.checkThat(markdown, is("- One\n- Two\n- Three\n\n"));
+        ec.checkThat(markdown, is("\n- One\n- Two\n- Three\n"));
     }
 
     @Test
     public void testConvertTagOl() {
         String html = "<ol><li>One</li><li>Two</li><li>Three</li></ol>";
         String markdown = converter.convert(html);
-        ec.checkThat(markdown, is("1. One\n2. Two\n3. Three\n\n"));
+        ec.checkThat(markdown, is("\n1. One\n2. Two\n3. Three\n"));
     }
 
     @Test
@@ -183,7 +183,7 @@ public class HtmlToMarkdownConverterTest {
     public void testConvertTagHr() {
         String html = "<hr>";
         String markdown = converter.convert(html);
-        ec.checkThat(markdown, is("---\n"));
+        ec.checkThat(markdown, is("\n---\n"));
     }
 
     @Test
@@ -197,14 +197,14 @@ public class HtmlToMarkdownConverterTest {
     public void testConvertTagDlDtDd() {
         String html = "<dl><dt>Term 1</dt><dd>Definition 1</dd><dt>Term 2</dt><dd>Definition 2</dd></dl>";
         String markdown = converter.convert(html);
-        ec.checkThat(markdown, is("<dl>\n  <dt>Term 1</dt>\n  <dd>Definition 1</dd>\n  <dt>Term 2</dt>\n  <dd>Definition 2</dd>\n</dl>\n"));
+        ec.checkThat(markdown, is("\n<dl>\n  <dt>Term 1</dt>\n  <dd>Definition 1</dd>\n  <dt>Term 2</dt>\n  <dd>Definition 2</dd>\n</dl>\n"));
     }
 
     @Test
     public void testConvertTagBlockquote() {
         String html = "<blockquote>This is a blockquote.</blockquote>";
         String markdown = converter.convert(html);
-        ec.checkThat(markdown, is("> This is a blockquote.\n> \n"));
+        ec.checkThat(markdown, is("\n> This is a blockquote.\n"));
     }
 
 }

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/HtmlToMarkdownConverterTest.java
@@ -276,5 +276,32 @@ public class HtmlToMarkdownConverterTest {
         ec.checkThat(markdown, is("<sup>This is superscript text.</sup> and<sup>this</sup>too."));
     }
 
+    @Test
+    public void testEndsWith() {
+        converter.sb.setLength(0);
+        converter.ensureEmptyOrEndsWith("");
+        ec.checkThat(converter.sb.toString(), is(""));
+
+        converter.sb.setLength(0);
+        converter.sb.append("x");
+        converter.ensureEmptyOrEndsWith("a");
+        ec.checkThat(converter.sb.toString(), is("xa"));
+        converter.ensureEmptyOrEndsWith("a");
+        ec.checkThat(converter.sb.toString(), is("xa"));
+
+        converter.sb.setLength(0);
+        converter.sb.append("x");
+        converter.ensureEmptyOrEndsWith("ab");
+        ec.checkThat(converter.sb.toString(), is("xab"));
+        converter.ensureEmptyOrEndsWith("ab");
+        ec.checkThat(converter.sb.toString(), is("xab"));
+
+        converter.sb.setLength(0);
+        converter.sb.append("x");
+        converter.sb.append("ab");
+        converter.ensureEmptyOrEndsWith("abcd");
+        ec.checkThat(converter.sb.toString(), is("xabcd"));
+    }
+
 
 }

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AICreateServlet.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AICreateServlet.java
@@ -1,6 +1,5 @@
 package com.composum.ai.backend.slingbase;
 
-import static org.apache.commons.lang3.StringUtils.isAllBlank;
 import static org.apache.commons.lang3.StringUtils.isNoneBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -268,7 +267,7 @@ public class AICreateServlet extends SlingAllMethodsServlet {
                 response.sendError(HttpServletResponse.SC_NOT_FOUND, "No resource found at " + sourcePath);
                 return;
             } else {
-                sourceText = markdownService.approximateMarkdown(resource);
+                sourceText = markdownService.approximateMarkdown(resource, request, response);
             }
         }
 

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AllowDenyMatcherUtil.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AllowDenyMatcherUtil.java
@@ -1,0 +1,46 @@
+package com.composum.ai.backend.slingbase;
+
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+
+/**
+ * Utilities for matching allow / deny String[] pattern collections.
+ */
+public class AllowDenyMatcherUtil {
+
+    /**
+     * Makes a pattern that matches whenever one of the patterns matches the input.
+     * If no patterns are given, we return null.
+     */
+    @Nullable
+    public static Pattern joinPatternsIntoAnyMatcher(@Nullable String[] patterns) {
+        if (patterns == null || patterns.length == 0) {
+            return null;
+        }
+        String regex = Stream.of(patterns)
+                .filter(p -> p != null && !p.isEmpty())
+                .map(p -> "(" + p + ")")
+                .collect(Collectors.joining("|"));
+        return regex.isEmpty() ? null : Pattern.compile(regex);
+    }
+
+    /**
+     * Check whether a value matches the allowPattern but not the denyPattern. Thouse could be created with {@link #joinPatternsIntoAnyMatcher(String[])}.
+     * If allowPattern is null it will never match. If denyPattern is null it is ignored, just the allowPattern matters.
+     *
+     * @see #joinPatternsIntoAnyMatcher(String[])
+     */
+    public static boolean allowDenyCheck(@Nullable String value, @Nullable Pattern allowPattern, @Nullable Pattern denyPattern) {
+        if (allowPattern == null) {
+            return false;
+        }
+        if (denyPattern != null && denyPattern.matcher(value).matches()) {
+            return false;
+        }
+        return allowPattern.matcher(value).matches();
+    }
+
+}

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/ApproximateMarkdownService.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/ApproximateMarkdownService.java
@@ -5,6 +5,8 @@ import java.io.PrintWriter;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 
 /**
@@ -17,10 +19,13 @@ public interface ApproximateMarkdownService {
      * That is rather heuristically - it cannot faithfully represent the page, but will probably be enough to generate summaries, keywords and so forth.
      *
      * @param resource the resource to render to markdown. Caution: if this is not the content resource of a page but the cpp:Page, the markdown will contain all subpages as well!
+     * @param request
+     * @param response
      * @return the markdown representation
      */
     @Nonnull
-    String approximateMarkdown(@Nullable Resource resource);
+    String approximateMarkdown(@Nullable Resource resource,
+                               @Nonnull SlingHttpServletRequest request, @Nonnull SlingHttpServletResponse response);
 
     /**
      * Generates a text formatted with markdown that heuristically represents the text content of a page or resource, mainly for use with the AI.
@@ -28,8 +33,11 @@ public interface ApproximateMarkdownService {
      *
      * @param resource the resource to render to markdown. Caution: if this is not the content resource of a page but the cpp:Page, the markdown will contain all subpages as well!
      * @param out      destination where the markdown rendering will be written.
+     * @param request
+     * @param response
      */
-    void approximateMarkdown(@Nullable Resource resource, PrintWriter out);
+    void approximateMarkdown(@Nullable Resource resource, @Nonnull PrintWriter out,
+                             @Nonnull SlingHttpServletRequest request, @Nonnull SlingHttpServletResponse response);
 
     /**
      * Returns a markdown representation of an attribute value, which might be plain text or HTML. We determine whether

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/ApproximateMarkdownServicePlugin.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/ApproximateMarkdownServicePlugin.java
@@ -5,6 +5,8 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 
 /**
@@ -33,7 +35,9 @@ public interface ApproximateMarkdownServicePlugin {
      * @return what is already handled by this plugin. It is possible to write to the PrintWriter in any case.
      */
     @Nonnull
-    PluginResult maybeHandle(@Nonnull Resource resource, @Nonnull PrintWriter out, @Nonnull ApproximateMarkdownService service);
+    PluginResult maybeHandle(@Nonnull Resource resource, @Nonnull PrintWriter out,
+                             @Nonnull ApproximateMarkdownService service,
+                             @Nonnull SlingHttpServletRequest request, @Nonnull SlingHttpServletResponse response);
 
     /**
      * Returns true when the sling:resourceType or one of the sling:resourceSuperType of the sling:resourceType match the pattern.

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/ApproximateMarkdownServlet.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/ApproximateMarkdownServlet.java
@@ -62,11 +62,11 @@ public class ApproximateMarkdownServlet extends SlingSafeMethodsServlet {
         if (Boolean.TRUE.toString().equalsIgnoreCase(richtext)) {
             response.setContentType("text/html");
             StringBuilderWriter writer = new StringBuilderWriter();
-            approximateMarkdownService.approximateMarkdown(resource, new PrintWriter(writer));
+            approximateMarkdownService.approximateMarkdown(resource, new PrintWriter(writer), request, response);
             response.getWriter().write(chatService.markdownToHtml(writer.toString()));
         } else {
             response.setContentType("text/plain");
-            approximateMarkdownService.approximateMarkdown(resource, response.getWriter());
+            approximateMarkdownService.approximateMarkdown(resource, response.getWriter(), request, response);
         }
     }
 

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/AllowDenyMatcherUtil.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/AllowDenyMatcherUtil.java
@@ -1,4 +1,4 @@
-package com.composum.ai.backend.slingbase;
+package com.composum.ai.backend.slingbase.impl;
 
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImpl.java
@@ -1,7 +1,7 @@
 package com.composum.ai.backend.slingbase.impl;
 
-import static com.composum.ai.backend.slingbase.AllowDenyMatcherUtil.allowDenyCheck;
 import static com.composum.ai.backend.slingbase.ApproximateMarkdownServicePlugin.PluginResult.NOT_HANDLED;
+import static com.composum.ai.backend.slingbase.impl.AllowDenyMatcherUtil.allowDenyCheck;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.IOException;

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImpl.java
@@ -292,7 +292,10 @@ public class ApproximateMarkdownServiceImpl implements ApproximateMarkdownServic
 
         @AttributeDefinition(name = "Labeled Attribute Pattern Deny",
                 description = "Regular expressions for attributes that are not output with a label. Takes precedence over the corresponding allow regexp list.")
-        String[] labelledAttributePatternDeny() default {".*:.*", "layout", "backgroundColor", "color"};
+        String[] labelledAttributePatternDeny() default {".*:.*", "layout", "backgroundColor", "color", "textColor", "template",
+                "theme", "variation", "buttonSymbol", "columns", "icon", "elementType", "textAlignment", "alignment",
+                "linkTarget", "interval", "fileReference", "height", "width", "textIsRich", "style",
+                "padding.*", ".*[cC]ss[cC]lass.*"};
 
         @AttributeDefinition(name = "Labelled Attribute Order",
                 description = "List of labelled attributes that come first if they are present, in the given order.")

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImpl.java
@@ -89,15 +89,9 @@ public class ApproximateMarkdownServiceImpl implements ApproximateMarkdownServic
 
 
     private static final Logger LOG = LoggerFactory.getLogger(ApproximateMarkdownServiceImpl.class);
-    /**
-     * Pattern that matches an opening html tag and captures the tag name.
-     */
-    protected Pattern PATTERN_HTML_TAG = Pattern.compile("<\\s*(ext|a|sly|strong|code|em|language|type|p|br|div|path|u|ul|attributes|li|ol)(\\s+[^>]*)?>", Pattern.CASE_INSENSITIVE);
 
     @Reference
     protected GPTChatCompletionService chatCompletionService;
-
-    protected final Set<String> htmltags = new HashSet<>();
 
     // List of ApproximateMarkdownServicePlugin dynamically injected by OSGI
     @Nonnull
@@ -121,8 +115,8 @@ public class ApproximateMarkdownServiceImpl implements ApproximateMarkdownServic
     @Override
     public String approximateMarkdown(@Nullable Resource resource) {
         try (StringWriter s = new StringWriter()) {
-            try (PrintWriter p = new PrintWriter(s)) {
-                approximateMarkdown(resource, p);
+            try (PrintWriter out = new PrintWriter(s)) {
+                approximateMarkdown(resource, out);
             }
             return s.toString();
         } catch (IOException e) {
@@ -290,16 +284,20 @@ public class ApproximateMarkdownServiceImpl implements ApproximateMarkdownServic
 
         @AttributeDefinition(name = "Labeled Attribute Pattern Deny",
                 description = "Regular expressions for attributes that are not output with a label. Takes precedence over the corresponding allow regexp list.")
-        String[] labelledAttributePatternDeny() default {".*:.*"};
+        String[] labelledAttributePatternDeny() default {".*:.*", "layout", "backgroundColor", "color"};
 
         @AttributeDefinition(name = "Labelled Attribute Order",
                 description = "List of labelled attributes that come first if they are present, in the given order.")
-        String[] labelledAttributeOrder() default {};
+        String[] labelledAttributeOrder() default {"cq:panelTitle"};
 
     }
 
 
     // debugging code; remove after it works.
+
+    protected Pattern PATTERN_HTML_TAG = Pattern.compile("<\\s*(ext|a|sly|strong|code|em|language|type|p|br|div|path|u|ul|attributes|li|ol)(\\s+[^>]*)?>", Pattern.CASE_INSENSITIVE);
+
+    protected final Set<String> htmltags = new HashSet<>();
 
     /**
      * This is debugging code we needed to gather information for the implementation; we keep it around for now.
@@ -318,9 +316,9 @@ public class ApproximateMarkdownServiceImpl implements ApproximateMarkdownServic
             if (entry.getValue() instanceof String) {
                 String value = (String) entry.getValue();
                 if (value.matches(".*\\s+.*\\s+.*\\s+.*")) {
-                    out.println(resource.getPath() + " [" + resourceTypeForChildren + "] " + subpathForAttributes + entry.getKey() + ": " + value);
+                    // out.println(resource.getPath() + " [" + resourceTypeForChildren + "] " + subpathForAttributes + entry.getKey() + ": " + value);
                     // out.println("[" + resourceTypeForChildren + "] " + subpathForAttributes + entry.getKey() + ": " + value);
-                    // out.println("[" + resourceTypeForChildren + "] " + subpathForAttributes + entry.getKey());
+                    out.println("[" + resourceTypeForChildren + "] " + subpathForAttributes + entry.getKey());
                     // out.println(entry.getKey() + " [" + resourceTypeForChildren + "] " + subpathForAttributes + entry.getKey());
                     captureHtmlTags(value);
                 }

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImpl.java
@@ -158,8 +158,8 @@ public class ApproximateMarkdownServiceImpl implements ApproximateMarkdownServic
                     printEmptyLine = true;
                 }
             }
-            printEmptyLine = handleCodeblock(resource, out) || printEmptyLine;
-            printEmptyLine = handleLabeledAttributes(resource, out) || printEmptyLine;
+            printEmptyLine = handleCodeblock(resource, out, printEmptyLine);
+            printEmptyLine = handleLabeledAttributes(resource, out, printEmptyLine);
         }
         if (printEmptyLine) {
             out.println();
@@ -195,7 +195,7 @@ public class ApproximateMarkdownServiceImpl implements ApproximateMarkdownServic
         return markdown;
     }
 
-    protected boolean handleCodeblock(Resource resource, PrintWriter out) {
+    protected boolean handleCodeblock(Resource resource, PrintWriter out, boolean printEmptyLine) {
         String code = resource.getValueMap().get("code", String.class);
         if (isNotBlank(code)) {
             out.println("```\n");
@@ -203,18 +203,22 @@ public class ApproximateMarkdownServiceImpl implements ApproximateMarkdownServic
             out.println("\n```\n");
             return true;
         }
-        return false;
+        return printEmptyLine;
     }
 
-    protected boolean handleLabeledAttributes(Resource resource, PrintWriter out) {
+    protected boolean handleLabeledAttributes(Resource resource, PrintWriter out, boolean printEmptyLine) {
         if (labeledAttributePatternAllow == null) {
             return false;
         }
-        boolean printEmptyLine = false;
+        boolean firstline = true;
         for (String attributename : labelledAttributeOrder) {
             String value = resource.getValueMap().get(attributename, String.class);
             if (isNotBlank(value)) {
-                out.println(attributename + ": " + getMarkdown(value));
+                if (printEmptyLine && firstline) {
+                    out.println();
+                    firstline = false;
+                }
+                out.println(attributename + ": " + getMarkdown(value) + " <br>");
                 printEmptyLine = true;
             }
         }
@@ -226,7 +230,11 @@ public class ApproximateMarkdownServiceImpl implements ApproximateMarkdownServic
                 String value = (String) entry.getValue();
                 if (isNotBlank(value) && admissibleValue(value) &&
                         allowDenyCheck(entry.getKey(), labeledAttributePatternAllow, labeledAttributePatternDeny)) {
-                    out.println(entry.getKey() + ": " + getMarkdown(value));
+                    if (printEmptyLine && firstline) {
+                        out.println();
+                        firstline = false;
+                    }
+                    out.println(entry.getKey() + ": " + getMarkdown(value) + " <br>");
                     printEmptyLine = true;
                 }
             }

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImpl.java
@@ -1,5 +1,6 @@
 package com.composum.ai.backend.slingbase.impl;
 
+import static com.composum.ai.backend.slingbase.ApproximateMarkdownServicePlugin.PluginResult.HANDLED_ATTRIBUTES;
 import static com.composum.ai.backend.slingbase.ApproximateMarkdownServicePlugin.PluginResult.NOT_HANDLED;
 import static com.composum.ai.backend.slingbase.impl.AllowDenyMatcherUtil.allowDenyCheck;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import com.composum.ai.backend.base.service.chat.GPTChatCompletionService;
 import com.composum.ai.backend.slingbase.ApproximateMarkdownService;
 import com.composum.ai.backend.slingbase.ApproximateMarkdownServicePlugin;
+import com.composum.ai.backend.slingbase.ApproximateMarkdownServicePlugin.PluginResult;
 
 /**
  * Implementation for {@link ApproximateMarkdownService}.
@@ -142,7 +144,7 @@ public class ApproximateMarkdownServiceImpl implements ApproximateMarkdownServic
         if (!resource.getPath().contains("/jcr:content") && resource.getChild("jcr:content") != null) {
             resource = resource.getChild("jcr:content");
         }
-        ApproximateMarkdownServicePlugin.PluginResult pluginResult = executePlugins(resource, out, request, response);
+        PluginResult pluginResult = executePlugins(resource, out, request, response);
         boolean printEmptyLine = false;
         if (pluginResult == NOT_HANDLED) {
             for (String attributename : textAttributes) {
@@ -167,18 +169,18 @@ public class ApproximateMarkdownServiceImpl implements ApproximateMarkdownServic
         if (printEmptyLine) {
             out.println();
         }
-        if (pluginResult == NOT_HANDLED || pluginResult == ApproximateMarkdownServicePlugin.PluginResult.HANDLED_ATTRIBUTES) {
+        if (pluginResult == NOT_HANDLED || pluginResult == HANDLED_ATTRIBUTES) {
             resource.getChildren().forEach(child -> approximateMarkdown(child, out, request, response));
         }
         logUnhandledAttributes(resource);
     }
 
     @Nonnull
-    protected ApproximateMarkdownServicePlugin.PluginResult executePlugins(
+    protected PluginResult executePlugins(
             @Nonnull Resource resource, @Nonnull PrintWriter out,
             @Nonnull SlingHttpServletRequest request, @Nonnull SlingHttpServletResponse response) {
         for (ApproximateMarkdownServicePlugin plugin : plugins) {
-            ApproximateMarkdownServicePlugin.PluginResult pluginResult =
+            PluginResult pluginResult =
                     plugin.maybeHandle(resource, out, this, request, response);
             if (pluginResult != null && pluginResult != NOT_HANDLED) {
                 return pluginResult;
@@ -312,7 +314,7 @@ public class ApproximateMarkdownServiceImpl implements ApproximateMarkdownServic
 
     // debugging code; remove after it works.
 
-    protected Pattern PATTERN_HTML_TAG = Pattern.compile("<\\s*(ext|a|sly|strong|code|em|language|type|p|br|div|path|u|ul|attributes|li|ol)(\\s+[^>]*)?>", Pattern.CASE_INSENSITIVE);
+    protected Pattern PATTERN_HTML_TAG = Pattern.compile("<\\s*(ext|a|sly|strong|code|em|language|type|p|br|div|path|u|ul|attributes|li|ol|h[1-6]|b|i)(\\s+[^>]*)?>", Pattern.CASE_INSENSITIVE);
 
     protected final Set<String> htmltags = new HashSet<>();
 

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/HtmlToApproximateMarkdownServicePlugin.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/HtmlToApproximateMarkdownServicePlugin.java
@@ -1,0 +1,360 @@
+package com.composum.ai.backend.slingbase.impl;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+import javax.servlet.AsyncContext;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpUpgradeHandler;
+
+import org.apache.commons.io.output.StringBuilderWriter;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.request.RequestDispatcherOptions;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
+import org.apache.sling.api.wrappers.SlingHttpServletResponseWrapper;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.composum.ai.backend.slingbase.ApproximateMarkdownService;
+import com.composum.ai.backend.slingbase.ApproximateMarkdownServicePlugin;
+
+/**
+ * A plugin for the {@link com.composum.ai.backend.slingbase.ApproximateMarkdownService} that transforms the rendered
+ * HTML to markdown.
+ * That doesn't work for all components, but might more easily capture the text content of certain components than
+ * trying to guess it from the JCR representation, as is the default.
+ */
+@Designate(ocd = HtmlToApproximateMarkdownServicePlugin.Config.class)
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE)
+public class HtmlToApproximateMarkdownServicePlugin implements ApproximateMarkdownServicePlugin {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HtmlToApproximateMarkdownServicePlugin.class);
+
+    protected Pattern allowedResourceTypePattern;
+    protected Pattern deniedResourceTypePattern;
+
+    @NotNull
+    @Override
+    public PluginResult maybeHandle(
+            @NotNull Resource resource, @NotNull PrintWriter out,
+            @NotNull ApproximateMarkdownService service,
+            @Nonnull SlingHttpServletRequest request, @Nonnull SlingHttpServletResponse response) {
+        String resourceType = resource.getResourceType();
+        if (allowedResourceTypePattern != null && allowedResourceTypePattern.matcher(resourceType).matches()) {
+            if (deniedResourceTypePattern == null || deniedResourceTypePattern.matcher(resourceType).matches()) {
+                LOG.debug("Resourcetype {} denied", resourceType);
+                return PluginResult.NOT_HANDLED;
+            }
+            LOG.debug("Resourcetype {} allowed", resourceType);
+            try {
+                String html = renderedAsHTML(resource, request, response);
+                String markdown = service.getMarkdown(html);
+                if (StringUtils.isBlank(markdown)) {
+                    LOG.debug("No markdown generated for {} with resoure type {}", resource.getPath(), resource.getResourceType());
+                } else {
+                    LOG.debug("Markdown generated for {} with resoure type {}:\n{}", resource.getPath(), resource.getResourceType(), markdown);
+                    out.println(markdown);
+                }
+                return PluginResult.HANDLED_ALL;
+            } catch (ServletException | IOException | RuntimeException e) {
+                LOG.error("Error rendering resource {} with resoure type {}", resource.getPath(), resource.getResourceType(), e);
+                return PluginResult.NOT_HANDLED;
+            }
+        }
+        return PluginResult.NOT_HANDLED;
+    }
+
+    /**
+     * We render the resource into a mock response and capture and return the generated HTML.
+     * The response is wrapped so that the real response cannot be modified.
+     * We don't do that for the request, because that would be more complicated and probably not needed.
+     */
+    protected String renderedAsHTML(Resource resource, SlingHttpServletRequest request, SlingHttpServletResponse response) throws ServletException, IOException {
+        StringBuilderWriter writer = new StringBuilderWriter();
+        try (PrintWriter printWriter = new PrintWriter(writer)) {
+            SlingHttpServletResponse wrappedResponse = new CapturingResponse(response, printWriter, resource.getPath());
+            SlingHttpServletRequest wrappedRequest = new NonModifyingRequestWrapper(request, resource.getPath());
+            request.getRequestDispatcher(resource.getPath()).include(wrappedRequest, wrappedResponse);
+        }
+        return writer.toString();
+    }
+
+    @Activate
+    @Modified
+    protected void activate(Config config) {
+        this.allowedResourceTypePattern = AllowDenyMatcherUtil.joinPatternsIntoAnyMatcher(config.allowedResourceTypes());
+        this.deniedResourceTypePattern = AllowDenyMatcherUtil.joinPatternsIntoAnyMatcher(config.deniedResourceTypes());
+        LOG.info("Allowed HTML to Markdown resource types: {}", this.allowedResourceTypePattern);
+        LOG.info("Denied HTML to Markdown resource types: {}", this.deniedResourceTypePattern);
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        this.allowedResourceTypePattern = null;
+        this.deniedResourceTypePattern = null;
+    }
+
+    @ObjectClassDefinition(name = "Composum AI Html To Approximate Markdown Service Plugin", description = "A plugin for the ApproximateMarkdownService that transforms the rendered HTML of components to markdown, which can work better than trying to guess the text content from the JCR representation (as is the default) but probably doesn't work for all components. So it can be enabled for some sling resource types by regex.")
+    protected @interface Config {
+
+        @AttributeDefinition(name = "Allowed resource types", description = "Regular expressions for allowed resource types. If not present, no resource types are allowed.") String[] allowedResourceTypes() default {".*"};
+
+        @AttributeDefinition(name = "Denied resource types", description = "Regular expressions for denied resource types. Takes precedence over allowed resource types.") String[] deniedResourceTypes() default {};
+
+    }
+
+    /**
+     * We wrap a response to capture the content, forwarding all but modifying methods to the original response.
+     */
+    protected static class CapturingResponse extends SlingHttpServletResponseWrapper {
+        private final PrintWriter writer;
+        private final String debuginfo;
+
+        public CapturingResponse(SlingHttpServletResponse response, PrintWriter printWriter, String debuginfo) {
+            super(response);
+            this.writer = printWriter;
+            this.debuginfo = debuginfo;
+        }
+
+        @Override
+        public PrintWriter getWriter() {
+            return writer;
+        }
+
+        protected UnsupportedOperationException logAndThrow(String error) {
+            LOG.warn("Unsupported method called for {} : {}", debuginfo, error);
+            throw new UnsupportedOperationException(error);
+        }
+
+        // The following methods are likely not needed; we mostly throw an exception to find whether this assumption is right.
+
+        @Override
+        public ServletOutputStream getOutputStream() throws IOException {
+            throw logAndThrow("Not implemented: CapturingResponse.getOutputStream");
+        }
+
+        @Override
+        public void addCookie(Cookie cookie) {
+            // that might actually get a problem later, so we at least log it. Not to be expected, though.
+            LOG.warn("Not implemented: CapturingResponse.addCookie {}", cookie.getName());
+        }
+
+        @Override
+        public void sendError(int sc, String msg) throws IOException {
+            throw logAndThrow("Not implemented: CapturingResponse.sendError");
+        }
+
+        @Override
+        public void sendError(int sc) throws IOException {
+            throw logAndThrow("Not implemented: CapturingResponse.sendError");
+        }
+
+        @Override
+        public void sendRedirect(String location) throws IOException {
+            throw logAndThrow("Not implemented: CapturingResponse.sendRedirect");
+        }
+
+        @Override
+        public void setDateHeader(String name, long date) {
+            // ignore
+        }
+
+        @Override
+        public void setHeader(String name, String value) {
+            // ignore
+        }
+
+        @Override
+        public void setIntHeader(String name, int value) {
+            // ignore
+        }
+
+        @Override
+        public void setStatus(int sc) {
+            throw logAndThrow("Not implemented: CapturingResponse.setStatus");
+        }
+
+        @Override
+        public void setStatus(int sc, String sm) {
+            throw logAndThrow("Not implemented: CapturingResponse.setStatus");
+        }
+
+        @Override
+        public int getStatus() {
+            return 200;
+        }
+
+        @Override
+        public void setCharacterEncoding(String charset) {
+            // ignore
+        }
+
+        @Override
+        public void setContentLength(int len) {
+            // ignore
+        }
+
+        @Override
+        public void setContentLengthLong(long len) {
+            // ignore
+        }
+
+        @Override
+        public void setContentType(String type) {
+            // ignore
+        }
+
+        @Override
+        public void setBufferSize(int size) {
+            // ignore
+        }
+
+        @Override
+        public void flushBuffer() throws IOException {
+            // ignore
+        }
+
+        @Override
+        public void reset() {
+            throw logAndThrow("Not implemented: CapturingResponse.reset");
+        }
+
+        @Override
+        public void resetBuffer() {
+            throw logAndThrow("Not implemented: CapturingResponse.resetBuffer");
+        }
+
+        @Override
+        public void setLocale(Locale loc) {
+            // ignore
+        }
+    }
+
+    /**
+     * Wraps the request to make sure nothing is modified.
+     */
+    protected static class NonModifyingRequestWrapper extends SlingHttpServletRequestWrapper {
+        private final String debuginfo;
+
+        public NonModifyingRequestWrapper(SlingHttpServletRequest wrappedRequest, String debuginfo) {
+            super(wrappedRequest);
+            this.debuginfo = debuginfo;
+        }
+
+        protected UnsupportedOperationException logAndThrow(String error) {
+            LOG.warn("Unsupported method called for {} : {}", debuginfo, error);
+            throw new UnsupportedOperationException(error);
+        }
+
+        // Methods we think are too dangerous to use since they might modify the request, so we mostly throw an exception.
+        // Possibly we'll have to rethink this.
+        @Nullable
+        @Override
+        public RequestDispatcher getRequestDispatcher(@NotNull String path, RequestDispatcherOptions options) {
+            throw logAndThrow("Not implemented: NonModifyingRequestWrapper.getRequestDispatcher");
+        }
+
+        @Nullable
+        @Override
+        public RequestDispatcher getRequestDispatcher(@NotNull Resource resource, RequestDispatcherOptions options) {
+            throw logAndThrow("Not implemented: NonModifyingRequestWrapper.getRequestDispatcher");
+        }
+
+        @Nullable
+        @Override
+        public RequestDispatcher getRequestDispatcher(@NotNull Resource resource) {
+            throw logAndThrow("Not implemented: NonModifyingRequestWrapper.getRequestDispatcher");
+        }
+
+        @Override
+        public HttpSession getSession(boolean create) {
+            throw logAndThrow("Not implemented: NonModifyingRequestWrapper.getSession");
+        }
+
+        @Override
+        public HttpSession getSession() {
+            throw logAndThrow("Not implemented: NonModifyingRequestWrapper.getSession");
+        }
+
+        @Override
+        public String changeSessionId() {
+            throw logAndThrow("Not implemented: NonModifyingRequestWrapper.changeSessionId");
+        }
+
+        @Override
+        public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
+            throw logAndThrow("Not implemented: NonModifyingRequestWrapper.authenticate");
+        }
+
+        @Override
+        public void login(String username, String password) throws ServletException {
+            throw logAndThrow("Not implemented: NonModifyingRequestWrapper.login");
+        }
+
+        @Override
+        public void logout() throws ServletException {
+            throw logAndThrow("Not implemented: NonModifyingRequestWrapper.logout");
+        }
+
+        @Override
+        public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException {
+            throw logAndThrow("Not implemented: NonModifyingRequestWrapper.upgrade");
+        }
+
+        @Override
+        public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
+            // ignore
+        }
+
+        @Override
+        public void setAttribute(String name, Object o) {
+            LOG.debug("NonModifyingRequestWrapper.setAttribute {} for {}", name, debuginfo);
+            // ignore
+        }
+
+        @Override
+        public void removeAttribute(String name) {
+            LOG.debug("NonModifyingRequestWrapper.removeAttribute {} for {}", name, debuginfo);
+            // ignore
+        }
+
+        @Override
+        public AsyncContext startAsync() throws IllegalStateException {
+            throw logAndThrow("Not implemented: NonModifyingRequestWrapper.startAsync");
+        }
+
+        @Override
+        public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException {
+            throw logAndThrow("Not implemented: NonModifyingRequestWrapper.startAsync");
+        }
+
+        @Override
+        public AsyncContext getAsyncContext() {
+            throw logAndThrow("Not implemented: NonModifyingRequestWrapper.getAsyncContext");
+        }
+    }
+}

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/HtmlToApproximateMarkdownServicePlugin.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/HtmlToApproximateMarkdownServicePlugin.java
@@ -58,7 +58,7 @@ import com.google.common.cache.CacheBuilder;
  */
 @Designate(ocd = HtmlToApproximateMarkdownServicePlugin.Config.class)
 @Component(configurationPolicy = ConfigurationPolicy.REQUIRE,
-        property = Constants.SERVICE_RANKING + ":Integer=-1000"
+        property = Constants.SERVICE_RANKING + ":Integer=1000"
 )
 public class HtmlToApproximateMarkdownServicePlugin implements ApproximateMarkdownServicePlugin {
 

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/HtmlToApproximateMarkdownServicePlugin.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/HtmlToApproximateMarkdownServicePlugin.java
@@ -32,6 +32,7 @@ import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
 import org.apache.sling.api.wrappers.SlingHttpServletResponseWrapper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -56,7 +57,9 @@ import com.google.common.cache.CacheBuilder;
  * trying to guess it from the JCR representation, as is the default.
  */
 @Designate(ocd = HtmlToApproximateMarkdownServicePlugin.Config.class)
-@Component(configurationPolicy = ConfigurationPolicy.REQUIRE)
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE,
+        property = Constants.SERVICE_RANKING + ":Integer=-1000"
+)
 public class HtmlToApproximateMarkdownServicePlugin implements ApproximateMarkdownServicePlugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(HtmlToApproximateMarkdownServicePlugin.class);

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/OsgiAIConfiguration.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/OsgiAIConfiguration.java
@@ -5,18 +5,22 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 import com.composum.ai.backend.slingbase.AIConfigurationServlet;
 
-@ObjectClassDefinition(name = "Composum AI Configuration", description = "Configuration for allowed AI services based on OSGI settings.")
+@ObjectClassDefinition(name = "Composum AI Configuration", description = "A configuration for allowed AI services. " +
+        "There can be multiple configurations, and the allowed services are aggregated.")
 public @interface OsgiAIConfiguration {
 
     @AttributeDefinition(name = "Services",
             description = "List of services to which this configuration applies. Possible values are: "
                     + AIConfigurationServlet.SERVICE_CATEGORIZE + ", " + AIConfigurationServlet.SERVICE_CREATE
-                    + ", " + AIConfigurationServlet.SERVICE_SIDEPANEL + ", " + AIConfigurationServlet.SERVICE_TRANSLATE + " .")
-    String[] services() default {};
+                    + ", " + AIConfigurationServlet.SERVICE_SIDEPANEL + ", " + AIConfigurationServlet.SERVICE_TRANSLATE + " . For AEM only create and sidepanel are supported.")
+    String[] services() default {
+            AIConfigurationServlet.SERVICE_CATEGORIZE, AIConfigurationServlet.SERVICE_CREATE,
+            AIConfigurationServlet.SERVICE_SIDEPANEL, AIConfigurationServlet.SERVICE_TRANSLATE
+    };
 
     @AttributeDefinition(name = "Allowed Users",
             description = "Regular expressions for allowed users or user groups. If not present, no user is allowed from this configuration.")
-    String[] allowedUsers() default {};
+    String[] allowedUsers() default {".*"};
 
     @AttributeDefinition(name = "Denied Users",
             description = "Regular expressions for denied users or user groups. Takes precedence over allowed users.")
@@ -24,15 +28,16 @@ public @interface OsgiAIConfiguration {
 
     @AttributeDefinition(name = "Allowed Paths",
             description = "Regular expressions for allowed content paths. If not present, no paths are allowed.")
-    String[] allowedPaths() default {};
+    String[] allowedPaths() default {"/content/.*"};
 
     @AttributeDefinition(name = "Denied Paths",
             description = "Regular expressions for denied content paths. Takes precedence over allowed paths.")
-    String[] deniedPaths() default {};
+    // content fragments are not allowed by default since there has been trouble in the UI
+    String[] deniedPaths() default {"/content/dam/.*"};
 
     @AttributeDefinition(name = "Allowed Views",
-            description = "Regular expressions for allowed views. If not present, no views are allowed.")
-    String[] allowedViews() default {};
+            description = "Regular expressions for allowed views - that is, for URLs like /editor.html/.* . If not present, no views are allowed. Use .* to allow all views.")
+    String[] allowedViews() default {".*"};
 
     @AttributeDefinition(name = "Denied Views",
             description = "Regular expressions for denied views. Takes precedence over allowed views.")

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/AllowDenyMatcherUtilTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/AllowDenyMatcherUtilTest.java
@@ -1,0 +1,59 @@
+package com.composum.ai.backend.slingbase;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.regex.Pattern;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+
+public class AllowDenyMatcherUtilTest {
+
+    @Rule
+    public ErrorCollector ec = new ErrorCollector();
+
+    @Test
+    public void testJoinPatternsIntoAnyMatcher() {
+        // Test with non-null patterns
+        Pattern pattern = AllowDenyMatcherUtil.joinPatternsIntoAnyMatcher(new String[]{"abc", "def", "ghi", "", null});
+        ec.checkThat(pattern.matcher("abc").matches(), is(true));
+        ec.checkThat(pattern.matcher("def").matches(), is(true));
+        ec.checkThat(pattern.matcher("ghi").matches(), is(true));
+        ec.checkThat(pattern.matcher("jkl").matches(), is(false));
+        ec.checkThat(pattern.matcher("").matches(), is(false));
+
+        // Test with null patterns
+        pattern = AllowDenyMatcherUtil.joinPatternsIntoAnyMatcher(null);
+        ec.checkThat(pattern, is((Pattern) null));
+
+        pattern = AllowDenyMatcherUtil.joinPatternsIntoAnyMatcher(new String[0]);
+        ec.checkThat(pattern, is((Pattern) null));
+    }
+
+    @Test
+    public void testAllowDenyCheck() {
+        // Test case 1: value matches allowPattern but not denyPattern
+        Pattern allowPattern = Pattern.compile("abc");
+        Pattern denyPattern = Pattern.compile("def");
+        ec.checkThat(AllowDenyMatcherUtil.allowDenyCheck("abc", allowPattern, denyPattern), is(true));
+
+        // Test case 2: value matches both allowPattern and denyPattern
+        denyPattern = Pattern.compile("abc");
+        ec.checkThat(AllowDenyMatcherUtil.allowDenyCheck("abc", allowPattern, denyPattern), is(false));
+
+        // Test case 3: value does not match allowPattern
+        ec.checkThat(AllowDenyMatcherUtil.allowDenyCheck("xyz", allowPattern, denyPattern), is(false));
+
+        // Test case 4: allowPattern is null
+        ec.checkThat(AllowDenyMatcherUtil.allowDenyCheck("abc", null, denyPattern), is(false));
+
+        // Test case 5: denyPattern is null and value matches allowPattern
+        ec.checkThat(AllowDenyMatcherUtil.allowDenyCheck("abc", allowPattern, null), is(true));
+
+        // Test case 6: denyPattern is null and value does not match allowPattern
+        ec.checkThat(AllowDenyMatcherUtil.allowDenyCheck("xyz", allowPattern, null), is(false));
+    }
+
+
+}

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/AllowDenyMatcherUtilTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/AllowDenyMatcherUtilTest.java
@@ -1,4 +1,4 @@
-package com.composum.ai.backend.slingbase;
+package com.composum.ai.backend.slingbase.impl;
 
 import static org.hamcrest.CoreMatchers.is;
 
@@ -7,6 +7,8 @@ import java.util.regex.Pattern;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
+
+import com.composum.ai.backend.slingbase.impl.AllowDenyMatcherUtil;
 
 public class AllowDenyMatcherUtilTest {
 

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImplTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImplTest.java
@@ -105,9 +105,10 @@ public class ApproximateMarkdownServiceImplTest {
         service.approximateMarkdown(component, printWriter);
         String expectedOutput =
                 "## unlabelled\n" +
-                        "thefirst: the first labelled attribute\n" +
-                        "asecond: Should be the second labelled attribute\n" +
-                        "unmentioned: other lattr\n" +
+                        "\n" +
+                        "thefirst: the first labelled attribute <br>\n" +
+                        "asecond: Should be the second labelled attribute <br>\n" +
+                        "unmentioned: other lattr <br>\n" +
                         "\n";
         assertThat(writer.toString(), is(expectedOutput));
     }
@@ -124,7 +125,7 @@ public class ApproximateMarkdownServiceImplTest {
 
         service.approximateMarkdown(component, printWriter);
         String expectedOutput =
-                "thefirst: this is there\n" +
+                "thefirst: this is there <br>\n" +
                         "\n";
         assertThat(writer.toString(), is(expectedOutput));
     }

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImplTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImplTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -20,9 +21,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import com.composum.ai.backend.base.service.chat.GPTChatCompletionService;
 import com.google.common.collect.ImmutableMap;
@@ -46,10 +44,8 @@ public class ApproximateMarkdownServiceImplTest {
     @Before
     public void setUp() {
         service = new ApproximateMarkdownServiceImpl();
-        config = mock(ApproximateMarkdownServiceImpl.Config.class);
-        when(config.textAttributes()).thenReturn(new String[]{"jcr:title", "jcr:description", "title", "text"});
-        when(config.labelledAttributePatternDeny()).thenReturn(new String[]{".*:.*"});
-        when(config.labelledAttributePatternAllow()).thenReturn(new String[]{".*"});
+        config = mock(ApproximateMarkdownServiceImpl.Config.class,
+                withSettings().defaultAnswer(invocation -> invocation.getMethod().getDefaultValue()));
         when(config.labelledAttributeOrder()).thenReturn(new String[]{"thefirst", "asecond"});
         service.activate(config);
 
@@ -94,8 +90,8 @@ public class ApproximateMarkdownServiceImplTest {
         String markdown = service.getMarkdown(str);
         assertEquals("**This** is *a* test string.", markdown.trim());
     }
-    
-    
+
+
     @Test
     public void testLabelledAttributes() {
         Resource component = createMockResource("nt:unstructured",

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImplTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImplTest.java
@@ -14,6 +14,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
@@ -21,6 +23,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
+import org.mockito.Mockito;
 
 import com.composum.ai.backend.base.service.chat.GPTChatCompletionService;
 import com.google.common.collect.ImmutableMap;
@@ -34,6 +37,8 @@ public class ApproximateMarkdownServiceImplTest {
     private ApproximateMarkdownServiceImpl service;
     private StringWriter writer;
     private PrintWriter printWriter;
+    private SlingHttpServletRequest request = Mockito.mock(SlingHttpServletRequest.class);
+    private SlingHttpServletResponse response = Mockito.mock(SlingHttpServletResponse.class);
 
     @Rule
     public ErrorCollector ec = new ErrorCollector();
@@ -57,14 +62,14 @@ public class ApproximateMarkdownServiceImplTest {
 
     @Test
     public void testMarkdownWithNullResource() {
-        service.approximateMarkdown(null, printWriter);
+        service.approximateMarkdown(null, printWriter, request, response);
         assertEquals("", writer.toString());
     }
 
     @Test
     public void testApproximateMarkdownForSuccess() {
         Resource component = createMockResource("res", Map.of("text", "This is a test string.", "title", "This is a test heading"));
-        service.approximateMarkdown(component, printWriter);
+        service.approximateMarkdown(component, printWriter, request, response);
         assertEquals("## This is a test heading\n" +
                 "This is a test string.\n" +
                 "\n", writer.toString());
@@ -72,7 +77,7 @@ public class ApproximateMarkdownServiceImplTest {
 
     @Test
     public void testGetMarkdownWithNullInput() {
-        String markdown = service.approximateMarkdown(null);
+        String markdown = service.approximateMarkdown(null, request, response);
         assertTrue(markdown.isEmpty());
     }
 
@@ -102,7 +107,7 @@ public class ApproximateMarkdownServiceImplTest {
                         "is:ignored", "denied"
                 ));
 
-        service.approximateMarkdown(component, printWriter);
+        service.approximateMarkdown(component, printWriter, request, response);
         String expectedOutput =
                 "## unlabelled\n" +
                         "\n" +
@@ -123,7 +128,7 @@ public class ApproximateMarkdownServiceImplTest {
                         "is:ignored", "denied"
                 ));
 
-        service.approximateMarkdown(component, printWriter);
+        service.approximateMarkdown(component, printWriter, request, response);
         String expectedOutput =
                 "thefirst: this is there <br>\n" +
                         "\n";

--- a/composum/bundle/src/main/java/com/composum/ai/composum/bundle/AIServlet.java
+++ b/composum/bundle/src/main/java/com/composum/ai/composum/bundle/AIServlet.java
@@ -512,7 +512,7 @@ public class AIServlet extends AbstractServiceServlet {
                     if (resource == null) {
                         status.error("No resource found at " + inputPath);
                     } else {
-                        inputText = markdownService.approximateMarkdown(resource);
+                        inputText = markdownService.approximateMarkdown(resource, request, response);
                     }
                 }
                 if (status.isValid()) {

--- a/composum/bundle/src/main/java/com/composum/ai/composum/bundle/model/CategorizeDialogModel.java
+++ b/composum/bundle/src/main/java/com/composum/ai/composum/bundle/model/CategorizeDialogModel.java
@@ -69,7 +69,7 @@ public class CategorizeDialogModel extends AbstractModel {
     public List<String> getSuggestedCategories() {
         ApproximateMarkdownService markdownService = Objects.requireNonNull(context.getService(ApproximateMarkdownService.class));
         Resource pageResource = getContainingPage().getResource();
-        String markdown = markdownService.approximateMarkdown(ResourceHandle.use(pageResource).getContentResource());
+        String markdown = markdownService.approximateMarkdown(ResourceHandle.use(pageResource).getContentResource(), getContext().getRequest(), getContext().getResponse());
         GPTContentCreationService contentCreationService = Objects.requireNonNull(context.getService(GPTContentCreationService.class));
         return contentCreationService.generateKeywords(markdown);
     }

--- a/composum/bundle/src/main/java/com/composum/ai/composum/bundle/service/ComposumApproximateMarkdownServicePlugin.java
+++ b/composum/bundle/src/main/java/com/composum/ai/composum/bundle/service/ComposumApproximateMarkdownServicePlugin.java
@@ -69,6 +69,7 @@ public class ComposumApproximateMarkdownServicePlugin implements ApproximateMark
             if (StringUtils.isNotBlank(description)) {
                 out.println(helper.getMarkdown(description));
             }
+            out.println();
         }
         return isPage;
     }

--- a/composum/bundle/src/main/java/com/composum/ai/composum/bundle/service/ComposumApproximateMarkdownServicePlugin.java
+++ b/composum/bundle/src/main/java/com/composum/ai/composum/bundle/service/ComposumApproximateMarkdownServicePlugin.java
@@ -12,6 +12,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
+import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +23,10 @@ import com.composum.ai.backend.slingbase.ApproximateMarkdownServicePlugin;
 /**
  * Special handling for composum/pages/components/page and components
  */
-@Component(service = ApproximateMarkdownServicePlugin.class)
+@Component(service = ApproximateMarkdownServicePlugin.class,
+        // higher priority than HtmlToApproximateMarkdownServicePlugin since this does a better job on tables
+        property = Constants.SERVICE_RANKING + ":Integer=2000"
+)
 public class ComposumApproximateMarkdownServicePlugin implements ApproximateMarkdownServicePlugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(ComposumApproximateMarkdownServicePlugin.class);

--- a/composum/bundle/src/test/java/com/composum/ai/composum/bundle/service/ComposumApproximateMarkdownServicePluginTest.java
+++ b/composum/bundle/src/test/java/com/composum/ai/composum/bundle/service/ComposumApproximateMarkdownServicePluginTest.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.resourcebuilder.api.ResourceBuilder;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
@@ -19,6 +21,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
+import org.mockito.Mockito;
 
 import com.composum.ai.backend.base.service.chat.GPTChatCompletionService;
 import com.composum.ai.backend.slingbase.impl.ApproximateMarkdownServiceImpl;
@@ -30,6 +33,8 @@ public class ComposumApproximateMarkdownServicePluginTest {
 
     private ApproximateMarkdownServiceImpl.Config config;
     private ApproximateMarkdownServiceImpl service;
+    private SlingHttpServletRequest request = Mockito.mock(SlingHttpServletRequest.class);
+    private SlingHttpServletResponse response = Mockito.mock(SlingHttpServletResponse.class);
     private Resource component;
     private StringWriter writer;
     private PrintWriter printWriter;
@@ -62,7 +67,7 @@ public class ComposumApproximateMarkdownServicePluginTest {
     @Test
     public void testTableHandlingWithNonTableResource() {
         component = createMockResource("not/table", new HashMap<>());
-        service.approximateMarkdown(component, printWriter);
+        service.approximateMarkdown(component, printWriter, request, response);
         assertEquals("", writer.toString());
     }
 
@@ -77,7 +82,7 @@ public class ComposumApproximateMarkdownServicePluginTest {
         row2Builder.resource("r2c1", "sling:resourceType", "composum/pages/components/composed/table/cell", "text", "r2c1");
         row2Builder.resource("r2c2", "sling:resourceType", "composum/pages/components/composed/table/cell", "text", "r2c2");
 
-        service.approximateMarkdown(table, printWriter);
+        service.approximateMarkdown(table, printWriter, request, response);
         String expectedOutput = "#### Test Table\n\n" +
                 "| r1c1 | r1c2 |  |\n" +
                 "| r2c1 | r2c2 |  |\n" +
@@ -88,7 +93,7 @@ public class ComposumApproximateMarkdownServicePluginTest {
     @Test
     public void testPageHandlingWithNonPageResource() {
         component = createMockResource("not/page", new HashMap<>());
-        service.approximateMarkdown(component, printWriter);
+        service.approximateMarkdown(component, printWriter, request, response);
         assertEquals("", writer.toString());
     }
 
@@ -98,7 +103,7 @@ public class ComposumApproximateMarkdownServicePluginTest {
                 "jcr:description", "The best page!",
                 "category", "test, dummy"));
 
-        service.approximateMarkdown(component, printWriter);
+        service.approximateMarkdown(component, printWriter, request, response);
         String expectedOutput = "# myPage\n\n" +
                 "The best page!\n";
         assertEquals(expectedOutput, writer.toString());

--- a/composum/bundle/src/test/java/com/composum/ai/composum/bundle/service/ComposumApproximateMarkdownServicePluginTest.java
+++ b/composum/bundle/src/test/java/com/composum/ai/composum/bundle/service/ComposumApproximateMarkdownServicePluginTest.java
@@ -2,6 +2,7 @@ package com.composum.ai.composum.bundle.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -26,6 +27,7 @@ import com.composum.ai.backend.slingbase.impl.ApproximateMarkdownServiceImpl;
  */
 public class ComposumApproximateMarkdownServicePluginTest {
 
+    private ApproximateMarkdownServiceImpl.Config config;
     private ApproximateMarkdownServiceImpl service;
     private Resource component;
     private StringWriter writer;
@@ -39,12 +41,19 @@ public class ComposumApproximateMarkdownServicePluginTest {
 
     @Before
     public void setUp() {
+        config = mock(ApproximateMarkdownServiceImpl.Config.class);
+        when(config.textAttributes()).thenReturn(new String[]{"jcr:title", "jcr:description", "title", "text"});
+        when(config.labelledAttributePatternDeny()).thenReturn(new String[]{".*:.*"});
+        when(config.labelledAttributePatternAllow()).thenReturn(new String[]{".*"});
+        when(config.labelledAttributeOrder()).thenReturn(new String[]{"thefirst", "asecond"});
         service = new ApproximateMarkdownServiceImpl() {
             {
                 chatCompletionService = mock(GPTChatCompletionService.class);
                 plugins = Collections.singletonList(new ComposumApproximateMarkdownServicePlugin());
+                activate(config);
             }
         };
+
         writer = new StringWriter();
         printWriter = new PrintWriter(writer);
     }

--- a/composum/bundle/src/test/java/com/composum/ai/composum/bundle/service/ComposumApproximateMarkdownServicePluginTest.java
+++ b/composum/bundle/src/test/java/com/composum/ai/composum/bundle/service/ComposumApproximateMarkdownServicePluginTest.java
@@ -3,6 +3,7 @@ package com.composum.ai.composum.bundle.service;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -43,8 +44,8 @@ public class ComposumApproximateMarkdownServicePluginTest {
     public void setUp() {
         config = mock(ApproximateMarkdownServiceImpl.Config.class);
         when(config.textAttributes()).thenReturn(new String[]{"jcr:title", "jcr:description", "title", "text"});
-        when(config.labelledAttributePatternDeny()).thenReturn(new String[]{".*:.*"});
-        when(config.labelledAttributePatternAllow()).thenReturn(new String[]{".*"});
+        config = mock(ApproximateMarkdownServiceImpl.Config.class,
+                withSettings().defaultAnswer(invocation -> invocation.getMethod().getDefaultValue()));
         when(config.labelledAttributeOrder()).thenReturn(new String[]{"thefirst", "asecond"});
         service = new ApproximateMarkdownServiceImpl() {
             {

--- a/composum/bundle/src/test/java/com/composum/ai/composum/bundle/service/ComposumApproximateMarkdownServicePluginTest.java
+++ b/composum/bundle/src/test/java/com/composum/ai/composum/bundle/service/ComposumApproximateMarkdownServicePluginTest.java
@@ -105,7 +105,7 @@ public class ComposumApproximateMarkdownServicePluginTest {
 
         service.approximateMarkdown(component, printWriter, request, response);
         String expectedOutput = "# myPage\n\n" +
-                "The best page!\n";
+                "The best page!\n\n";
         assertEquals(expectedOutput, writer.toString());
     }
 

--- a/composum/config/pom.xml
+++ b/composum/config/pom.xml
@@ -62,6 +62,9 @@
 								<include>
 									.*/com.composum.ai.backend.base.service.chat.impl.GPTChatCompletionServiceImpl.*
 								</include>
+								<include>
+									.*/com.composum.ai.backend.slingbase.impl.HtmlToApproximateMarkdownServicePlugin.*
+								</include>
 							</includes>
 						</filter>
 

--- a/composum/config/src/main/content/jcr_root/libs/composum/pages/install/com.composum.ai.backend.slingbase.impl.HtmlToApproximateMarkdownServicePlugin.cfg.json
+++ b/composum/config/src/main/content/jcr_root/libs/composum/pages/install/com.composum.ai.backend.slingbase.impl.HtmlToApproximateMarkdownServicePlugin.cfg.json
@@ -1,0 +1,7 @@
+{
+  "allowedResourceTypes": [
+    ".*"
+  ],
+  "deniedResourceTypes": [
+  ]
+}

--- a/composum/package/src/main/content/jcr_root/libs/composum/pages/options/ai/js/ai.js
+++ b/composum/package/src/main/content/jcr_root/libs/composum/pages/options/ai/js/ai.js
@@ -23,7 +23,7 @@
         // all dialogs create their own subnodes in ai.const.url to put that into several files.
         ai.const.url.general = {
             authoring: '/bin/cpm/ai/authoring',
-            markdown: '/bin/cpm/ai/approximated.markdown'
+            markdown: '/bin/cpm/ai/approximated'
         };
 
         /** Will be called from Pages after a dialog is rendered via the dialogplugins hook.


### PR DESCRIPTION
- reverse heuristical strategy from JCR to print attributes except if (heuristically) forbidden, to better handle custom components
- introduce plugin to create markdown from the actual HTML rendering and use that as new default (OSGI configurable)
- extend html to markdown converter with many HTML tags to allow good markdown from component renderings