### PR TITLE
Feature/32 OpenAI key configuration from content

### DIFF
--- a/aem/ui.config/src/main/content/jcr_root/apps/composum-ai/osgiconfig/config.author/com.composum.ai.backend.base.service.chat.impl.GPTChatCompletionServiceImpl.cfg.json
+++ b/aem/ui.config/src/main/content/jcr_root/apps/composum-ai/osgiconfig/config.author/com.composum.ai.backend.base.service.chat.impl.GPTChatCompletionServiceImpl.cfg.json
@@ -1,0 +1,3 @@
+{
+  "openAiApiKey": "$[secret:OPENAI_API_KEY]"
+}

--- a/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
+++ b/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
@@ -271,6 +271,7 @@ class ContentCreationDialog {
             source: this.getSourceContent(),
             textLength: this.$textLengthSelector.val(),
             richText: this.isRichtext,
+            configBasePath: this.pagePath(this.componentPath)
         };
         console.log("createContent", data);
         this.setLoading(true);

--- a/aem/ui.frontend/src/main/webpack/site/SidePanelDialog.js
+++ b/aem/ui.frontend/src/main/webpack/site/SidePanelDialog.js
@@ -248,7 +248,8 @@ class SidePanelDialog {
         const data = {
             prompt: this.$promptContainer.find('.composum-ai-prompt:first').val(),
             chat: JSON.stringify(chatHistory),
-            sourcePath: this.getSelectedPath()
+            sourcePath: this.getSelectedPath(),
+            configBasePath: this.getContentPath()
         };
         console.log("createContent", data);
         this.setLoading(true);

--- a/backend/base/pom.xml
+++ b/backend/base/pom.xml
@@ -81,6 +81,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- Java Annotations -->

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTChatCompletionService.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTChatCompletionService.java
@@ -75,4 +75,9 @@ public interface GPTChatCompletionService {
      */
     boolean isEnabled();
 
+    /**
+     * Checks whether {@link #isEnabled()} and whether gptConfig enables executing GPT calls.
+     * (That is currently whether there is an api key either globally or in the gptConfig).
+     */
+    boolean isEnabled(GPTConfiguration gptConfig);
 }

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTChatMessage.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTChatMessage.java
@@ -1,5 +1,7 @@
 package com.composum.ai.backend.base.service.chat;
 
+import java.util.Objects;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -40,6 +42,19 @@ public class GPTChatMessage {
                 "role=" + role +
                 ", text='" + content + '\'' +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GPTChatMessage)) return false;
+        GPTChatMessage that = (GPTChatMessage) o;
+        return getRole() == that.getRole() && Objects.equals(getContent(), that.getContent());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getRole(), getContent());
     }
 
 }

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTChatRequest.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTChatRequest.java
@@ -5,13 +5,30 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A request to ChatGPT.
  */
 public class GPTChatRequest {
 
+    private static final Logger LOG = LoggerFactory.getLogger(GPTChatRequest.class);
+
     private final List<GPTChatMessage> messages = new ArrayList<>();
     private Integer maxTokens;
+    private GPTConfiguration configuration;
+
+    public GPTChatRequest() {
+    }
+
+    public GPTChatRequest(List<GPTChatMessage> messages) {
+        this.messages.addAll(messages);
+    }
+
+    public GPTChatRequest(GPTConfiguration configuration) {
+        this.configuration = configuration;
+    }
 
     /**
      * Builder style adding of messages.
@@ -59,6 +76,22 @@ public class GPTChatRequest {
     }
 
     /**
+     * Optionally, sets the configuration.
+     */
+    public GPTChatRequest setConfiguration(@Nullable GPTConfiguration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    /**
+     * Sets the LLM configuration
+     */
+    @Nullable
+    public GPTConfiguration getConfiguration() {
+        return configuration;
+    }
+
+    /**
      * Optionally the maximum number of tokens (approx. 0.75 words).
      */
     public Integer getMaxTokens() {
@@ -68,11 +101,17 @@ public class GPTChatRequest {
     /**
      * Merges in additional parameters: maxtokens overwrites, if there is a system message it's appended to the
      * current one, and the other messages are added at the back.
+     *
+     * @throws IllegalArgumentException if we already have a configuration and the additional parameters have a different one
      */
     public void mergeIn(@Nullable GPTChatRequest additionalParameters) {
         if (additionalParameters != null) {
             if (additionalParameters.getMaxTokens() != null) {
                 setMaxTokens(additionalParameters.getMaxTokens());
+            }
+
+            if (additionalParameters.getConfiguration() != null) {
+                setConfiguration(GPTConfiguration.merge(getConfiguration(), additionalParameters.getConfiguration()));
             }
 
             if (additionalParameters.getMessages() != null) {

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTChatRequest.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTChatRequest.java
@@ -2,6 +2,7 @@ package com.composum.ai.backend.base.service.chat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -145,4 +146,16 @@ public class GPTChatRequest {
                 '}';
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GPTChatRequest)) return false;
+        GPTChatRequest that = (GPTChatRequest) o;
+        return Objects.equals(getMessages(), that.getMessages()) && Objects.equals(getMaxTokens(), that.getMaxTokens()) && Objects.equals(getConfiguration(), that.getConfiguration());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getMessages(), getMaxTokens(), getConfiguration());
+    }
 }

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTChatRequest.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTChatRequest.java
@@ -143,6 +143,7 @@ public class GPTChatRequest {
         return "GPTChatRequest{" +
                 "messages=" + messages +
                 ", maxTokens=" + maxTokens +
+                ", configuration=" + configuration +
                 '}';
     }
 

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTConfiguration.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTConfiguration.java
@@ -1,0 +1,106 @@
+package com.composum.ai.backend.base.service.chat;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.jsoup.internal.StringUtil;
+
+/**
+ * A configuration to use for accessing the external LLM service. That currently contains the API key for ChatGPT,
+ * but could later include information about which LLM to use, template language, rate limiting, etc.
+ * This can be a separate parameter to a request, or implicitly contained in a passed GPTChatRequest.
+ */
+public class GPTConfiguration {
+
+    public enum AnswerType {
+        /**
+         * The default if nothing is requested - markdown is the "native" output form at least of ChatGPT.
+         */
+        MARKDOWN,
+        /**
+         * Real HTML or, more likely, richtext as simplified HTML.
+         */
+        HTML
+    }
+
+    private final String apiKey;
+
+    private final AnswerType answerType;
+
+    public GPTConfiguration(@Nullable String apiKey, @Nullable AnswerType answerType) {
+        this.apiKey = apiKey;
+        this.answerType = answerType;
+    }
+
+    /**
+     * The API key to use with ChatGPT or another service. If this isnot set, we will try to fall back to global configurations.
+     */
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    /**
+     * The type of answer we want from the LLM.
+     */
+    public AnswerType getAnswerType() {
+        return answerType;
+    }
+
+    public boolean isHtml() {
+        return answerType == AnswerType.HTML;
+    }
+
+    /**
+     * Creates a configuration that joins the values.
+     *
+     * @throws IllegalArgumentException if values conflict
+     */
+    public GPTConfiguration merge(@Nullable GPTConfiguration other) throws IllegalArgumentException {
+        if (other == null) {
+            return this;
+        }
+        String apiKey = this.apiKey != null ? this.apiKey : other.apiKey;
+        if (this.apiKey != null && other.apiKey != null && !this.apiKey.equals(other.apiKey)) {
+            throw new IllegalArgumentException("Cannot merge conflicting API keys: " + this.apiKey + " vs. " + other.apiKey);
+        }
+        AnswerType answerType = this.answerType != null ? this.answerType : other.answerType;
+        if (this.answerType != null && other.answerType != null && !this.answerType.equals(other.answerType)) {
+            throw new IllegalArgumentException("Cannot merge conflicting answer types: " + this.answerType + " vs. " + other.answerType);
+        }
+        return new GPTConfiguration(apiKey, answerType);
+    }
+
+    /**
+     * {@link #merge(GPTConfiguration)} several configurations.
+     */
+    @Nullable
+    public static GPTConfiguration merge(@Nullable GPTConfiguration first, @Nullable GPTConfiguration second) {
+        return first != null ? first.merge(second) : second;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GPTConfiguration)) return false;
+        GPTConfiguration that = (GPTConfiguration) o;
+        return Objects.equals(getApiKey(), that.getApiKey()) && getAnswerType() == that.getAnswerType();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getApiKey(), getAnswerType());
+    }
+
+    @Override
+    public String toString() {
+        return "GPTConfiguration{" +
+                "answerType=" + getAnswerType() +
+                ", apiKey='" + (StringUtil.isBlank(getApiKey()) ? "" : "(hidden)") + '\'' +
+                '}';
+    }
+
+    public static final GPTConfiguration MARKDOWN = new GPTConfiguration(null, AnswerType.MARKDOWN);
+    public static final GPTConfiguration HTML = new GPTConfiguration(null, AnswerType.HTML);
+
+}

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTConfiguration.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTConfiguration.java
@@ -2,6 +2,7 @@ package com.composum.ai.backend.base.service.chat;
 
 import java.util.Objects;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.jsoup.internal.StringUtil;
@@ -77,6 +78,14 @@ public class GPTConfiguration {
     @Nullable
     public static GPTConfiguration merge(@Nullable GPTConfiguration first, @Nullable GPTConfiguration second) {
         return first != null ? first.merge(second) : second;
+    }
+
+    /**
+     * Returns {@link #HTML} if richText is true, {@link #MARKDOWN} otherwise.
+     */
+    @Nonnull
+    public static GPTConfiguration ofRichText(boolean richText) {
+        return new GPTConfiguration(null, richText ? AnswerType.HTML : AnswerType.MARKDOWN);
     }
 
     @Override

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTConfiguration.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTConfiguration.java
@@ -89,6 +89,17 @@ public class GPTConfiguration {
     }
 
     @Override
+    public String toString() {
+        return "GPTConfiguration{" +
+                "answerType=" + getAnswerType() +
+                ", apiKey='" + (StringUtil.isBlank(getApiKey()) ? "" : "(hidden)") + '\'' +
+                '}';
+    }
+
+    public static final GPTConfiguration MARKDOWN = new GPTConfiguration(null, AnswerType.MARKDOWN);
+    public static final GPTConfiguration HTML = new GPTConfiguration(null, AnswerType.HTML);
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof GPTConfiguration)) return false;
@@ -100,16 +111,4 @@ public class GPTConfiguration {
     public int hashCode() {
         return Objects.hash(getApiKey(), getAnswerType());
     }
-
-    @Override
-    public String toString() {
-        return "GPTConfiguration{" +
-                "answerType=" + getAnswerType() +
-                ", apiKey='" + (StringUtil.isBlank(getApiKey()) ? "" : "(hidden)") + '\'' +
-                '}';
-    }
-
-    public static final GPTConfiguration MARKDOWN = new GPTConfiguration(null, AnswerType.MARKDOWN);
-    public static final GPTConfiguration HTML = new GPTConfiguration(null, AnswerType.HTML);
-
 }

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTContentCreationService.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTContentCreationService.java
@@ -19,7 +19,7 @@ public interface GPTContentCreationService {
      * @return A list of generated keywords, possibly empty.
      */
     @Nonnull
-    List<String> generateKeywords(@Nullable String text) throws GPTException;
+    List<String> generateKeywords(@Nullable String text, @Nullable GPTConfiguration configuration) throws GPTException;
 
     /**
      * Generates a description from the given text.
@@ -29,7 +29,7 @@ public interface GPTContentCreationService {
      * @return A generated description, possibly empty.
      */
     @Nonnull
-    String generateDescription(@Nullable String text, int maxwords) throws GPTException;
+    String generateDescription(@Nullable String text, int maxwords, @Nullable GPTConfiguration configuration) throws GPTException;
 
     /**
      * Executes a given prompt from the user using ChatGPT.

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTTranslationService.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTTranslationService.java
@@ -14,12 +14,12 @@ public interface GPTTranslationService {
      * Translate the text from the target to destination language, either Java locale name or language name.
      */
     @Nonnull
-    String singleTranslation(@Nullable String text, @Nullable String sourceLanguage, @Nullable String targetLanguage, boolean richtext) throws GPTException;
+    String singleTranslation(@Nullable String text, @Nullable String sourceLanguage, @Nullable String targetLanguage, @Nullable GPTConfiguration configuration) throws GPTException;
 
 
     /**
      * Translate the text from the target to destination language, either Java locale name or language name.
      */
-    void streamingSingleTranslation(@Nonnull String text, @Nonnull String sourceLanguage, @Nonnull String targetLanguage, boolean richtext, @Nonnull GPTCompletionCallback callback) throws GPTException;
+    void streamingSingleTranslation(@Nonnull String text, @Nonnull String sourceLanguage, @Nonnull String targetLanguage, @Nullable GPTConfiguration configuration, @Nonnull GPTCompletionCallback callback) throws GPTException;
 
 }

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/GPTChatCompletionServiceImpl.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/GPTChatCompletionServiceImpl.java
@@ -103,6 +103,9 @@ public class GPTChatCompletionServiceImpl implements GPTChatCompletionService {
      */
     public static final String COMPOSUM_AI_CHAT_GPT = "Composum-AI-ChatGPT";
 
+    /**
+     * The OpenAI Key for accessing ChatGPT; system default if not given in request.
+     */
     private String apiKey;
     private String defaultModel;
 

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/GPTContentCreationServiceImpl.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/GPTContentCreationServiceImpl.java
@@ -18,6 +18,7 @@ import com.composum.ai.backend.base.service.chat.GPTChatCompletionService;
 import com.composum.ai.backend.base.service.chat.GPTChatMessage;
 import com.composum.ai.backend.base.service.chat.GPTChatRequest;
 import com.composum.ai.backend.base.service.chat.GPTCompletionCallback;
+import com.composum.ai.backend.base.service.chat.GPTConfiguration;
 import com.composum.ai.backend.base.service.chat.GPTContentCreationService;
 import com.composum.ai.backend.base.service.chat.GPTMessageRole;
 
@@ -55,12 +56,12 @@ public class GPTContentCreationServiceImpl implements GPTContentCreationService 
 
     @Nonnull
     @Override
-    public List<String> generateKeywords(@Nullable String text) {
+    public List<String> generateKeywords(@Nullable String text, @Nullable GPTConfiguration configuration) {
         if (text == null || text.isBlank()) {
             return List.of();
         }
         GPTChatMessagesTemplate template = chatCompletionService.getTemplate(TEMPLATE_MAKEKEYWORDS);
-        GPTChatRequest request = new GPTChatRequest();
+        GPTChatRequest request = new GPTChatRequest(configuration);
         String shortenedText = chatCompletionService.shorten(text, MAXTOKENS);
         List<GPTChatMessage> messages = template.getMessages(Map.of(PLACEHOLDER_TEXT, shortenedText));
         request.addMessages(messages);
@@ -78,12 +79,12 @@ public class GPTContentCreationServiceImpl implements GPTContentCreationService 
 
     @Nonnull
     @Override
-    public String generateDescription(@Nullable String text, int maxwords) {
+    public String generateDescription(@Nullable String text, int maxwords, @Nullable GPTConfiguration configuration) {
         if (text == null || text.isBlank()) {
             return "";
         }
         GPTChatMessagesTemplate template = chatCompletionService.getTemplate(TEMPLATE_MAKEDESCRIPTION);
-        GPTChatRequest request = new GPTChatRequest();
+        GPTChatRequest request = new GPTChatRequest(configuration);
         String shortenedText = chatCompletionService.shorten(text, MAXTOKENS);
         int maxtokens = 150;
         Map<String, String> placeholders = new HashMap<>();

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/AbstractGPTRunner.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/AbstractGPTRunner.java
@@ -41,7 +41,7 @@ public abstract class AbstractGPTRunner {
             }
 
             @Override
-            public boolean disable() {
+            public boolean disabled() {
                 return false;
             }
 

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/AbstractGPTRunner.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/AbstractGPTRunner.java
@@ -18,12 +18,18 @@ public abstract class AbstractGPTRunner {
 
     protected ThreadPoolManager mockThreadPoolManager = Mockito.mock(ThreadPoolManager.class);
 
+    protected DefaultThreadPool defaultThreadPool;
+
     protected void setup() throws IOException {
         chatCompletionService = new GPTChatCompletionServiceImpl() {{
             this.threadPoolManager = mockThreadPoolManager;
         }};
-        Mockito.when(mockThreadPoolManager.get(COMPOSUM_AI_CHAT_GPT))
-                .thenReturn(new DefaultThreadPool(COMPOSUM_AI_CHAT_GPT, null));
+        Mockito.when(mockThreadPoolManager.get(COMPOSUM_AI_CHAT_GPT)).thenAnswer(invocation -> {
+            if (defaultThreadPool == null) {
+                defaultThreadPool = new DefaultThreadPool(COMPOSUM_AI_CHAT_GPT, null);
+            }
+            return defaultThreadPool;
+        });
         // read key from file ~/.openaiapi
         Path filePath = Paths.get(System.getProperty("user.home"), ".openaiapi");
         String apiKey = Files.readString(filePath);
@@ -69,6 +75,12 @@ public abstract class AbstractGPTRunner {
                 return 20;
             }
         }, null);
+    }
+
+    protected void shutdown() {
+        if (defaultThreadPool != null) {
+            defaultThreadPool.shutdown();
+        }
     }
 
 }

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/RunGPTCreateDescriptionImpl.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/RunGPTCreateDescriptionImpl.java
@@ -26,7 +26,7 @@ public class RunGPTCreateDescriptionImpl extends AbstractGPTRunner {
     }
 
     private void printDescriptionFor(String text, int maxWords) {
-        String result = service.generateDescription(text, maxWords);
+        String result = service.generateDescription(text, maxWords, null);
         // print parameters and result
         System.out.printf("%ndescription for '%s': %n%s%n%n", text, result);
     }

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/RunGPTCreateKeywordsImpl.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/RunGPTCreateKeywordsImpl.java
@@ -27,7 +27,7 @@ public class RunGPTCreateKeywordsImpl extends AbstractGPTRunner {
     }
 
     private void printKeywordsFor(String text) {
-        List<String> result = service.generateKeywords(text);
+        List<String> result = service.generateKeywords(text, null);
         // print parameters and result
         System.out.printf("%n%nkeywords for '%s': %s%n%n", text, result);
     }

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/RunGPTTranslationServiceImpl.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/RunGPTTranslationServiceImpl.java
@@ -2,6 +2,8 @@ package com.composum.ai.backend.base.service.chat.impl;
 
 import java.io.IOException;
 
+import com.composum.ai.backend.base.service.chat.GPTConfiguration;
+
 /**
  * Tries an actual call to ChatGPT. Since that costs money (though much less than a cent), needs a secret key and takes a couple of seconds,
  * we don't do that as an JUnit test.
@@ -34,7 +36,8 @@ public class RunGPTTranslationServiceImpl extends AbstractGPTRunner {
     }
 
     private void doTranslation(String text, String from, String to, boolean richText) {
-        String result = translationService.singleTranslation(text, from, to, richText);
+        String result = translationService.singleTranslation(text, from, to,
+                richText ? GPTConfiguration.HTML : GPTConfiguration.MARKDOWN);
         // print parameters and result
         System.out.printf("%n%ntranslation of '%s' from %s to %s: %s%n%n", text, from, to, result);
     }

--- a/backend/slingbase/pom.xml
+++ b/backend/slingbase/pom.xml
@@ -1,141 +1,171 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd ">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>com.composum.ai</groupId>
-		<artifactId>composum-ai-integration-backend</artifactId>
-		<version>0.5.2-SNAPSHOT</version>
-	</parent>
+    <parent>
+        <groupId>com.composum.ai</groupId>
+        <artifactId>composum-ai-integration-backend</artifactId>
+        <version>0.5.2-SNAPSHOT</version>
+    </parent>
 
-	<artifactId>composum-ai-integration-backend-slingbase</artifactId>
-	<packaging>bundle</packaging>
+    <artifactId>composum-ai-integration-backend-slingbase</artifactId>
+    <packaging>bundle</packaging>
 
-	<name>Composum AI::Backend::SlingBase</name>
-	<description>
+    <name>Composum AI::Backend::SlingBase</name>
+    <description>
 		Common Functionality for Composum AI specific to Sling but would be useable in both Composum and AEM and similar.
-	</description>
+    </description>
 
-	<properties>
-		<wikitext.version>3.0.42</wikitext.version>
-	</properties>
+    <properties>
+        <wikitext.version>3.0.42</wikitext.version>
+    </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.composum.ai</groupId>
-			<artifactId>composum-ai-integration-backend-base</artifactId>
-			<version>${project.version}</version>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>com.composum.ai</groupId>
+            <artifactId>composum-ai-integration-backend-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
-		<!-- Other libraries -->
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-		</dependency>
+        <!-- Other libraries -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
 
-		<!-- Sling, JCR -->
-		<dependency>
-			<groupId>org.apache.sling</groupId>
-			<artifactId>org.apache.sling.api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>javax.jcr</groupId>
-			<artifactId>jcr</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.jackrabbit</groupId>
-			<artifactId>jackrabbit-jcr-commons</artifactId>
-		</dependency>
+        <!-- Sling, JCR -->
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.jcr</groupId>
+            <artifactId>jcr</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-jcr-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.caconfig.api</artifactId>
+        </dependency>
 
-		<!-- JSON -->
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-		</dependency>
+        <!-- JSON -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
 
-		<!-- Java Annotations -->
-		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>jsr305</artifactId>
-		</dependency>
+        <!-- Java Annotations -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
 
-		<!-- OSGi, Felix -->
-		<dependency>
-			<groupId>org.osgi</groupId>
-			<artifactId>org.osgi.core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.osgi</groupId>
-			<artifactId>osgi.cmpn</artifactId>
-		</dependency>
+        <!-- OSGi, Felix -->
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+        </dependency>
 
-		<!-- JUnit -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.sling</groupId>
-			<artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.sling</groupId>
-			<artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-		</dependency>
+        <!-- JUnit -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.sling/org.apache.sling.testing.caconfig-mock-plugin -->
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.caconfig-mock-plugin</artifactId>
+            <version>1.5.2</version>
+            <scope>test</scope>
+        </dependency>
 
-	</dependencies>
+    </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>pl.project13.maven</groupId>
-				<artifactId>git-commit-id-plugin</artifactId>
-			</plugin>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+            </plugin>
 
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Import-Package>
-							javax.annotation;version="[1,4)",
-							!javax.annotation.meta,
-							*
-						</Import-Package>
-						<Export-Package>
-							!com.composum.ai.backend.slingbase.impl,
-							!com.composum.ai.backend.slingbase.*.impl,
-							com.composum.ai.backend.slingbase.*
-						</Export-Package>
-					</instructions>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            javax.annotation;version="[1,4)",
+                            !javax.annotation.meta,
+                            *
+                        </Import-Package>
+                        <Export-Package>
+                            !com.composum.ai.backend.slingbase.impl,
+                            !com.composum.ai.backend.slingbase.*.impl,
+                            com.composum.ai.backend.slingbase.*
+                        </Export-Package>
 
-	<profiles>
+                        <!-- Generate bundle header containing all configuration annotation classes -->
+                        <!-- TODO that breaks intellij build :-( So we have to do it by hand -->
+                        <!-- <_plugin>org.apache.sling.caconfig.bndplugin.ConfigurationClassScannerPlugin</_plugin> -->
+                        <Sling-ContextAware-Configuration-Classes>
+                            com.composum.ai.backend.slingbase.model.OpenAIConfig
+                        </Sling-ContextAware-Configuration-Classes>
+                    </instructions>
+                </configuration>
+                <!-- <dependencies>
+                    <dependency>
+                        <groupId>org.apache.sling</groupId>
+                        <artifactId>org.apache.sling.caconfig.bnd-plugin</artifactId>
+                        <version>1.0.2</version>
+                    </dependency>
+                </dependencies> -->
+            </plugin>
+        </plugins>
+    </build>
 
-		<profile>
-			<id>installBundle</id>
-		</profile>
-		<profile>
-			<id>installPackage</id>
-		</profile>
-		<profile>
-			<id>installTestContent</id>
-		</profile>
+    <profiles>
 
-	</profiles>
+        <profile>
+            <id>installBundle</id>
+        </profile>
+        <profile>
+            <id>installPackage</id>
+        </profile>
+        <profile>
+            <id>installTestContent</id>
+        </profile>
+
+    </profiles>
 
 </project>

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationPlugin.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationPlugin.java
@@ -3,8 +3,11 @@ package com.composum.ai.backend.slingbase;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+
+import com.composum.ai.backend.base.service.chat.GPTConfiguration;
 
 public interface AIConfigurationPlugin {
 
@@ -14,13 +17,24 @@ public interface AIConfigurationPlugin {
      * @param request     The SlingHttpServletRequest representing the current request.
      * @param contentPath The path of the content being edited.
      * @param editorUrl   The URL of the editor in the browser.
-     * @return A set of allowed services.
+     * @return A set of allowed services; null if this plugin doesn't implement this method.
      * @see AIConfigurationServlet#SERVICE_CATEGORIZE
      * @see AIConfigurationServlet#SERVICE_CREATE
      * @see AIConfigurationServlet#SERVICE_SIDEPANEL
      * @see AIConfigurationServlet#SERVICE_TRANSLATE
      */
-    @Nonnull
+    @Nullable
     Set<String> allowedServices(SlingHttpServletRequest request, String contentPath, String editorUrl);
+
+    /**
+     * Reads the GPTConfiguration from sling context aware configurations.
+     *
+     * @param request     the request
+     * @param contentPath if that's given we read the configuration for this path, otherwise we take the requests path, as long as it starts with /content/
+     * @return if the configuration could be determined we return it, otherwise null.
+     * @throws IllegalArgumentException if none of the paths is a /content/ path.
+     */
+    @Nullable
+    GPTConfiguration getGPTConfiguration(@Nonnull SlingHttpServletRequest request, @Nonnull String contentPath) throws IllegalArgumentException;
 
 }

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationPlugin.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationPlugin.java
@@ -24,7 +24,7 @@ public interface AIConfigurationPlugin {
      * @see AIConfigurationServlet#SERVICE_TRANSLATE
      */
     @Nullable
-    Set<String> allowedServices(SlingHttpServletRequest request, String contentPath, String editorUrl);
+    Set<String> allowedServices(@Nonnull SlingHttpServletRequest request, @Nonnull String contentPath, @Nonnull String editorUrl);
 
     /**
      * Reads the GPTConfiguration from sling context aware configurations.
@@ -35,6 +35,6 @@ public interface AIConfigurationPlugin {
      * @throws IllegalArgumentException if none of the paths is a /content/ path.
      */
     @Nullable
-    GPTConfiguration getGPTConfiguration(@Nonnull SlingHttpServletRequest request, @Nonnull String contentPath) throws IllegalArgumentException;
+    GPTConfiguration getGPTConfiguration(@Nonnull SlingHttpServletRequest request, @Nullable String contentPath) throws IllegalArgumentException;
 
 }

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationService.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationService.java
@@ -1,8 +1,13 @@
 package com.composum.ai.backend.slingbase;
 
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.apache.sling.api.SlingHttpServletRequest;
 
-import java.util.Set;
+import com.composum.ai.backend.base.service.chat.GPTConfiguration;
 
 /**
  * This is the primary service interface that provides methods to check which
@@ -14,11 +19,21 @@ public interface AIConfigurationService {
      * Method to check which services are allowed, based on the path
      * and editor URL provided.
      *
-     * @param request    the SlingHttpServletRequest
+     * @param request     the SlingHttpServletRequest
      * @param contentPath the content path
      * @param editorUrl   the editor URL
      * @return a set of allowed services
      */
-    Set<String> allowedServices(SlingHttpServletRequest request, String contentPath, String editorUrl);
+    @Nullable
+    Set<String> allowedServices(@Nonnull SlingHttpServletRequest request, @Nonnull String contentPath, @Nonnull String editorUrl);
+
+    /**
+     * Reads the GPTConfiguration from sling context aware configurations.
+     *
+     * @param request     the request
+     * @param contentPath if that's given we read the configuration for this path, otherwise we take the requests path, as long as it starts with /content/
+     * @throws IllegalArgumentException if none of the paths is a /content/ path.
+     */
+    GPTConfiguration getGPTConfiguration(@Nonnull SlingHttpServletRequest request, @Nonnull String contentPath) throws IllegalArgumentException;
 
 }

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationService.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationService.java
@@ -35,6 +35,6 @@ public interface AIConfigurationService {
      * @throws IllegalArgumentException if none of the paths is a /content/ path.
      */
     @Nullable
-    GPTConfiguration getGPTConfiguration(@Nonnull SlingHttpServletRequest request, @Nonnull String contentPath) throws IllegalArgumentException;
+    GPTConfiguration getGPTConfiguration(@Nonnull SlingHttpServletRequest request, @Nullable String contentPath) throws IllegalArgumentException;
 
 }

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationService.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationService.java
@@ -34,6 +34,7 @@ public interface AIConfigurationService {
      * @param contentPath if that's given we read the configuration for this path, otherwise we take the requests path, as long as it starts with /content/
      * @throws IllegalArgumentException if none of the paths is a /content/ path.
      */
+    @Nullable
     GPTConfiguration getGPTConfiguration(@Nonnull SlingHttpServletRequest request, @Nonnull String contentPath) throws IllegalArgumentException;
 
 }

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationServlet.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationServlet.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 import javax.servlet.Servlet;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.HttpConstants;
@@ -93,7 +94,7 @@ public class AIConfigurationServlet extends SlingSafeMethodsServlet {
 
     @Override
     protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException {
-        String contentPath = request.getRequestPathInfo().getSuffix();
+        String contentPath = StringUtils.removeEnd(request.getRequestPathInfo().getSuffix(), ".html");
         String editorUrl = request.getParameter(PARAM_EDITORURL);
         Set<String> allowedServices = aiConfigurationService.allowedServices(request, contentPath, editorUrl);
         Map<String, Boolean> allowedServicesMap = allowedServices.stream()

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/AIConfigurationServiceImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/AIConfigurationServiceImpl.java
@@ -55,7 +55,7 @@ public class AIConfigurationServiceImpl implements AIConfigurationService {
     }
 
     @Override
-    public GPTConfiguration getGPTConfiguration(@NotNull SlingHttpServletRequest request, @NotNull String contentPath) throws IllegalArgumentException {
+    public GPTConfiguration getGPTConfiguration(@NotNull SlingHttpServletRequest request, @Nullable String contentPath) throws IllegalArgumentException {
         for (AIConfigurationPlugin plugin : plugins) {
             try {
                 GPTConfiguration configuration = plugin.getGPTConfiguration(request, contentPath);

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/AIConfigurationServiceImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/AIConfigurationServiceImpl.java
@@ -4,7 +4,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -12,6 +16,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.composum.ai.backend.base.service.chat.GPTConfiguration;
 import com.composum.ai.backend.slingbase.AIConfigurationPlugin;
 import com.composum.ai.backend.slingbase.AIConfigurationService;
 
@@ -24,25 +29,44 @@ public class AIConfigurationServiceImpl implements AIConfigurationService {
     private static final Logger LOG = LoggerFactory.getLogger(AIConfigurationServiceImpl.class);
 
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)
-    private volatile List<AIConfigurationPlugin> plugins;
+    protected volatile List<AIConfigurationPlugin> plugins;
 
     /**
      * Union of the plugin's results.
      */
     @Override
-    public Set<String> allowedServices(SlingHttpServletRequest request, String contentPath, String editorUrl) {
+    @Nullable
+    public Set<String> allowedServices(@Nonnull SlingHttpServletRequest request, @Nonnull String contentPath, @Nonnull String editorUrl) {
         Set<String> allowedServices = new HashSet<>();
         for (AIConfigurationPlugin plugin : plugins) {
             try {
                 Set<String> services = plugin.allowedServices(request, contentPath, editorUrl);
-                allowedServices.addAll(services);
-                if (!services.isEmpty()) {
-                    LOG.info("Plugin {} allowed services {}", plugin.getClass(), services);
+                if (services != null) {
+                    allowedServices.addAll(services);
+                    if (!services.isEmpty()) {
+                        LOG.info("Plugin {} allowed services {}", plugin.getClass(), services);
+                    }
                 }
             } catch (Exception e) {
                 LOG.error("Error in AIConfigurationPlugin with {}", plugin.getClass(), e);
             }
         }
         return allowedServices;
+    }
+
+    @Override
+    public GPTConfiguration getGPTConfiguration(@NotNull SlingHttpServletRequest request, @NotNull String contentPath) throws IllegalArgumentException {
+        for (AIConfigurationPlugin plugin : plugins) {
+            try {
+                GPTConfiguration configuration = plugin.getGPTConfiguration(request, contentPath);
+                if (configuration != null) {
+                    LOG.info("Plugin {} returned configuration {}", plugin.getClass(), configuration);
+                    return configuration;
+                }
+            } catch (Exception e) {
+                LOG.error("Error in AIConfigurationPlugin with {}", plugin.getClass(), e);
+            }
+        }
+        return null;
     }
 }

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/OsgiAIConfigurationPluginImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/OsgiAIConfigurationPluginImpl.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
@@ -18,8 +20,6 @@ import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -116,7 +116,7 @@ public class OsgiAIConfigurationPluginImpl implements AIConfigurationPlugin {
      */
     @Nullable
     @Override
-    public GPTConfiguration getGPTConfiguration(@NotNull SlingHttpServletRequest request, @NotNull String contentPath) throws IllegalArgumentException {
+    public GPTConfiguration getGPTConfiguration(@Nonnull SlingHttpServletRequest request, @Nullable String contentPath) throws IllegalArgumentException {
         return null;
     }
 

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/OsgiAIConfigurationPluginImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/OsgiAIConfigurationPluginImpl.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.annotation.Nonnull;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
@@ -19,6 +18,9 @@ import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -27,6 +29,7 @@ import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.composum.ai.backend.base.service.chat.GPTConfiguration;
 import com.composum.ai.backend.slingbase.AIConfigurationPlugin;
 
 /**
@@ -60,7 +63,9 @@ import com.composum.ai.backend.slingbase.AIConfigurationPlugin;
  * @see AIConfigurationPlugin
  * @see OsgiAIConfiguration
  */
-@Component
+@Component(
+        property = Constants.SERVICE_RANKING + ":Integer=2000"
+)
 @Designate(ocd = OsgiAIConfiguration.class, factory = true)
 public class OsgiAIConfigurationPluginImpl implements AIConfigurationPlugin {
 
@@ -82,7 +87,7 @@ public class OsgiAIConfigurationPluginImpl implements AIConfigurationPlugin {
     }
 
     @Override
-    @Nonnull
+    @Nullable
     public Set<String> allowedServices(SlingHttpServletRequest request, String contentPath, String editorUrl) {
         Set<String> allowedServices = new HashSet<>();
         try {
@@ -106,6 +111,15 @@ public class OsgiAIConfigurationPluginImpl implements AIConfigurationPlugin {
         return allowedServices;
     }
 
+    /**
+     * Not implemented here.
+     */
+    @Nullable
+    @Override
+    public GPTConfiguration getGPTConfiguration(@NotNull SlingHttpServletRequest request, @NotNull String contentPath) throws IllegalArgumentException {
+        return null;
+    }
+
     protected List<String> userAndGroupsOfUser(SlingHttpServletRequest request) throws RepositoryException {
         List<String> authorizableNames = new ArrayList<>();
         UserManager userManager = request.getResourceResolver().adaptTo(UserManager.class);
@@ -127,9 +141,11 @@ public class OsgiAIConfigurationPluginImpl implements AIConfigurationPlugin {
     }
 
     protected boolean matchesAny(String value, String[] patterns) {
-        for (String pattern : patterns) {
-            if (value.matches(pattern)) {
-                return true;
+        if (patterns != null) {
+            for (String pattern : patterns) {
+                if (value.matches(pattern)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/SlingCaConfigPluginImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/SlingCaConfigPluginImpl.java
@@ -53,8 +53,8 @@ public class SlingCaConfigPluginImpl implements AIConfigurationPlugin {
         ConfigurationBuilder confBuilder = Objects.requireNonNull(resource.adaptTo(ConfigurationBuilder.class));
         OpenAIConfig config = confBuilder.as(OpenAIConfig.class);
         GPTConfiguration result = null;
-        if (StringUtils.isNotBlank(config.openaikey())) {
-            result = new GPTConfiguration(config.openaikey(), null);
+        if (StringUtils.isNotBlank(config.openAiApiKey())) {
+            result = new GPTConfiguration(config.openAiApiKey(), null);
         }
         LOG.debug("found key: {}", result);
         return result;

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/SlingCaConfigPluginImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/SlingCaConfigPluginImpl.java
@@ -1,0 +1,72 @@
+package com.composum.ai.backend.slingbase.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.caconfig.ConfigurationBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.composum.ai.backend.base.service.chat.GPTConfiguration;
+import com.composum.ai.backend.slingbase.AIConfigurationPlugin;
+import com.composum.ai.backend.slingbase.model.OpenAIConfig;
+
+/**
+ * Reads configurations using Sling context aware configuration.
+ * Higher precedence than {@link OsgiAIConfigurationPluginImpl}.
+ */
+@Component(
+        property = Constants.SERVICE_RANKING + ":Integer=1000"
+)
+public class SlingCaConfigPluginImpl implements AIConfigurationPlugin {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SlingCaConfigPluginImpl.class);
+
+    @Override
+    @javax.annotation.Nullable
+    public Set<String> allowedServices(SlingHttpServletRequest request, String contentPath, String editorUrl) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public GPTConfiguration getGPTConfiguration(@NotNull SlingHttpServletRequest request, @NotNull String contentPath) throws IllegalArgumentException {
+        LOG.debug("getGPTConfiguration({}, {})", request.getResource().getPath(), contentPath);
+        Resource resource = request.getResource();
+        if (StringUtils.isNotBlank(contentPath)) {
+            resource = request.getResourceResolver().getResource(contentPath);
+        }
+        if (resource == null) {
+            throw new IllegalArgumentException("No resource found for path " + contentPath);
+        }
+        if (!resource.getPath().startsWith("/content/")) {
+            throw new IllegalArgumentException("Path " + resource.getPath() + " is not a /content/ path");
+        }
+
+        ConfigurationBuilder confBuilder = resource.adaptTo(ConfigurationBuilder.class);
+        Collection<OpenAIConfig> configs = confBuilder.asCollection(OpenAIConfig.class);
+        // Hack since strangely configs is empty in the test, but not the result of confBuilder.as .
+        configs = new ArrayList<>(configs);
+        OpenAIConfig config = confBuilder.as(OpenAIConfig.class);
+        configs.add(config);
+
+        GPTConfiguration result = null;
+        String key = configs.stream()
+                .filter(Objects::nonNull)
+                .filter(k -> StringUtils.isNotBlank(k.openaikey()))
+                .findFirst()
+                .map(OpenAIConfig::openaikey)
+                .orElse(null);
+        LOG.debug("found key: {}", key != null);
+        return key != null ? new GPTConfiguration(key, null) : null;
+    }
+}

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/SlingCaConfigPluginImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/SlingCaConfigPluginImpl.java
@@ -1,7 +1,5 @@
 package com.composum.ai.backend.slingbase.impl;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
 
@@ -52,21 +50,13 @@ public class SlingCaConfigPluginImpl implements AIConfigurationPlugin {
             throw new IllegalArgumentException("Path " + resource.getPath() + " is not a /content/ path");
         }
 
-        ConfigurationBuilder confBuilder = resource.adaptTo(ConfigurationBuilder.class);
-        Collection<OpenAIConfig> configs = confBuilder.asCollection(OpenAIConfig.class);
-        // Hack since strangely configs is empty in the test, but not the result of confBuilder.as .
-        configs = new ArrayList<>(configs);
+        ConfigurationBuilder confBuilder = Objects.requireNonNull(resource.adaptTo(ConfigurationBuilder.class));
         OpenAIConfig config = confBuilder.as(OpenAIConfig.class);
-        configs.add(config);
-
         GPTConfiguration result = null;
-        String key = configs.stream()
-                .filter(Objects::nonNull)
-                .filter(k -> StringUtils.isNotBlank(k.openaikey()))
-                .findFirst()
-                .map(OpenAIConfig::openaikey)
-                .orElse(null);
-        LOG.debug("found key: {}", key != null);
-        return key != null ? new GPTConfiguration(key, null) : null;
+        if (StringUtils.isNotBlank(config.openaikey())) {
+            result = new GPTConfiguration(config.openaikey(), null);
+        }
+        LOG.debug("found key: {}", result);
+        return result;
     }
 }

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/model/OpenAIConfig.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/model/OpenAIConfig.java
@@ -8,6 +8,6 @@ import org.apache.sling.caconfig.annotation.Property;
 public @interface OpenAIConfig {
 
     @Property(label = "OpenAI API Key", description = "OpenAI API Key from https://platform.openai.com/. If not given, this falls back to the OSGI configuration, the environment Variable OPENAI_API_KEY, and the system property openai.api.key .")
-    String openaikey() default "";
+    String openAiApiKey();
 
 }

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/model/OpenAIConfig.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/model/OpenAIConfig.java
@@ -1,0 +1,13 @@
+package com.composum.ai.backend.slingbase.model;
+
+import org.apache.sling.caconfig.annotation.Configuration;
+import org.apache.sling.caconfig.annotation.Property;
+
+@Configuration(label = "Composum AI OpenAI Configuration", description = "Configurations for the OpenAI backend for Composum AI")
+// is also added to Sling-ContextAware-Configuration-Classes bnd header in pom.xml
+public @interface OpenAIConfig {
+
+    @Property(label = "OpenAI API Key", description = "OpenAI API Key from https://platform.openai.com/. If not given, this falls back to the OSGI configuration, the environment Variable OPENAI_API_KEY, and the system property openai.api.key .")
+    String openaikey() default "";
+
+}

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/AIConfigurationServiceImplTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/AIConfigurationServiceImplTest.java
@@ -97,7 +97,7 @@ public class AIConfigurationServiceImplTest {
         String key = "thekey";
         // set up sling configuration for the path with key
         context.create().resource("/conf/global/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig",
-                "openaikey", key);
+                "openAiApiKey", key);
         GPTConfiguration config = service.getGPTConfiguration(getRequest(), "/content/allowed/path");
         assertThat(config, notNullValue());
         assertThat(config.getApiKey(), is(key));

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/AIConfigurationServiceImplTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/AIConfigurationServiceImplTest.java
@@ -1,0 +1,96 @@
+package com.composum.ai.backend.slingbase.impl;
+
+import static org.apache.sling.testing.mock.caconfig.ContextPlugins.CACONFIG;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.jackrabbit.api.security.user.UserManager;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.junit.SlingContextBuilder;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.composum.ai.backend.base.service.chat.GPTConfiguration;
+
+/**
+ * "Integration test" for the AI Configuration Service.
+ */
+public class AIConfigurationServiceImplTest {
+
+    @Rule
+    public SlingContext context =
+            new SlingContextBuilder(ResourceResolverType.RESOURCERESOLVER_MOCK).plugin(CACONFIG).build();
+
+    private OsgiAIConfigurationPluginImpl osgiAIConfigurationPlugin = new OsgiAIConfigurationPluginImpl();
+    private SlingCaConfigPluginImpl slingCaConfigPlugin = new SlingCaConfigPluginImpl();
+    private OsgiAIConfiguration osgiCfg = Mockito.mock(OsgiAIConfiguration.class);
+
+    private Principal principal = Mockito.mock(Principal.class);
+    private UserManager userManager = Mockito.mock(UserManager.class);
+
+    private AIConfigurationServiceImpl service = new AIConfigurationServiceImpl() {{
+        this.plugins = List.of(slingCaConfigPlugin, osgiAIConfigurationPlugin);
+    }};
+
+    @Before
+    public void setup() {
+        context.registerAdapter(ResourceResolver.class, UserManager.class, userManager);
+        when(principal.getName()).thenReturn("theuser");
+
+        when(osgiCfg.services()).thenReturn(new String[]{"create"});
+        when(osgiCfg.allowedPaths()).thenReturn(new String[]{"/content/allowed/.*"});
+        when(osgiCfg.deniedPaths()).thenReturn(new String[]{"/content/allowed/denied/.*"});
+        when(osgiCfg.allowedUsers()).thenReturn(new String[]{"theuser"});
+        when(osgiCfg.allowedViews()).thenReturn(new String[]{".*"});
+        osgiAIConfigurationPlugin.activate(osgiCfg);
+    }
+
+    protected SlingHttpServletRequest getRequest() {
+        SlingHttpServletRequest wrapped = Mockito.spy(context.request());
+        doReturn(principal).when(wrapped).getUserPrincipal();
+        assertThat(wrapped.getUserPrincipal(), is(principal));
+        return wrapped;
+    }
+
+    @Test
+    public void testAllow() {
+        Set<String> allowed = service.allowedServices(getRequest(), "/content/allowed/path", "whatever");
+        assertThat(allowed.size(), is((1)));
+        assertThat(allowed, CoreMatchers.hasItem("create"));
+    }
+
+    @Test
+    public void testDeny() {
+        Set<String> allowed = service.allowedServices(getRequest(), "/content/allowed/denied/path", "whatever");
+        assertThat(allowed.size(), is((0)));
+
+        allowed = service.allowedServices(getRequest(), "/content/other/path", null);
+        assertThat(allowed.size(), is((0)));
+    }
+
+    @Test
+    public void testGetConfiguration() {
+        context.request().setResource(context.create().resource("/content/allowed/path"));
+        String key = "thekey";
+        // set up sling configuration for the path with key
+        context.create().resource("/conf/global/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig",
+                "openaikey", key);
+        GPTConfiguration config = service.getGPTConfiguration(getRequest(), "/content/allowed/path");
+        assertThat(config, notNullValue());
+        assertThat(config.getApiKey(), is(key));
+    }
+
+}

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/model/OpenAIConfigTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/model/OpenAIConfigTest.java
@@ -1,5 +1,14 @@
 package com.composum.ai.backend.slingbase.model;
 
+import static org.apache.sling.testing.mock.caconfig.ContextPlugins.CACONFIG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.caconfig.ConfigurationBuilder;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
@@ -7,16 +16,6 @@ import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.apache.sling.testing.mock.sling.junit.SlingContextBuilder;
 import org.junit.Rule;
 import org.junit.Test;
-
-import static org.apache.sling.testing.mock.caconfig.ContextPlugins.CACONFIG;
-
-import static org.junit.Assert.assertEquals;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertTrue;
 
 public class OpenAIConfigTest {
 
@@ -27,27 +26,41 @@ public class OpenAIConfigTest {
     @Test
     public void testOpenAIConfig() {
         context.create().resource("/conf/test/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig",
-                "openaikey", "test-api-key");
+                "openAiApiKey", "test-api-key");
         context.create().resource("/content/test", "sling:configRef", "/conf/test");
 
         Resource resource = context.resourceResolver().getResource("/content/test");
         ConfigurationBuilder configurationBuilder = resource.adaptTo(ConfigurationBuilder.class);
         OpenAIConfig config = configurationBuilder.as(OpenAIConfig.class);
 
-        assertEquals("test-api-key", config.openaikey());
+        assertEquals("test-api-key", config.openAiApiKey());
+    }
+
+    @Test
+    public void testOpenAIConfigDirectDoesNotWork() {
+        // not supported by Sling CA Config :-/
+        context.create().resource("/content/test/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig",
+                "openAiApiKey", "test-api-key");
+
+        Resource resource = context.resourceResolver().getResource("/content/test");
+        ConfigurationBuilder configurationBuilder = resource.adaptTo(ConfigurationBuilder.class);
+        OpenAIConfig config = configurationBuilder.as(OpenAIConfig.class);
+
+        assertNull(config.openAiApiKey());
     }
 
     @Test
     public void testGlobalFallback() {
         context.create().resource("/conf/global/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig",
-                "openaikey", "test-api-key-global");
-        context.create().resource("/content/test", "sling:configRef", "/conf/test");
+                "openAiApiKey", "test-api-key-global");
+        // context.create().resource("/content/test", "sling:configRef", "/conf/test");
+        context.create().resource("/content/test");
 
         Resource resource = context.resourceResolver().getResource("/content/test");
         ConfigurationBuilder configurationBuilder = resource.adaptTo(ConfigurationBuilder.class);
         OpenAIConfig config = configurationBuilder.as(OpenAIConfig.class);
 
-        assertEquals("test-api-key-global", config.openaikey());
+        assertEquals("test-api-key-global", config.openAiApiKey());
     }
 
     /**
@@ -56,16 +69,16 @@ public class OpenAIConfigTest {
     @Test
     public void testOpenAIConfigAsCollection() {
         context.create().resource("/conf/test/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig/test1",
-                "openaikey", "test-api-key-1");
+                "openAiApiKey", "test-api-key-1");
         context.create().resource("/conf/test/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig/test2",
-                "openaikey", "test-api-key-2");
+                "openAiApiKey", "test-api-key-2");
         context.create().resource("/content/test", "sling:configRef", "/conf/test");
 
         Resource resource = context.resourceResolver().getResource("/content/test");
         ConfigurationBuilder configurationBuilder = resource.adaptTo(ConfigurationBuilder.class);
         Collection<OpenAIConfig> configs = configurationBuilder.asCollection(OpenAIConfig.class);
 
-        List<String> apiKeys = configs.stream().map(OpenAIConfig::openaikey).collect(Collectors.toList());
+        List<String> apiKeys = configs.stream().map(OpenAIConfig::openAiApiKey).collect(Collectors.toList());
         assertTrue(apiKeys.contains("test-api-key-1"));
         assertTrue(apiKeys.contains("test-api-key-2"));
     }

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/model/OpenAIConfigTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/model/OpenAIConfigTest.java
@@ -13,6 +13,10 @@ import static org.apache.sling.testing.mock.caconfig.ContextPlugins.CACONFIG;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
 
 public class OpenAIConfigTest {
 
@@ -44,6 +48,26 @@ public class OpenAIConfigTest {
         OpenAIConfig config = configurationBuilder.as(OpenAIConfig.class);
 
         assertEquals("test-api-key-global", config.openaikey());
+    }
+
+    /**
+     * Just a demonstration how collections work; not actually used so far.
+     */
+    @Test
+    public void testOpenAIConfigAsCollection() {
+        context.create().resource("/conf/test/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig/test1",
+                "openaikey", "test-api-key-1");
+        context.create().resource("/conf/test/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig/test2",
+                "openaikey", "test-api-key-2");
+        context.create().resource("/content/test", "sling:configRef", "/conf/test");
+
+        Resource resource = context.resourceResolver().getResource("/content/test");
+        ConfigurationBuilder configurationBuilder = resource.adaptTo(ConfigurationBuilder.class);
+        Collection<OpenAIConfig> configs = configurationBuilder.asCollection(OpenAIConfig.class);
+
+        List<String> apiKeys = configs.stream().map(OpenAIConfig::openaikey).collect(Collectors.toList());
+        assertTrue(apiKeys.contains("test-api-key-1"));
+        assertTrue(apiKeys.contains("test-api-key-2"));
     }
 
 }

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/model/OpenAIConfigTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/model/OpenAIConfigTest.java
@@ -31,11 +31,6 @@ public class OpenAIConfigTest {
         OpenAIConfig config = configurationBuilder.as(OpenAIConfig.class);
 
         assertEquals("test-api-key", config.openaikey());
-
-        Collection<OpenAIConfig> configs = configurationBuilder.asCollection(OpenAIConfig.class);
-        // HUH???? Why is this empty? Let's see whether that happens also in the server.
-        assertEquals(0, configs.size());
-        // assertEquals("test-api-key-global", configs.iterator().next().openaikey());
     }
 
     @Test
@@ -49,10 +44,6 @@ public class OpenAIConfigTest {
         OpenAIConfig config = configurationBuilder.as(OpenAIConfig.class);
 
         assertEquals("test-api-key-global", config.openaikey());
-
-        Collection<OpenAIConfig> configs = configurationBuilder.asCollection(OpenAIConfig.class);
-        assertEquals(0, configs.size()); // HUH???
-        // assertEquals("test-api-key-global", configs.iterator().next().openaikey());
     }
 
 }

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/model/OpenAIConfigTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/model/OpenAIConfigTest.java
@@ -1,0 +1,58 @@
+package com.composum.ai.backend.slingbase.model;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.caconfig.ConfigurationBuilder;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.junit.SlingContextBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.apache.sling.testing.mock.caconfig.ContextPlugins.CACONFIG;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+
+public class OpenAIConfigTest {
+
+    @Rule
+    public SlingContext context =
+            new SlingContextBuilder(ResourceResolverType.RESOURCERESOLVER_MOCK).plugin(CACONFIG).build();
+
+    @Test
+    public void testOpenAIConfig() {
+        context.create().resource("/conf/test/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig",
+                "openaikey", "test-api-key");
+        context.create().resource("/content/test", "sling:configRef", "/conf/test");
+
+        Resource resource = context.resourceResolver().getResource("/content/test");
+        ConfigurationBuilder configurationBuilder = resource.adaptTo(ConfigurationBuilder.class);
+        OpenAIConfig config = configurationBuilder.as(OpenAIConfig.class);
+
+        assertEquals("test-api-key", config.openaikey());
+
+        Collection<OpenAIConfig> configs = configurationBuilder.asCollection(OpenAIConfig.class);
+        // HUH???? Why is this empty? Let's see whether that happens also in the server.
+        assertEquals(0, configs.size());
+        // assertEquals("test-api-key-global", configs.iterator().next().openaikey());
+    }
+
+    @Test
+    public void testGlobalFallback() {
+        context.create().resource("/conf/global/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig",
+                "openaikey", "test-api-key-global");
+        context.create().resource("/content/test", "sling:configRef", "/conf/test");
+
+        Resource resource = context.resourceResolver().getResource("/content/test");
+        ConfigurationBuilder configurationBuilder = resource.adaptTo(ConfigurationBuilder.class);
+        OpenAIConfig config = configurationBuilder.as(OpenAIConfig.class);
+
+        assertEquals("test-api-key-global", config.openaikey());
+
+        Collection<OpenAIConfig> configs = configurationBuilder.asCollection(OpenAIConfig.class);
+        assertEquals(0, configs.size()); // HUH???
+        // assertEquals("test-api-key-global", configs.iterator().next().openaikey());
+    }
+
+}

--- a/backend/slingbase/src/test/resources/simplelogger.properties
+++ b/backend/slingbase/src/test/resources/simplelogger.properties
@@ -1,0 +1,3 @@
+org.slf4j.simpleLogger.defaultLogLevel=debug
+org.slf4j.simpleLogger.showShortLogName=true
+org.slf4j.simpleLogger.log.com.composum.sling.core.AbstractSlingBean=warn

--- a/composum/bundle/src/main/java/com/composum/ai/composum/bundle/AIServlet.java
+++ b/composum/bundle/src/main/java/com/composum/ai/composum/bundle/AIServlet.java
@@ -43,7 +43,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.composum.ai.backend.base.service.GPTException;
-import com.composum.ai.backend.base.service.chat.GPTChatCompletionService;
 import com.composum.ai.backend.base.service.chat.GPTChatMessage;
 import com.composum.ai.backend.base.service.chat.GPTChatRequest;
 import com.composum.ai.backend.base.service.chat.GPTConfiguration;
@@ -172,9 +171,9 @@ public class AIServlet extends AbstractServiceServlet {
     public static final String RESULTKEY_STREAMID = "streamid";
 
     /**
-     * Parameter for the path of the page, for determining the configuration.
+     * Parameter containing the path of the page, for determining the configuration.
      */
-    public static final String PARAMETER_PAGEPATH = "pagePath";
+    public static final String PARAMETER_CONFIGBASEPATH = "configBasePath";
 
     /**
      * Session contains a map at this key that maps the streamids to the streaming handle.
@@ -275,8 +274,8 @@ public class AIServlet extends AbstractServiceServlet {
         @Override
         public final void doIt(@Nonnull SlingHttpServletRequest request, @Nonnull SlingHttpServletResponse response, @Nullable ResourceHandle resource) throws RepositoryException, IOException, ServletException {
             Status status = new Status(request, response, LOG);
-            String pagePath = status.getRequiredParameter(PARAMETER_PAGEPATH, null, "No pagePath given");
-            GPTConfiguration config = configurationService.getGPTConfiguration(request, pagePath);
+            String configBasePath = request.getParameter(PARAMETER_CONFIGBASEPATH);
+            GPTConfiguration config = configurationService.getGPTConfiguration(request, configBasePath);
 
             try {
                 performOperation(status, request, response, config);

--- a/composum/bundle/src/main/java/com/composum/ai/composum/bundle/model/CategorizeDialogModel.java
+++ b/composum/bundle/src/main/java/com/composum/ai/composum/bundle/model/CategorizeDialogModel.java
@@ -71,6 +71,6 @@ public class CategorizeDialogModel extends AbstractModel {
         Resource pageResource = getContainingPage().getResource();
         String markdown = markdownService.approximateMarkdown(ResourceHandle.use(pageResource).getContentResource(), getContext().getRequest(), getContext().getResponse());
         GPTContentCreationService contentCreationService = Objects.requireNonNull(context.getService(GPTContentCreationService.class));
-        return contentCreationService.generateKeywords(markdown);
+        return contentCreationService.generateKeywords(markdown, null);
     }
 }

--- a/composum/bundle/src/main/java/com/composum/ai/composum/bundle/model/LabelExtensionModel.java
+++ b/composum/bundle/src/main/java/com/composum/ai/composum/bundle/model/LabelExtensionModel.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.composum.ai.backend.base.service.chat.GPTChatCompletionService;
+import com.composum.ai.backend.base.service.chat.GPTConfiguration;
 import com.composum.ai.backend.slingbase.AIConfigurationService;
 import com.composum.ai.backend.slingbase.AIConfigurationServlet;
 import com.composum.pages.commons.model.AbstractModel;
@@ -70,7 +71,8 @@ public class LabelExtensionModel extends AbstractModel {
             widget = context.getAttribute(EditWidgetTag.WIDGET_VAR, EditWidgetTag.class);
             chatCompletionService = context.getService(GPTChatCompletionService.class);
             aiConfigurationService = context.getService(AIConfigurationService.class);
-            if (widget.getModel() instanceof Model && chatCompletionService != null && chatCompletionService.isEnabled()) {
+            GPTConfiguration gptConfig = aiConfigurationService != null ? aiConfigurationService.getGPTConfiguration(context.getRequest(), getPath()) : null;
+            if (widget.getModel() instanceof Model && chatCompletionService != null && chatCompletionService.isEnabled(gptConfig)) {
                 model = (Model) widget.getModel();
                 valid = true;
             }

--- a/featurespecs/6Configuration.md
+++ b/featurespecs/6Configuration.md
@@ -32,3 +32,8 @@ configuration auditing, configuration validation.
 We will discuss the structure of storing the configuration in the JCR and the model classes for that.
 
 ### Configuration in the JCR, using sling context aware configuration
+
+## References
+
+- [Sling Context Aware Configuration](https://sling.apache.org/documentation/bundles/context-aware-configuration/context-aware-configuration.html)
+- [Secrets in the AEMaaCS cloud](https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/deploying/configuring-osgi.html?lang=en)

--- a/featurespecs/6Configuration.md
+++ b/featurespecs/6Configuration.md
@@ -1,5 +1,7 @@
 # Configuration of Composum AI
 
+Status: partially specified and implemented - only the API key
+
 ## Basic idea
 
 We need a way to configure the application for several points:
@@ -29,9 +31,43 @@ configuration auditing, configuration validation.
 
 ## Implementation details
 
-We will discuss the structure of storing the configuration in the JCR and the model classes for that.
-
 ### Configuration in the JCR, using sling context aware configuration
+
+package com.composum.ai.backend.slingbase.model;
+
+import org.apache.sling.caconfig.annotation.Configuration;
+import org.apache.sling.caconfig.annotation.Property;
+
+@Configuration(label = "Composum AI OpenAI Configuration", description = "Configurations for the OpenAI backend for
+Composum AI")
+// is also added to Sling-ContextAware-Configuration-Classes bnd header in pom.xml
+public @interface OpenAIConfig {
+
+    @Property(label = "OpenAI API Key", description = "OpenAI API Key from https://platform.openai.com/. If not given, this falls back to the OSGI configuration, the environment Variable OPENAI_API_KEY, and the system property openai.api.key .")
+    String openAiApiKey();
+
+}
+
+We have a fallback hierarchy for the OpenAI API key:
+
+- Sling Context Aware Configuration
+- OSGI configuration at "Composum AI GPT Chat Completion Service" - this is configured by default for AEMaaCS
+  as $[secret:OPENAI_API_KEY] to retrieve a value configurable in the cloud manager
+- Environment variable OPENAI_API_KEY
+
+For the sling context aware configuration, we have a configuration
+com.composum.ai.backend.slingbase.model.OpenAIConfig with the property openAiApiKey . Thus, set up configuration of
+the API key in the JCR repository has the following possibilities:
+
+- to enable it globally (even if you do not normally use Sling Context Aware Configuration), you could set up a
+  configuration node at
+  /conf/global/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig
+  with the property openAiApiKey set to the OpenAI API key. Caution: this requires read permissions for the users.
+- to enable it for a site or page tree that already has a sling:configRef set up (searchable with query
+  /content//*[@sling:configRef]) you could set up a configuration node
+  com.composum.ai.backend.slingbase.model.OpenAIConfig in
+  the corresponding /conf/.../sling:configs node.
+- otherwise you'd have to set up Sling Context Aware Configuration for the page tree in question.
 
 ## References
 

--- a/featurespecs/6Configuration.md
+++ b/featurespecs/6Configuration.md
@@ -1,0 +1,34 @@
+# Configuration of Composum AI
+
+## Basic idea
+
+We need a way to configure the application for several points:
+
+- the API key for OpenAI
+- the rate limiting
+- the prompt library
+
+There should be a basic configuration in the OSGI (or a default contained in the application itself, if applicable),
+but all these configurations can be site-specific, or even user-specific. So it's more appropriate to have a
+configuration in the JCR repository that is inherited from parent pages and takes precedence over OSGI configuration
+if present.
+
+As a first step, we will only implement the API key configuration.
+
+## Basic implementation decisions
+
+We will use Sling Context Aware Configuration for that. There will be @interface configuration classes for that using
+@Configuration . There will be separate configuration classes for the API key, the rate limiting and the prompt library.
+
+## Not in scope
+
+As a first step, we currently will not implement configuring the rate limiting and the prompt library. The aim of the
+design in this document is, however, to make it easy to add these later, without changing the basic design.
+We currently do not implement user specific configuration, version control, environment-based configuration,
+configuration auditing, configuration validation.
+
+## Implementation details
+
+We will discuss the structure of storing the configuration in the JCR and the model classes for that.
+
+### Configuration in the JCR, using sling context aware configuration


### PR DESCRIPTION
This sets up lookup for the OpenAI API Key via Sling Context Aware Configuration, and adds a configuration so that it can set up in AEMaaCS as cloud secret.

We have now a fallback hierarchy for the OpenAI API key:

- Sling Context Aware Configuration
- OSGI configuration at "Composum AI GPT Chat Completion Service" - this is configured by default for AEMaaCS
  as $[secret:OPENAI_API_KEY] to retrieve a value configurable in the cloud manager
- Environment variable OPENAI_API_KEY

For the sling context aware configuration, we have a configuration
com.composum.ai.backend.slingbase.model.OpenAIConfig with the property openAiApiKey . Thus, set up configuration of
the API key in the JCR repository has the following possibilities:

- to enable it globally (even if you do not normally use Sling Context Aware Configuration), you could set up a
  configuration node at
  /conf/global/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig
  with the property openAiApiKey set to the OpenAI API key. Caution: this requires read permissions for the users.
- to enable it for a site or page tree that already has a sling:configRef set up (searchable with query
  /content//*[@sling:configRef]) you could set up a configuration node
  com.composum.ai.backend.slingbase.model.OpenAIConfig in
  the corresponding /conf/.../sling:configs node.
- otherwise you'd have to set up Sling Context Aware Configuration for the page tree in question.
