### PR TITLE
Issue#23

### DIFF
--- a/aem/ui.frontend/src/main/webpack/site/styles/composum-ai.scss
+++ b/aem/ui.frontend/src/main/webpack/site/styles/composum-ai.scss
@@ -43,3 +43,7 @@
     background-position: center;
     background-repeat: no-repeat;
 }
+
+.betty-ActionBar {
+    min-height: 48px;
+}


### PR DESCRIPTION
Css fix: set a minimum height to the button container. This will make sure the buttons always have enough space in the layout and will never be squashed behind other elements or components.