### PR TITLE
Port down to AEM 6.5.x

### DIFF
--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/_cq_dialog/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/_cq_dialog/.content.xml
@@ -20,6 +20,7 @@
                 <items jcr:primaryType="nt:unstructured">
                     <container
                             jcr:primaryType="nt:unstructured"
+                            granite:class="composum-ai-prompt-column"
                             sling:resourceType="granite/ui/components/coral/foundation/container">
                         <items jcr:primaryType="nt:unstructured">
                             <promptFieldset
@@ -52,6 +53,7 @@
                     </container>
                     <container2
                             jcr:primaryType="nt:unstructured"
+                            granite:class="composum-ai-source-column"
                             sling:resourceType="granite/ui/components/coral/foundation/container">
                         <items jcr:primaryType="nt:unstructured">
                             <sourceFieldset

--- a/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
+++ b/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
@@ -73,6 +73,9 @@ class ContentCreationDialog {
         this.$dialog.find('form').addClass('_coral-Dialog--fullscreenTakeover');
         this.$dialog.find('coral-dialog-footer').children().appendTo(this.$dialog.find('coral-dialog-header div.cq-dialog-actions'));
         this.$dialog.find('.composum-ai-prompt-columns .u-coral-padding').removeClass('u-coral-padding');
+        // AEM 6.5.7
+        $('coral-dialog#composumAI-create-dialog').removeAttr('moveable').attr('fullscreen', 'fullscreen')
+            .addClass('coral3-Dialog--fullscreen');
     }
 
     removeFormAction() {

--- a/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
+++ b/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
@@ -291,6 +291,8 @@ try {
                 clickevent.stopPropagation();
                 const oldContent = rteinstance.getContent();
                 rteinstance.suspend();
+                const backdropOpen = $('.cq-dialog-backdrop').hasClass('is-open');
+
                 showCreateDialog({
                     componentPath,
                     property: propertyName,
@@ -304,7 +306,9 @@ try {
                         rteinstance.reactivate();
                         rteinstance.setContent(oldContent);
                         rteinstance.focus();
-                        $('.cq-dialog-backdrop').removeClass('is-open').hide();
+                        if (!backdropOpen) { // only hide if we weren't called from a dialog but an inline editor:
+                            $('.cq-dialog-backdrop').removeClass('is-open').hide();
+                        }
                     }
                 });
             });

--- a/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
+++ b/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
@@ -108,11 +108,10 @@ try {
         }
 
         const fieldlabeliconHTML =
-            '<coral-icon class="coral-Form-fieldinfo _coral-Icon _coral-Icon--sizeS composum-ai-create-dialog-action" title="AI Content Creation" icon="gearsEdit" role="img" size="S">\n' +
-            '  <svg focusable="false" aria-hidden="true" class="_coral-Icon--svg _coral-Icon">\n' +
-            '    <use xlink:href="#spectrum-icon-18-GearsEdit"></use>\n' +
-            '  </svg>\n' +
-            '</coral-icon>';
+            '<coral-icon ' +
+            '   class="coral-Form-fieldinfo coral3-Icon coral3-Icon--gearsEdit coral3-Icon--sizeS composum-ai-create-dialog-action" ' +
+            '   title="AI Content Creation" icon="gearsEdit" alt="description" size="S" autoarialabel="on" role="img" ' +
+            '   aria-label="AI Content Creation"></coral-icon>';
 
         /**
          * Inserts the AI content creation buttons for text areas in the provided element.

--- a/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
+++ b/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
@@ -28,6 +28,8 @@ try {
         var debug = true;
 
         channel.on('cq-sidepanel-loaded', (event) => Coral.commons.ready(event.target, loadSidebarPanelDialog));
+        // for AEM 6.5.7 we, strangely, don't get the cq-sidepanel-loaded event. Try something else.
+        channel.on('cq-layer-activated', (event) => Coral.commons.ready(event.target, loadSidebarPanelDialog));
 
         /**
          * Loads the Sidebar Panel AI if it wasn't loaded already and if there's a sidebar present.

--- a/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
+++ b/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
@@ -206,16 +206,12 @@ try {
             }
         }
 
-        const rtebuttonHTML = '<button is="coral-button" variant="quietaction" class="rte-toolbar-item _coral-ActionButton composum-ai-create-dialog-action" type="button"\n' +
+        const rtebuttonHTML = '<button is="coral-button" variant="quiet" class="rte-toolbar-item _coral-ActionButton composum-ai-create-dialog-action coral3-Button--quiet" type="button"\n' +
             '        title="AI Content Creation" icon="gearsEdit" size="S">\n' +
             '    <coral-icon size="S"\n' +
-            '                class="_coral-Icon--sizeS _coral-Icon" role="img" icon="gearsEdit" alt="AI Content Creation"\n' +
+            '                class="_coral-Icon--sizeS _coral-Icon coral3-Icon--gearsEdit" role="img" icon="gearsEdit" alt="AI Content Creation"\n' +
             '                aria-label="AI Content Creation">\n' +
-            '        <svg focusable="false" aria-hidden="true" class="_coral-Icon--svg _coral-Icon">\n' +
-            '            <use xlink:href="#spectrum-icon-18-GearsEdit"></use>\n' +
-            '        </svg>\n' +
             '    </coral-icon>\n' +
-            '    <coral-button-label class="_coral-ActionButton-label"></coral-button-label>\n' +
             '</button>\n';
 
         /** editing-start event is received for an richtext editor - we have to register the button. */

--- a/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
+++ b/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
@@ -303,12 +303,12 @@ try {
                     isRichtext: true,
                     stackeddialog: true,
                     onFinishCallback: function () {
-                        rteinstance.reactivate();
-                        rteinstance.setContent(oldContent);
-                        rteinstance.focus();
                         if (!backdropOpen) { // only hide if we weren't called from a dialog but an inline editor:
                             $('.cq-dialog-backdrop').removeClass('is-open').hide();
                         }
+                        rteinstance.reactivate();
+                        rteinstance.setContent(oldContent);
+                        rteinstance.focus();
                     }
                 });
             });

--- a/aem/ui.frontend/src/main/webpack/site/styles/composum-ai.scss
+++ b/aem/ui.frontend/src/main/webpack/site/styles/composum-ai.scss
@@ -2,7 +2,7 @@
 //== we make that horribly specific to override the default coral style there
 
 .coral-Form--vertical .coral-Form-fieldwrapper .coral-Form-fieldinfo.composum-ai-iconshiftleft {
-    right: 18px;
+    right: 22px;
 }
 
 #composumAI-sidebar-panel .composum-ai-response {
@@ -11,13 +11,15 @@
 
 .composum-ai-dialog .composum-ai-prompt-columns {
 
+    display: flex; // AEM 6.5.7
+
     .coral-FixedColumn-column {
         width: auto;
         flex: 1;
     }
 
     .coral-Form-fieldset .coral-Form-fieldset-legend {
-        margin-top: 0;
+        margin-top: 0; // FIXME has to be switched off for AEM 6.5.7
     }
 
     .coral-Form-fieldset {

--- a/aem/ui.frontend/src/main/webpack/site/styles/composum-ai.scss
+++ b/aem/ui.frontend/src/main/webpack/site/styles/composum-ai.scss
@@ -19,7 +19,7 @@
     }
 
     .coral-Form-fieldset .coral-Form-fieldset-legend {
-        margin-top: 0; // FIXME has to be switched off for AEM 6.5.7
+        margin-top: 0.5rem;
     }
 
     .coral-Form-fieldset {
@@ -28,9 +28,8 @@
 
 }
 
-.cq-Dialog:not([fullscreen]) .composum-ai-dialog .composum-ai-prompt-columns {
+.cq-Dialog .composum-ai-dialog .composum-ai-prompt-columns {
     .cq-RichText-editable {
-        height: 11.5rem;
+        height: 9.3rem; // AEM 6.5.7 appropriate default. AEMaaCS - 11.5rem ; we rather align via javascript
     }
-
 }

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/SlingCaConfigPluginImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/SlingCaConfigPluginImpl.java
@@ -78,6 +78,7 @@ public class SlingCaConfigPluginImpl implements AIConfigurationPlugin {
     private static Resource determineResource(@Nonnull SlingHttpServletRequest request, @Nonnull String contentPath) {
         Resource resource = request.getResource();
         if (StringUtils.isNotBlank(contentPath)) {
+            contentPath = contentPath.replace("_jcr_content", "jcr:content");
             resource = request.getResourceResolver().getResource(contentPath);
         }
         if (resource == null) {


### PR DESCRIPTION
That solves most of https://github.com/ist-dresden/composum-AI/issues/31 .
Mostly layout fixes were needed. There was a seriously weird problem that the tab blocked in Chrome at 100% on every content request in AEM 6.5.x (I assume in JQuery) - I tracked that down to the content creation request being HTTP 202 with a Location header and changed that mechanism to return the stream ID for the continuation in a JSON response.

It still works only with Java 11, though, since we use the asynchronous featores of java.net.http and the HttpClient 4 available on AEM 6.5.x does not have asynchronous features.