### PR TITLE
add external URL as source for content creation dialog

### DIFF
--- a/NextSteps.md
+++ b/NextSteps.md
@@ -1,23 +1,13 @@
 # Next steps in the implementation
 
-- AEM announcement and installation and usage description
-- Update Pages content creation dialog with separate content field like AEM
-- Check where it should appear and where not - extend tag.
-    - Autor, key Felder
-- API key in site configuration? Tenant configuration?
-- (Explain: why isn't it there in edit styles)
-  
 - ??? Konfiguration f. Seiten?
 - ??? Input prompt nicht ersetzen? Predefined
-- Bug: for new component the history key is wrong in the create dialog
 
 ## Small bugs
 
-- Stacked Modals: scroll des untersten?
-- Bug, please report: no widget found for /content/ist/composum/home/pages/setup/jcr:
+- ??? Stacked Modals: scroll des untersten?
+- ??? Bug, please report: no widget found for /content/ist/composum/home/pages/setup/jcr:
   content/main/row/column-0/section/codeblock/code
-- Reset history button for create dialog
-- Reset in create dialog should clear response, too
 
 ## In evaluation
 
@@ -43,6 +33,8 @@
 - (Extend content creation assistent with selection as input. (Not possible on page, but there.) -> could also
   replace the selection / insert created text at point. Alternative: explicit input. Isn't really necessary, since
   user can just incorporate that into the prompt, or put it into the content suggestion field and iterate over that.)
+- Check where it should appear in Pages and where not - extend tag.
+  - Autor, key Felder
 
 # Archive
 
@@ -81,3 +73,6 @@
 - DONE Somehow implement streaming to make result more responsive.
 - DONE: Update AEM dialog with history
 - DONE: AEM 6.5 version
+- DONE: API key in site configuration? Tenant configuration?
+- DONE: AEM announcement and installation and usage description
+- DONE: Update Pages content creation dialog with separate content field like AEM

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/_cq_dialog/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/_cq_dialog/.content.xml
@@ -72,6 +72,13 @@
                                                 sling:resourceType="cq/gui/components/common/wcm/datasources/childresources"
                                                 path="/conf/composum-ai/settings/dialogs/contentcreation/contentselectors"/>
                                     </contentSelector>
+                                    <url
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                            fieldLabel="URL for source text"
+                                            fieldDescription="Enter an URL from which to grab the source text."
+                                            granite:class="composum-ai-url-field"
+                                            name="./sourceurl"/>
                                     <sourcePlaintext
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/textarea"

--- a/aem/ui.content/src/main/content/jcr_root/conf/composum-ai/settings/dialogs/contentcreation/contentselectors/.content.xml
+++ b/aem/ui.content/src/main/content/jcr_root/conf/composum-ai/settings/dialogs/contentcreation/contentselectors/.content.xml
@@ -13,6 +13,9 @@
     <lastoutput jcr:primaryType="nt:unstructured" sling:resourceType="nt:unstructured"
         text="Current suggestion shown in this dialog (for iterative improvement)"
         value="lastoutput"></lastoutput>
+    <url jcr:primaryType="nt:unstructured" sling:resourceType="nt:unstructured"
+         text="Text content of an external URL"
+         value="url"></url>
     <empty jcr:primaryType="nt:unstructured" sling:resourceType="nt:unstructured"
         text="No additional content"
            value="empty"></empty>

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/ApproximateMarkdownServlet.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/ApproximateMarkdownServlet.java
@@ -67,10 +67,12 @@ public class ApproximateMarkdownServlet extends SlingSafeMethodsServlet {
         String path = info.getSuffix();
         String url = request.getParameter(PARAM_URL);
         boolean richtext = "html".equalsIgnoreCase(info.getExtension()) || "htm".equalsIgnoreCase(info.getExtension());
+
         if (StringUtils.isBlank(path) && StringUtils.isNotBlank(url)) {
-            getUrl(url, richtext, response);
+            getUrl(url, richtext, request, response);
             return;
         }
+
         Resource resource = request.getResourceResolver().getResource(path);
         if (richtext) {
             response.setContentType("text/html");
@@ -85,7 +87,8 @@ public class ApproximateMarkdownServlet extends SlingSafeMethodsServlet {
         }
     }
 
-    protected void getUrl(String urlString, boolean richtext, SlingHttpServletResponse response) throws IOException {
+    protected void getUrl(String urlString, boolean richtext, @Nonnull SlingHttpServletRequest request,
+                          @Nonnull SlingHttpServletResponse response) throws IOException {
         InputStream in = null;
         try {
             if (!StringUtils.startsWith(urlString, "http")) {
@@ -112,14 +115,17 @@ public class ApproximateMarkdownServlet extends SlingSafeMethodsServlet {
                 // no idea what to do if richtext is wanted. Quote it somehow?
             } else {
                 response.setContentType("text/plain");
-                response.getWriter().println("Unknown content type: " + conn.getContentType());
+                String msg = request.getResourceBundle(request.getLocale()).getString("Unknown content type: ");
+                response.getWriter().println(msg + conn.getContentType());
             }
         } catch (MalformedURLException e) {
             response.setContentType("text/plain");
-            response.getWriter().println("Invalid URL: " + urlString);
+            String msg = request.getResourceBundle(request.getLocale()).getString("Invalid URL: ");
+            response.getWriter().println(msg + urlString);
         } catch (IOException e) {
             response.setContentType("text/plain");
-            response.getWriter().println("Problem reading URL: " + e.toString());
+            String msg = request.getResourceBundle(request.getLocale()).getString("Problem reading URL: ");
+            response.getWriter().println(msg + e.toString());
         } finally {
             if (in != null) {
                 in.close();

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/ApproximateMarkdownServlet.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/ApproximateMarkdownServlet.java
@@ -1,13 +1,19 @@
 package com.composum.ai.backend.slingbase;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
 
 import javax.annotation.Nonnull;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.StringBuilderWriter;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestPathInfo;
@@ -39,10 +45,15 @@ import com.composum.ai.backend.base.service.chat.GPTChatCompletionService;
         })
 // curl -u admin:admin http://localhost:9090/bin/cpm/ai/approximated.md/content/ist/composum/home/platform/_jcr_content
 // http://localhost:4502/bin/cpm/ai/approximated.md/content/wknd/us/en/magazine/_jcr_content
+// http://localhost:9090/bin/cpm/ai/approximated.md?fromurl=https://www.composum.com/home.html
 public class ApproximateMarkdownServlet extends SlingSafeMethodsServlet {
 
     protected static final Logger LOG = LoggerFactory.getLogger(ApproximateMarkdownServlet.class);
 
+    /**
+     * If this is given with an URL instead of a suffix, we retrieve the HTML from the given source.
+     */
+    public static final String PARAM_URL = "fromurl";
 
     @Reference
     ApproximateMarkdownService approximateMarkdownService;
@@ -54,7 +65,12 @@ public class ApproximateMarkdownServlet extends SlingSafeMethodsServlet {
     protected void doGet(@Nonnull SlingHttpServletRequest request, @Nonnull SlingHttpServletResponse response) throws ServletException, IOException {
         RequestPathInfo info = request.getRequestPathInfo();
         String path = info.getSuffix();
+        String url = request.getParameter(PARAM_URL);
         boolean richtext = "html".equalsIgnoreCase(info.getExtension()) || "htm".equalsIgnoreCase(info.getExtension());
+        if (StringUtils.isBlank(path) && StringUtils.isNotBlank(url)) {
+            getUrl(url, richtext, response);
+            return;
+        }
         Resource resource = request.getResourceResolver().getResource(path);
         if (richtext) {
             response.setContentType("text/html");
@@ -67,6 +83,49 @@ public class ApproximateMarkdownServlet extends SlingSafeMethodsServlet {
             response.setContentType("text/plain");
             approximateMarkdownService.approximateMarkdown(resource, response.getWriter(), request, response);
         }
+    }
+
+    protected void getUrl(String urlString, boolean richtext, SlingHttpServletResponse response) throws IOException {
+        InputStream in = null;
+        try {
+            if (!StringUtils.startsWith(urlString, "http")) {
+                urlString = "https://" + urlString;
+            }
+            URL url = new URL(urlString);
+            URLConnection conn = url.openConnection();
+            conn.setConnectTimeout(3000);
+            conn.setReadTimeout(3000);
+            in = conn.getInputStream();
+
+            if (conn.getContentType().contains("text/html")) {
+                String result = IOUtils.toString(in, response.getCharacterEncoding());
+                String markdown = chatService.htmlToMarkdown(result);
+                if (richtext) {
+                    // convert it back and forth since that massively simplifies the HTML
+                    response.getWriter().println(chatService.markdownToHtml(markdown));
+                } else {
+                    response.getWriter().println(markdown);
+                }
+            } else if (conn.getContentType().contains("text/plain")) {
+                String result = IOUtils.toString(in, response.getCharacterEncoding());
+                response.getWriter().println(result);
+                // no idea what to do if richtext is wanted. Quote it somehow?
+            } else {
+                response.setContentType("text/plain");
+                response.getWriter().println("Unknown content type: " + conn.getContentType());
+            }
+        } catch (MalformedURLException e) {
+            response.setContentType("text/plain");
+            response.getWriter().println("Invalid URL: " + urlString);
+        } catch (IOException e) {
+            response.setContentType("text/plain");
+            response.getWriter().println("Problem reading URL: " + e.toString());
+        } finally {
+            if (in != null) {
+                in.close();
+            }
+        }
+
     }
 
 }

--- a/composum/bundle/src/main/resources/create/contentselectors.json
+++ b/composum/bundle/src/main/resources/create/contentselectors.json
@@ -3,6 +3,7 @@
   "component": "The component you were editing, including subcomponents",
   "page": "Current page text",
   "lastoutput": "Current suggestion shown in this dialog (for iterative improvement)",
+  "url": "Text content of an external URL",
   "empty": "No text is added to your prompt",
   "-": "Manually entered source content"
 }

--- a/composum/package/src/main/content/jcr_root/libs/composum/pages/options/ai/dialogs/create/create.jsp
+++ b/composum/package/src/main/content/jcr_root/libs/composum/pages/options/ai/dialogs/create/create.jsp
@@ -77,7 +77,7 @@
                                         </select>
                                     </div>
 
-                                    <div class="form-group ai-url-container" style="display: none;"
+                                    <div class="form-group composum-ai-url-container" style="display: none;"
                                          title="${cpn:i18n(slingRequest,'Enter an URL from which to grab the source text.')}">
                                         <label for="contentSelector">
                                             <cpn:text
@@ -85,7 +85,7 @@
                                         </label>
 
                                         <input name="title" data-label="Subtitle"
-                                               class="form-control ai-url-field"
+                                               class="form-control composum-ai-url-field"
                                                maxlength="256" type="text" value="" placeholder="">
                                     </div>
 

--- a/composum/package/src/main/content/jcr_root/libs/composum/pages/options/ai/dialogs/create/create.jsp
+++ b/composum/package/src/main/content/jcr_root/libs/composum/pages/options/ai/dialogs/create/create.jsp
@@ -77,6 +77,18 @@
                                         </select>
                                     </div>
 
+                                    <div class="form-group ai-url-container" style="display: none;"
+                                         title="${cpn:i18n(slingRequest,'Enter an URL from which to grab the source text.')}">
+                                        <label for="contentSelector">
+                                            <cpn:text
+                                                    i18n="true">URL for source text</cpn:text>
+                                        </label>
+
+                                        <input name="title" data-label="Subtitle"
+                                               class="form-control ai-url-field"
+                                               maxlength="256" type="text" value="" placeholder="">
+                                    </div>
+
                                     <div class="form-group"
                                          title="${cpn:i18n(slingRequest,'The base text that is modified according to the prompt. Will be overwritten when the Content Selector is changed.')}">
                                         <label for="promptTextarea">

--- a/composum/package/src/main/content/jcr_root/libs/composum/pages/options/ai/js/create.js
+++ b/composum/package/src/main/content/jcr_root/libs/composum/pages/options/ai/js/create.js
@@ -66,6 +66,9 @@
                 this.$response = this.$el.find('.ai-response-field');
                 this.$sourceContent = this.$el.find('.ai-source-field');
 
+                this.$urlContainer = this.$el.find('.ai-url-container');
+                this.$urlField = this.$el.find('.ai-url-field');
+
                 this.setSourceContent(this.widget.getValue());
 
                 this.$el.find('.back-button').click(this.backButtonClicked.bind(this));
@@ -80,6 +83,7 @@
 
                 this.$contentSelect.change(this.contentSelectChanged.bind(this));
                 this.$sourceContent.change(this.sourceChanged.bind(this));
+                this.$urlField.change(this.urlChanged.bind(this));
 
                 this.$el.find('.replace-button').click(this.replaceButtonClicked.bind(this));
                 this.$el.find('.append-button').click(this.appendButtonClicked.bind(this));
@@ -201,6 +205,7 @@
                 event.preventDefault();
                 let contentSelect = this.$contentSelect.val();
                 const key = this.$contentSelect.val();
+                this.$urlContainer.hide();
                 switch (key) {
                     case 'lastoutput':
                         this.setSourceContent(this.getResponse());
@@ -217,6 +222,8 @@
                     case 'empty':
                         this.setSourceContent('');
                         break;
+                    case 'url':
+                        this.$urlContainer.show();
                     case '-':
                         this.setSourceContent('');
                         break;
@@ -260,6 +267,12 @@
                         this.showError(status + " " + error);
                     }
                 });
+            },
+
+            urlChanged(event) {
+                const url = this.$urlField.val();
+                // XXX cannot retrieve content directly because of CORS limitiations - we need to do that
+                // via the server.
             },
 
             resetHistoryButtonClicked: function (event) {


### PR DESCRIPTION
The content creation dialog got a new choice 'Text content of an external URL' which makes an URL field appear. If something is entered there the text content of the URL will be written into the source field (or an error message). The content is simplified to either markdown or a HTML representation of markdown.