### PR TITLE
Automatic translation on Rollout

### DIFF
--- a/aem/core/pom.xml
+++ b/aem/core/pom.xml
@@ -45,7 +45,8 @@
                             <bnd><![CDATA[
 Export-Package: com.composum.ai.aem.core.impl.autotranslate
 Import-Package: javax.annotation;version=0.0.0,*
-                                ]]></bnd>
+Sling-ContextAware-Configuration-Classes: com.composum.ai.aem.core.impl.autotranslate.rollout.AutoTranslateLiveActionConfig
+]]></bnd>
                         </configuration>
                     </execution>
                 </executions>

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapper.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapper.java
@@ -1,0 +1,179 @@
+package com.composum.ai.aem.core.impl.autotranslate;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.ValueMap;
+
+class AITranslatePropertyWrapper {
+
+    /**
+     * Saves the date when a resource was automatically translated.
+     * Find translated resources with /content//*[@ai_translated] .
+     */
+    public static final String PROPERTY_AI_TRANSLATED_DATE = "ai_translated";
+
+    /**
+     * Saves user who triggered the automatic translation of the resource.
+     */
+    public static final String PROPERTY_AI_TRANSLATED_BY = "ai_translatedBy";
+
+    /**
+     * Prefix for property names of saved values.
+     */
+    public static final String AI_PREFIX = "ai_";
+
+    /**
+     * Prefix for property names changed to language copies
+     */
+    public static final String LC_PREFIX = "lc_";
+
+    /**
+     * Suffix for the property name of a property that saves the original value of the property, to track when it
+     * has to be re-translated.
+     */
+    public static final String AI_ORIGINAL_SUFFIX = "_original";
+
+    /**
+     * Suffix for the property name of a property that saves the translated value of the property, to track whether
+     * it has been manually changed after automatic translation.
+     */
+    public static final String AI_TRANSLATED_SUFFIX = "_translated";
+
+    /**
+     * Suffix for a property name where a manual change is saved when a retranslation is done despite a manual modification.
+     * Will be overwritten if another retranslation is done. Also keep original and translated values - as additional suffix.
+     */
+    public static final String AI_MANUAL_CHANGE_SUFFIX = "_manualChange";
+
+    private final ModifiableValueMap targetValueMap;
+    private final String propertyName;
+    private final ValueMap sourceValueMap;
+
+    public AITranslatePropertyWrapper(ValueMap sourceValueMap, ModifiableValueMap targetValueMap, String propertyName) {
+        this.targetValueMap = targetValueMap;
+        this.propertyName = propertyName;
+        this.sourceValueMap = sourceValueMap;
+    }
+
+    public String getOriginal() {
+        return sourceValueMap.get(propertyName, String.class);
+    }
+
+    public String getCurrentValue() {
+        Object value = targetValueMap.get(propertyName);
+        return value instanceof String ? (String) value : null;
+    }
+
+    public void setCurrentValue(String value) {
+        setValue(propertyName, value);
+    }
+
+    public String getOriginalCopy() {
+        return targetValueMap.get(AutoPageTranslateServiceImpl.encodePropertyName(AI_PREFIX, propertyName, AI_ORIGINAL_SUFFIX), String.class);
+    }
+
+    public void setOriginalCopy(String value) {
+        setValue(AutoPageTranslateServiceImpl.encodePropertyName(AI_PREFIX, propertyName, AI_ORIGINAL_SUFFIX), value);
+    }
+
+    public String getTranslatedCopy() {
+        return targetValueMap.get(AutoPageTranslateServiceImpl.encodePropertyName(AI_PREFIX, propertyName, AI_TRANSLATED_SUFFIX), String.class);
+    }
+
+    public void setTranslatedCopy(String value) {
+        setValue(AutoPageTranslateServiceImpl.encodePropertyName(AI_PREFIX, propertyName, AI_TRANSLATED_SUFFIX), value);
+    }
+
+    private void setValue(String key, String value) {
+        if (value != null) {
+            targetValueMap.put(key, value);
+        } else {
+            targetValueMap.remove(key);
+        }
+    }
+
+    public String getLcOriginal() {
+        return targetValueMap.get(AutoPageTranslateServiceImpl.encodePropertyName(LC_PREFIX, propertyName, AI_ORIGINAL_SUFFIX), String.class);
+    }
+
+    public void setLcOriginal(String value) {
+        setValue(AutoPageTranslateServiceImpl.encodePropertyName(LC_PREFIX, propertyName, AI_ORIGINAL_SUFFIX), value);
+    }
+
+    public String getLcTranslated() {
+        return targetValueMap.get(AutoPageTranslateServiceImpl.encodePropertyName(LC_PREFIX, propertyName, AI_TRANSLATED_SUFFIX), String.class);
+    }
+
+    public void setLcTranslated(String value) {
+        setValue(AutoPageTranslateServiceImpl.encodePropertyName(LC_PREFIX, propertyName, AI_TRANSLATED_SUFFIX), value);
+    }
+
+    public void setAiTranslatedBy(String value) {
+        setValue(PROPERTY_AI_TRANSLATED_BY, value);
+    }
+
+    public void setAiTranslatedDate(Calendar value) {
+        setValue(PROPERTY_AI_TRANSLATED_DATE, value != null ? value.toInstant().toString() : null);
+    }
+
+    /**
+     * Currently not actually used, but save for differential retranslation.
+     */
+    public void saveManualChange() {
+        setValue(AutoPageTranslateServiceImpl.encodePropertyName(AI_PREFIX, propertyName, AI_MANUAL_CHANGE_SUFFIX), getCurrentValue());
+        setValue(AutoPageTranslateServiceImpl.encodePropertyName(AI_PREFIX, propertyName, AI_MANUAL_CHANGE_SUFFIX + AI_ORIGINAL_SUFFIX), getOriginalCopy());
+        setValue(AutoPageTranslateServiceImpl.encodePropertyName(AI_PREFIX, propertyName, AI_MANUAL_CHANGE_SUFFIX + AI_TRANSLATED_SUFFIX), getTranslatedCopy());
+    }
+
+    public boolean hasSavedTranslation() {
+        return isNotBlank(getOriginalCopy()) && isNotBlank(getTranslatedCopy());
+    }
+
+    public boolean isOriginalAsWhenLastTranslating() {
+        return StringUtils.equals(getOriginal(), getOriginalCopy());
+    }
+
+    public String[] allLcKeys() {
+        return new String[]{
+                AutoPageTranslateServiceImpl.encodePropertyName(LC_PREFIX, propertyName, AI_ORIGINAL_SUFFIX),
+                AutoPageTranslateServiceImpl.encodePropertyName(LC_PREFIX, propertyName, AI_TRANSLATED_SUFFIX)
+        };
+    }
+
+    public String[] allAiKeys() {
+        return new String[]{
+                AutoPageTranslateServiceImpl.encodePropertyName(AI_PREFIX, propertyName, AI_ORIGINAL_SUFFIX),
+                AutoPageTranslateServiceImpl.encodePropertyName(AI_PREFIX, propertyName, AI_TRANSLATED_SUFFIX),
+                AutoPageTranslateServiceImpl.encodePropertyName(AI_PREFIX, propertyName, AI_MANUAL_CHANGE_SUFFIX),
+                AutoPageTranslateServiceImpl.encodePropertyName(AI_PREFIX, propertyName, AI_MANUAL_CHANGE_SUFFIX + AI_ORIGINAL_SUFFIX),
+                AutoPageTranslateServiceImpl.encodePropertyName(AI_PREFIX, propertyName, AI_MANUAL_CHANGE_SUFFIX + AI_TRANSLATED_SUFFIX)
+        };
+    }
+
+    public String[] allGeneralKeys() {
+        return new String[]{propertyName, PROPERTY_AI_TRANSLATED_BY, PROPERTY_AI_TRANSLATED_DATE};
+    }
+
+    public String[] allKeys() {
+        List<String> keys = new ArrayList<>();
+        Arrays.stream(allLcKeys()).map(keys::add);
+        Arrays.stream(allAiKeys()).map(keys::add);
+        Arrays.stream(allGeneralKeys()).map(keys::add);
+        return keys.toArray(new String[0]);
+    }
+
+    /**
+     * Checks whether a property was created by us and must not be translated etc.
+     */
+    protected static boolean isAiTranslateProperty(String name) {
+        return name.startsWith(AI_PREFIX) || name.startsWith(LC_PREFIX);
+    }
+
+}

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapper.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapper.java
@@ -158,14 +158,14 @@ class AITranslatePropertyWrapper {
     }
 
     public String[] allGeneralKeys() {
-        return new String[]{propertyName, PROPERTY_AI_TRANSLATED_BY, PROPERTY_AI_TRANSLATED_DATE};
+        return new String[]{PROPERTY_AI_TRANSLATED_BY, PROPERTY_AI_TRANSLATED_DATE};
     }
 
     public String[] allKeys() {
         List<String> keys = new ArrayList<>();
-        Arrays.stream(allLcKeys()).map(keys::add);
-        Arrays.stream(allAiKeys()).map(keys::add);
-        Arrays.stream(allGeneralKeys()).map(keys::add);
+        keys.addAll(Arrays.asList(allLcKeys()));
+        keys.addAll(Arrays.asList(allAiKeys()));
+        keys.addAll(Arrays.asList(allGeneralKeys()));
         return keys.toArray(new String[0]);
     }
 

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
@@ -339,7 +339,6 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
                         stats.modifiedButRetranslatedProperties++;
                     }
 
-                    stats.translatedProperties++;
                     if (targetWrapper.hasSavedTranslation()) {
                         stats.retranslatedProperties++;
                     }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
@@ -1,13 +1,16 @@
 package com.composum.ai.aem.core.impl.autotranslate;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -50,46 +53,6 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
     protected static final Logger LOG = LoggerFactory.getLogger(AutoPageTranslateServiceImpl.class);
 
     /**
-     * Saves the date when a resource was automatically translated.
-     * Find translated resources with /content//*[@ai_translated] .
-     */
-    public static final String PROPERTY_AI_TRANSLATED_DATE = "ai_translated";
-
-    /**
-     * Saves user who triggered the automatic translation of the resource.
-     */
-    public static final String PROPERTY_AI_TRANSLATED_BY = "ai_translatedBy";
-
-    /**
-     * Prefix for property names of saved values.
-     */
-    public static final String AI_PREFIX = "ai_";
-
-    /**
-     * Prefix for property names changed to language copies
-     */
-    public static final String LC_PREFIX = "lc_";
-
-    /**
-     * Suffix for the property name of a property that saves the original value of the property, to track when it
-     * has to be re-translated.
-     */
-    public static final String AI_ORIGINAL_SUFFIX = "_original";
-
-    /**
-     * Suffix for the property name of a property that saves the translated value of the property, to track whether
-     * it has been manually changed after automatic translation.
-     */
-    public static final String AI_TRANSLATED_SUFFIX = "_translated";
-
-    /**
-     * Suffix for a property name where a manual change is saved when a retranslation is done despite a manual modification.
-     * Will be overwritten if another retranslation is done.
-     */
-    public static final String AI_MANUAL_CHANGE_SUFFIX = "_manualChange";
-
-
-    /**
      * List of properties that should always be translated.
      */
     public static final List<String> CERTAINLY_TRANSLATABLE_PROPERTIES =
@@ -113,8 +76,7 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
         LOG.debug(">>> translateLiveCopy: {}", resource.getPath());
         Stats stats = new Stats();
         List<PropertyToTranslate> propertiesToTranslate = new ArrayList<>();
-        boolean changed = false;
-        collectPropertiesToTranslate(resource, propertiesToTranslate, stats, translationParameters);
+        boolean changed = collectPropertiesToTranslate(resource, propertiesToTranslate, stats, translationParameters);
 
         LOG.debug("Set of property names to translate in {} : {}", resource.getPath(),
                 propertiesToTranslate.stream()
@@ -134,32 +96,28 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
         translationService.fragmentedTranslation(valuesToTranslate, languageName, configuration);
 
         Map<String, LiveRelationship> relationships = new HashMap<>();
-        for (PropertyToTranslate propertyToTranslate : propertiesToTranslate) {
-            relationships.put(propertyToTranslate.targetResource.getPath(),
-                    liveRelationshipManager.getLiveRelationship(propertyToTranslate.targetResource, false));
-        }
 
         for (int i = 0; i < propertiesToTranslate.size(); i++) {
             PropertyToTranslate propertyToTranslate = propertiesToTranslate.get(i);
             String originalValue = valuesToTranslate.get(i);
             String translatedValue = translatedValues.get(i);
-//            if (StringUtils.equals(StringUtils.trim(originalValue), StringUtils.trim(translatedValue))) {
-//                LOG.trace("Translation of {} in {} is the same as the original, not setting it.",
-//                        propertyToTranslate.propertyName, propertyToTranslate.resource.getPath());
-//                continue; // not quite sure whether that's right - that could lead to multiple user alerts
-//            }
             String propertyName = propertyToTranslate.propertyName;
             Resource resourceToTranslate = propertyToTranslate.targetResource;
             LOG.trace("Setting {} in {} to {}", propertyName, propertyToTranslate.targetResource.getPath(), translatedValue);
             ModifiableValueMap valueMap = requireNonNull(resourceToTranslate.adaptTo(ModifiableValueMap.class));
-            String originalKey = encodePropertyName(AI_PREFIX, propertyName, AI_ORIGINAL_SUFFIX);
-            valueMap.put(originalKey, originalValue);
-            String translatedKey = encodePropertyName(AI_PREFIX, propertyName, AI_TRANSLATED_SUFFIX);
-            valueMap.put(translatedKey, translatedValue);
-            valueMap.put(propertyName, translatedValue);
+            AITranslatePropertyWrapper targetWrapper = new AITranslatePropertyWrapper(propertyToTranslate.sourceResource.getValueMap(), valueMap, propertyName);
+            targetWrapper.setOriginalCopy(originalValue);
+            targetWrapper.setTranslatedCopy(translatedValue);
+            targetWrapper.setCurrentValue(translatedValue);
+
             LiveRelationship liveRelationship = relationships.get(propertyToTranslate.targetResource.getPath());
+            if (liveRelationship == null) {
+                liveRelationship = liveRelationshipManager.getLiveRelationship(propertyToTranslate.targetResource, false);
+                relationships.put(propertyToTranslate.targetResource.getPath(), liveRelationship);
+            }
+
             liveRelationshipManager.cancelPropertyRelationship(propertyToTranslate.targetResource.getResourceResolver(),
-                    liveRelationship, new String[]{originalKey, translatedKey}, false);
+                    liveRelationship, targetWrapper.allAiKeys(), false);
 
             markAsAiTranslated(resourceToTranslate, liveRelationship);
             stats.translatedProperties++;
@@ -183,11 +141,12 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
 
     protected void markAsAiTranslated(Resource resource, LiveRelationship liveRelationship) throws WCMException {
         ModifiableValueMap valueMap = requireNonNull(resource.adaptTo(ModifiableValueMap.class));
-        valueMap.put(PROPERTY_AI_TRANSLATED_BY, true);
-        valueMap.put(PROPERTY_AI_TRANSLATED_DATE, Calendar.getInstance());
+        AITranslatePropertyWrapper targetWrapper = new AITranslatePropertyWrapper(null, valueMap, "dummy");
+        targetWrapper.setAiTranslatedBy(resource.getResourceResolver().getUserID());
+        targetWrapper.setAiTranslatedDate(Calendar.getInstance());
         if (liveRelationship != null) {
             liveRelationshipManager.cancelPropertyRelationship(resource.getResourceResolver(),
-                    liveRelationship, new String[]{PROPERTY_AI_TRANSLATED_BY, PROPERTY_AI_TRANSLATED_DATE}, false);
+                    liveRelationship, targetWrapper.allGeneralKeys(), false);
         }
     }
 
@@ -197,20 +156,20 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
      *
      * @return true if something was changed.
      */
-    protected boolean migratePathsToLanguageCopy(Resource resource, String language, Stats stats) {
+    protected boolean migratePathsToLanguageCopy(Resource resource, String language, Stats stats) throws WCMException {
         boolean changed = false;
         for (Resource child : resource.getChildren()) {
             changed |= migratePathsToLanguageCopy(child, language, stats);
         }
         ModifiableValueMap mvm = resource.adaptTo(ModifiableValueMap.class);
         if (mvm != null) {
-            Map<String, Object> newEntries = new java.util.HashMap<>(); // avoid concurrency problems with the iterator
-            for (Map.Entry<String, Object> entry : mvm.entrySet()) {
+            for (Map.Entry<String, Object> entry : new HashMap<String, Object>(mvm).entrySet()) {
                 String key = entry.getKey();
-                if (key.contains(":") || isAiTranslateProperty(key)) {
+                if (key.contains(":") || AITranslatePropertyWrapper.isAiTranslateProperty(key)) {
                     continue; // don't touch system stuff with : - usually the relevant paths are in fileReference or similar.
                 }
                 if (entry.getValue() instanceof String) {
+                    AITranslatePropertyWrapper targetWrapper = new AITranslatePropertyWrapper(null, mvm, key);
                     String value = (String) entry.getValue();
                     if (value.startsWith("/content/dam/") || value.startsWith("/content/experience-fragments/")) {
                         stats.paths++;
@@ -219,12 +178,14 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
                         if (languageSiblings.size() == 1) {
                             stats.relocatedPaths++;
                             Resource languageCopy = languageSiblings.get(0);
-                            newEntries.put(key, languageCopy.getPath());
-                            String origKey = encodePropertyName(LC_PREFIX, key, AI_ORIGINAL_SUFFIX);
-                            if (mvm.get(origKey) == null) {
-                                newEntries.put(origKey, value);
+                            targetWrapper.setCurrentValue(languageCopy.getPath());
+                            if (targetWrapper.getLcOriginal() == null) {
+                                targetWrapper.setLcOriginal(value);
                             }
-                            newEntries.put(encodePropertyName(LC_PREFIX, key, AI_TRANSLATED_SUFFIX), languageCopy.getPath());
+                            targetWrapper.setLcTranslated(languageCopy.getPath());
+                            LiveRelationship liveRelationship = liveRelationshipManager.getLiveRelationship(resource, false);
+                            liveRelationshipManager.cancelPropertyRelationship(resource.getResourceResolver(),
+                                    liveRelationship, targetWrapper.allLcKeys(), false);
                             changed = true;
                         } else if (languageSiblings.size() > 1) {
                             LOG.warn("More than one language copy for {} in {} - {}", key, resource.getPath(),
@@ -233,7 +194,6 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
                     }
                 }
             }
-            mvm.putAll(newEntries);
         }
         return changed;
     }
@@ -299,73 +259,97 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
         }
         ModifiableValueMap mvm = requireNonNull(resource.adaptTo(ModifiableValueMap.class));
         LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, false);
-        List<String> keysToKeep = new ArrayList<>();
+        Set<String> resetPropertyExclusionKeys = new HashSet<>();
         for (String key : new ArrayList<>(mvm.keySet())) {
-            String originalKey = encodePropertyName(AI_PREFIX, key, AI_ORIGINAL_SUFFIX);
-            String translatedKey = encodePropertyName(AI_PREFIX, key, AI_TRANSLATED_SUFFIX);
-            String originalPathKey = encodePropertyName(LC_PREFIX, key, AI_ORIGINAL_SUFFIX);
-            String translatedPathKey = encodePropertyName(LC_PREFIX, key, AI_TRANSLATED_SUFFIX);
-            if (mvm.containsKey(originalKey)) {
-                mvm.put(key, mvm.get(originalKey));
-                mvm.remove(originalKey);
-                mvm.remove(translatedKey);
-                reenableInheritance(resource, key, relationship);
-                keysToKeep.add(originalKey);
-                keysToKeep.add(translatedKey);
+            if (AITranslatePropertyWrapper.isAiTranslateProperty(key)) {
+                continue; // will be removed when working on the original key.
             }
-            if (mvm.containsKey(originalPathKey)) {
-                mvm.put(key, mvm.get(originalPathKey));
-                mvm.remove(originalPathKey);
-                mvm.remove(translatedPathKey);
+
+            AITranslatePropertyWrapper targetWrapper = new AITranslatePropertyWrapper(null, mvm, key);
+            if (targetWrapper.hasSavedTranslation()) {
+                targetWrapper.setCurrentValue(targetWrapper.getOriginalCopy());
                 reenableInheritance(resource, key, relationship);
-                keysToKeep.add(originalPathKey);
-                keysToKeep.add(translatedPathKey);
             }
+            if (isNotBlank(targetWrapper.getLcOriginal())) {
+                targetWrapper.setCurrentValue(targetWrapper.getLcOriginal());
+                reenableInheritance(resource, key, relationship);
+            }
+            String[] allKeys = targetWrapper.allKeys();
+            Arrays.stream(allKeys).forEach(mvm::remove);
+            resetPropertyExclusionKeys.addAll(Arrays.asList(allKeys));
+            targetWrapper.setAiTranslatedBy(null);
+            targetWrapper.setAiTranslatedDate(null);
+            resetPropertyExclusionKeys.addAll(Arrays.asList(targetWrapper.allGeneralKeys()));
         }
-        mvm.remove(PROPERTY_AI_TRANSLATED_BY);
-        mvm.remove(PROPERTY_AI_TRANSLATED_DATE);
-        keysToKeep.add(PROPERTY_AI_TRANSLATED_BY);
-        keysToKeep.add(PROPERTY_AI_TRANSLATED_DATE);
         if (relationship != null) {
-            liveRelationshipManager.reenablePropertyRelationship(resource.getResourceResolver(), relationship, keysToKeep.toArray(new String[0]), false);
+            liveRelationshipManager.reenablePropertyRelationship(resource.getResourceResolver(), relationship,
+                    resetPropertyExclusionKeys.toArray(new String[0]), false);
         }
     }
 
     /**
      * Searches for properties we have to translate.
+     *
+     * @return true if something was changed already
      */
-    protected void collectPropertiesToTranslate(
+    protected boolean collectPropertiesToTranslate(
             @Nonnull Resource resource, @Nonnull List<PropertyToTranslate> propertiesToTranslate, @Nonnull Stats stats,
             @Nonnull AutoTranslateService.TranslationParameters translationParameters) throws WCMException {
+        boolean changed = false;
         LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, false);
         if (relationship == null) {
             LOG.warn("No live relationship for {}", resource.getPath());
-            return;
+            return false;
         }
         String sourcePath = relationship.getSourcePath();
         Resource sourceResource = resource.getResourceResolver().getResource(sourcePath);
         if (sourceResource != null) {
             ValueMap sourceValueMap = sourceResource.getValueMap();
-            ValueMap targetValueMap = resource.getValueMap();
+            ModifiableValueMap targetValueMap = requireNonNull(resource.adaptTo(ModifiableValueMap.class));
             for (Map.Entry<String, Object> entry : sourceValueMap.entrySet()) {
                 if (isTranslatableProperty(entry.getKey(), entry.getValue())) {
                     stats.translateableProperties++;
-                    String originallyTranslatedValue = targetValueMap.get(encodePropertyName(AI_PREFIX, entry.getKey(), AI_ORIGINAL_SUFFIX), String.class);
-                    boolean alreadyTranslated = originallyTranslatedValue != null;
-                    boolean addProperty = !alreadyTranslated;
-                    if (alreadyTranslated && translationParameters.translateWhenChanged) {
-                        addProperty = !StringUtils.equals(originallyTranslatedValue, sourceValueMap.get(entry.getKey(), String.class));
-                        if (addProperty) {
-                            LOG.debug("Re-translating because of change: {} in {}", entry.getKey(), resource.getPath());
-                        }
+                    AITranslatePropertyWrapper targetWrapper = new AITranslatePropertyWrapper(sourceValueMap, targetValueMap, entry.getKey());
+                    boolean isCancelled = relationship.getStatus() != null && (
+                            relationship.getStatus().isCancelled() ||
+                                    relationship.getStatus().getCanceledProperties().contains(entry.getKey())
+                    );
+
+                    // we will translate except if the property is cancelled and we don't want to touch cancelled properties,
+                    // or if we have a current translation.
+
+                    if (isCancelled && !translationParameters.translateWhenChanged) {
+                        continue; // don't touch cancelled properties
                     }
-                    if (addProperty) {
-                        PropertyToTranslate propertyToTranslate = new PropertyToTranslate();
-                        propertyToTranslate.sourceResource = sourceResource;
-                        propertyToTranslate.targetResource = resource;
-                        propertyToTranslate.propertyName = entry.getKey();
-                        propertiesToTranslate.add(propertyToTranslate);
+
+                    if (targetWrapper.isOriginalAsWhenLastTranslating()) {
+                        // shortcut: we have a recent translation already
+                        targetWrapper.setCurrentValue(targetWrapper.getTranslatedCopy());
+                        changed = changed || !StringUtils.equals(targetWrapper.getTranslatedCopy(), targetWrapper.getOriginalCopy());
+                        continue;
                     }
+
+                    if (isCancelled && targetWrapper.hasSavedTranslation()
+                            && !StringUtils.equals(targetWrapper.getTranslatedCopy(), targetWrapper.getCurrentValue())
+                            && !StringUtils.equals(targetWrapper.getOriginal(), targetWrapper.getCurrentValue())) {
+                        // = translateWhenChanged override; save manual change. We also exclude the phase during rollout
+                        // where the property is reset to the original value and we have to restore the translation.
+                        LOG.info("Re-translating {} in {} despite manual change", entry.getKey(), resource.getPath());
+                        targetWrapper.saveManualChange();
+                        stats.modifiedButRetranslatedProperties++;
+                    }
+
+                    stats.translatedProperties++;
+                    if (targetWrapper.hasSavedTranslation()) {
+                        stats.retranslatedProperties++;
+                    }
+
+                    LOG.debug("Re-translating {} in {}", entry.getKey(), resource.getPath());
+                    PropertyToTranslate propertyToTranslate = new PropertyToTranslate();
+                    propertyToTranslate.sourceResource = sourceResource;
+                    propertyToTranslate.targetResource = resource;
+                    propertyToTranslate.propertyName = entry.getKey();
+                    propertiesToTranslate.add(propertyToTranslate);
                 }
             }
         } else {
@@ -375,16 +359,18 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
         }
         for (Resource child : resource.getChildren()) {
             if (!PATTERN_IGNORED_SUBNODE_NAMES.matcher(child.getName()).matches()) {
-                collectPropertiesToTranslate(child, propertiesToTranslate, stats, translationParameters);
+                boolean childChanged = collectPropertiesToTranslate(child, propertiesToTranslate, stats, translationParameters);
+                changed |= childChanged;
             }
         }
+        return changed;
     }
 
     /**
      * Searches for properties
      */
 
-    protected String encodePropertyName(String prefix, String propertyName, String suffix) {
+    protected static String encodePropertyName(String prefix, String propertyName, String suffix) {
         return prefix + propertyName.replace(":", "_") + suffix;
     }
 
@@ -422,7 +408,7 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
                 return false;
             }
 
-            if (isAiTranslateProperty(name)) {
+            if (AITranslatePropertyWrapper.isAiTranslateProperty(name)) {
                 return false;
             }
             return PATTERN_HAS_WHITESPACE.matcher(stringValue).find() &&
@@ -430,14 +416,6 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
         }
         return false;
     }
-
-    /**
-     * Checks whether a property was created by us and must not be translated etc.
-     */
-    protected static boolean isAiTranslateProperty(String name) {
-        return name.startsWith(AI_PREFIX) || name.startsWith(LC_PREFIX);
-    }
-
 
     protected static class PropertyToTranslate {
         /**

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
@@ -141,7 +141,7 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
 
     protected void markAsAiTranslated(Resource resource, LiveRelationship liveRelationship) throws WCMException {
         ModifiableValueMap valueMap = requireNonNull(resource.adaptTo(ModifiableValueMap.class));
-        AITranslatePropertyWrapper targetWrapper = new AITranslatePropertyWrapper(null, valueMap, "dummy");
+        AITranslatePropertyWrapper targetWrapper = new AITranslatePropertyWrapper(null, valueMap, null);
         targetWrapper.setAiTranslatedBy(resource.getResourceResolver().getUserID());
         targetWrapper.setAiTranslatedDate(Calendar.getInstance());
         if (liveRelationship != null) {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
@@ -185,8 +185,10 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
         ModifiableValueMap valueMap = requireNonNull(resource.adaptTo(ModifiableValueMap.class));
         valueMap.put(PROPERTY_AI_TRANSLATED_BY, true);
         valueMap.put(PROPERTY_AI_TRANSLATED_DATE, Calendar.getInstance());
-        liveRelationshipManager.cancelPropertyRelationship(resource.getResourceResolver(),
-                liveRelationship, new String[]{PROPERTY_AI_TRANSLATED_BY, PROPERTY_AI_TRANSLATED_DATE}, false);
+        if (liveRelationship != null) {
+            liveRelationshipManager.cancelPropertyRelationship(resource.getResourceResolver(),
+                    liveRelationship, new String[]{PROPERTY_AI_TRANSLATED_BY, PROPERTY_AI_TRANSLATED_DATE}, false);
+        }
     }
 
     /**

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateListModel.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateListModel.java
@@ -47,7 +47,7 @@ public class AutoTranslateListModel {
             boolean changed = request.getParameter("translateWhenChanged") != null;
             String additionalInstructions = request.getParameter("additionalInstructions");
             boolean breakInheritance = request.getParameter("breakInheritance") != null;
-            GPTConfiguration configuration = configurationService.getGPTConfiguration(request, path);
+            GPTConfiguration configuration = configurationService.getGPTConfiguration(request.getResourceResolver(), path);
             AutoTranslateService.TranslationParameters parms = new AutoTranslateService.TranslationParameters();
             parms.recursive = recursive;
             parms.translateWhenChanged = changed;

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateService.java
@@ -75,6 +75,19 @@ public interface AutoTranslateService {
         public abstract void cancel();
 
         public abstract void rollback(@Nonnull ResourceResolver resourceResolver) throws PersistenceException, WCMException;
+
+
+        @Override
+        public String toString() {
+            return "TranslationRun: id='" + id + '\'' +
+                    ", status='" + status + '\'' +
+                    ", startTime='" + startTime + '\'' +
+                    ", stopTime='" + stopTime + '\'' +
+                    ", user='" + user + '\'' +
+                    ", rootPath='" + rootPath + '\'' +
+                    ", messages=" + messages;
+        }
+
     }
 
     static abstract class TranslationPage {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateService.java
@@ -54,6 +54,11 @@ public interface AutoTranslateService {
          * If true, we break the inheritance of the component / the property on translation.
          */
         public boolean breakInheritance;
+
+        /**
+         * If true the changes are saved ({@link ResourceResolver#commit()}) after each page.
+         */
+        public boolean autoSave = true;
     }
 
     static abstract class TranslationRun {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateServiceImpl.java
@@ -5,9 +5,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateServiceImpl.java
@@ -219,7 +219,7 @@ public class AutoTranslateServiceImpl implements AutoTranslateService {
                 startTime = new Date().toString();
                 boolean interrupted = false;
                 GPTConfiguration mergedConfiguration = configuration;
-                if (translationParameters.additionalInstructions != null ||
+                if (translationParameters.additionalInstructions != null &&
                         !translationParameters.additionalInstructions.trim().isEmpty()) {
                     mergedConfiguration = new GPTConfiguration(null, null, null,
                             translationParameters.additionalInstructions).merge(configuration);
@@ -259,11 +259,19 @@ public class AutoTranslateServiceImpl implements AutoTranslateService {
                     }
                 }
                 status = hasErrors ? "doneWithErrors" : interrupted ? "cancelled" : "done";
-                stopTime = new Date().toString();
             } catch (InterruptedException e) {
-                LOG.error("" + e, e);
+                LOG.error("Interruption during " + this, e);
                 Thread.currentThread().interrupt();
+                status = "interrupted";
+            } catch (Exception e) {
+                LOG.error("Error during " + this, e);
+                status = "error";
+                messages.append("Error: " + e.toString() + "\n");
             } finally {
+                stopTime = new Date().toString();
+                if (status == null) {
+                    status = "finished";
+                }
                 future = null;
                 callResourceResolver.close();
             }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveAction.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveAction.java
@@ -1,0 +1,12 @@
+package com.composum.ai.aem.core.impl.autotranslate.rollout;
+
+import com.day.cq.wcm.msm.api.LiveAction;
+
+/**
+ * Action to translate a resource in a live copy with the automatic translation service.
+ */
+public interface AutoTranslateLiveAction extends LiveAction {
+
+    // empty
+
+}

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionConfig.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionConfig.java
@@ -1,0 +1,15 @@
+package com.composum.ai.aem.core.impl.autotranslate.rollout;
+
+import org.apache.sling.caconfig.annotation.Configuration;
+import org.apache.sling.caconfig.annotation.Property;
+
+@Configuration(label = "Composum AI Automatic Translation POC Rollout Configuration",
+        description = "Configures rollout details for automatic translation. This is a demo and not yet fully functional.",
+        property = {"category=Composum-AI"})
+// is also added to Sling-ContextAware-Configuration-Classes bnd header in pom.xml
+public @interface AutoTranslateLiveActionConfig {
+
+    @Property(label = "Additional Instructions", description = "Additional instructions for the automatic translation.")
+    String additionalInstructions();
+
+}

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionFactory.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionFactory.java
@@ -4,9 +4,12 @@ import org.apache.sling.api.resource.ValueMap;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.composum.ai.aem.core.impl.autotranslate.AutoPageTranslateService;
+import com.composum.ai.backend.slingbase.AIConfigurationService;
 import com.day.cq.wcm.api.WCMException;
 import com.day.cq.wcm.msm.api.LiveActionFactory;
 import com.day.cq.wcm.msm.commons.BaseActionFactory;
@@ -26,6 +29,12 @@ public class AutoTranslateLiveActionFactory extends BaseActionFactory<AutoTransl
 
     private static final Logger LOG = LoggerFactory.getLogger(AutoTranslateLiveActionFactory.class);
 
+    @Reference
+    protected AutoPageTranslateService autoPageTranslateService;
+
+    @Reference
+    private AIConfigurationService configurationService;
+
     @Activate
     protected void activate(ComponentContext componentContext) {
         LOG.info("AutoTranslateLiveActionFactory.activate", componentContext.getProperties());
@@ -33,7 +42,7 @@ public class AutoTranslateLiveActionFactory extends BaseActionFactory<AutoTransl
 
     @Override
     protected AutoTranslateLiveAction newActionInstance(ValueMap valueMap) throws WCMException {
-        return new AutoTranslateLiveActionImpl(valueMap, this);
+        return new AutoTranslateLiveActionImpl(valueMap, this, autoPageTranslateService, configurationService);
     }
 
     @Override

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionFactory.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionFactory.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.composum.ai.aem.core.impl.autotranslate.AutoPageTranslateService;
+import com.composum.ai.aem.core.impl.autotranslate.AutoTranslateService;
 import com.composum.ai.backend.slingbase.AIConfigurationService;
 import com.day.cq.wcm.api.WCMException;
 import com.day.cq.wcm.msm.api.LiveActionFactory;
@@ -33,7 +34,10 @@ public class AutoTranslateLiveActionFactory extends BaseActionFactory<AutoTransl
     protected AutoPageTranslateService autoPageTranslateService;
 
     @Reference
-    private AIConfigurationService configurationService;
+    protected AIConfigurationService configurationService;
+
+    @Reference
+    protected AutoTranslateService autoTranslateService;
 
     @Activate
     protected void activate(ComponentContext componentContext) {
@@ -42,7 +46,7 @@ public class AutoTranslateLiveActionFactory extends BaseActionFactory<AutoTransl
 
     @Override
     protected AutoTranslateLiveAction newActionInstance(ValueMap valueMap) throws WCMException {
-        return new AutoTranslateLiveActionImpl(valueMap, this, autoPageTranslateService, configurationService);
+        return new AutoTranslateLiveActionImpl(valueMap, this, autoPageTranslateService, configurationService, autoTranslateService);
     }
 
     @Override

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionFactory.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionFactory.java
@@ -1,0 +1,43 @@
+package com.composum.ai.aem.core.impl.autotranslate.rollout;
+
+import org.apache.sling.api.resource.ValueMap;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.day.cq.wcm.api.WCMException;
+import com.day.cq.wcm.msm.api.LiveActionFactory;
+import com.day.cq.wcm.msm.commons.BaseActionFactory;
+
+/**
+ * Produces {@link AutoTranslateLiveActionImpl}s.
+ *
+ * @see "https://experienceleague.adobe.com/docs/experience-manager-65/content/sites/administering/introduction/msm-sync.html?lang=en#installed-synchronization-actions"
+ * @see "https://experienceleague.adobe.com/docs/experience-manager-65/content/implementing/developing/extending-aem/extending-msm.html?lang=en#creating-a-new-synchronization-action"
+ */
+@Component(service = LiveActionFactory.class,
+        property = {
+                LiveActionFactory.LIVE_ACTION_NAME + "=" + AutoTranslateLiveActionImpl.NAME
+        }
+)
+public class AutoTranslateLiveActionFactory extends BaseActionFactory<AutoTranslateLiveAction> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AutoTranslateLiveActionFactory.class);
+
+    @Activate
+    protected void activate(ComponentContext componentContext) {
+        LOG.info("AutoTranslateLiveActionFactory.activate", componentContext.getProperties());
+    }
+
+    @Override
+    protected AutoTranslateLiveAction newActionInstance(ValueMap valueMap) throws WCMException {
+        return new AutoTranslateLiveActionImpl(valueMap, this);
+    }
+
+    @Override
+    public String createsAction() {
+        return AutoTranslateLiveActionImpl.NAME;
+    }
+}

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionImpl.java
@@ -1,0 +1,45 @@
+package com.composum.ai.aem.core.impl.autotranslate.rollout;
+
+
+import javax.jcr.RepositoryException;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.day.cq.wcm.api.WCMException;
+import com.day.cq.wcm.msm.api.LiveAction;
+import com.day.cq.wcm.msm.api.LiveRelationship;
+import com.day.cq.wcm.msm.commons.BaseAction;
+import com.day.cq.wcm.msm.commons.BaseActionFactory;
+
+public class AutoTranslateLiveActionImpl extends BaseAction implements AutoTranslateLiveAction {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AutoTranslateLiveActionImpl.class);
+
+    public static final String NAME = "composumAiAutoTranslate";
+
+    protected AutoTranslateLiveActionImpl(ValueMap config, BaseActionFactory<? extends LiveAction> liveActionFactory) {
+        super(config, liveActionFactory);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    protected boolean handles(Resource source, Resource target, LiveRelationship relation, boolean isResetRollout)
+            throws RepositoryException, WCMException {
+        LOG.info("AutoTranslateLiveActionImpl.handles({}, {})", source.getPath(), target.getPath());
+        return true;
+    }
+
+    @Override
+    protected void doExecute(Resource resource, Resource resource1, LiveRelationship liveRelationship, boolean autoSave)
+            throws RepositoryException, WCMException {
+        LOG.error("AutoTranslateLiveActionImpl.doExecute({}, {})", resource.getPath(), resource1.getPath());
+    }
+
+}

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionImpl.java
@@ -72,8 +72,10 @@ public class AutoTranslateLiveActionImpl extends BaseAction implements AutoTrans
             } else {
                 autoPageTranslateService.translateLiveCopy(target, config, parms);
             }
-        } catch (PersistenceException | LoginException e) {
-            throw new WCMException("Error translating " + source.getPath(), e);
+//        } catch (PersistenceException | LoginException e) {
+//            throw new WCMException("Error translating " + source.getPath(), e);
+        } catch (Exception e) { // rather log exception for now since a demo is coming...
+            LOG.error("Error translating " + source.getPath(), e);
         }
     }
 

--- a/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImplTest.java
+++ b/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImplTest.java
@@ -66,10 +66,10 @@ public class AutoPageTranslateServiceImplTest {
         assertFalse(isTranslatableProperty("propertyName", "/mnt/someValue"));
 
         // Test with property name starting with AI_PREFIX or LC_PREFIX and ending with AI_TRANSLATED_SUFFIX or AI_ORIGINAL_SUFFIX
-        assertFalse(isTranslatableProperty(AutoPageTranslateServiceImpl.AI_PREFIX + "propertyName" + AutoPageTranslateServiceImpl.AI_TRANSLATED_SUFFIX, "Some value"));
-        assertFalse(isTranslatableProperty(AutoPageTranslateServiceImpl.AI_PREFIX + "propertyName" + AutoPageTranslateServiceImpl.AI_ORIGINAL_SUFFIX, "Some value"));
-        assertFalse(isTranslatableProperty(AutoPageTranslateServiceImpl.LC_PREFIX + "propertyName" + AutoPageTranslateServiceImpl.AI_TRANSLATED_SUFFIX, "Some value"));
-        assertFalse(isTranslatableProperty(AutoPageTranslateServiceImpl.LC_PREFIX + "propertyName" + AutoPageTranslateServiceImpl.AI_ORIGINAL_SUFFIX, "Some value"));
+        assertFalse(isTranslatableProperty(AITranslatePropertyWrapper.AI_PREFIX + "propertyName" + AITranslatePropertyWrapper.AI_TRANSLATED_SUFFIX, "Some value"));
+        assertFalse(isTranslatableProperty(AITranslatePropertyWrapper.AI_PREFIX + "propertyName" + AITranslatePropertyWrapper.AI_ORIGINAL_SUFFIX, "Some value"));
+        assertFalse(isTranslatableProperty(AITranslatePropertyWrapper.LC_PREFIX + "propertyName" + AITranslatePropertyWrapper.AI_TRANSLATED_SUFFIX, "Some value"));
+        assertFalse(isTranslatableProperty(AITranslatePropertyWrapper.LC_PREFIX + "propertyName" + AITranslatePropertyWrapper.AI_ORIGINAL_SUFFIX, "Some value"));
 
         // Test with string value without whitespace and 4 letter sequence
         assertFalse(isTranslatableProperty("propertyName", "abc"));

--- a/aem/pom.xml
+++ b/aem/pom.xml
@@ -77,7 +77,7 @@
         <!-- https://mvnrepository.com/artifact/com.adobe.aem/aemanalyser-maven-plugin -->
         <aemanalyser.version>1.5.8</aemanalyser.version>
         <aem.sdk.api>2023.7.12874.20230726T072051Z-230702</aem.sdk.api>
-        <aem.uber.jar.version>6.5.7</aem.uber.jar.version> <!-- 6.5.8 is last one with sources -->
+        <aem.uber.jar.version>6.5.7</aem.uber.jar.version>
         <osgi.version>6.0.0</osgi.version>
 
         <siteurl>https://github.com/ist-dresden/composum-AI</siteurl>

--- a/aem/ui.apps.structure/pom.xml
+++ b/aem/ui.apps.structure/pom.xml
@@ -37,6 +37,7 @@
                         <!-- /apps root -->
                         <filter><root>/apps</root></filter>
                         <filter><root>/apps/composum-ai</root></filter>
+                        <filter><root>/apps/msm/composum-ai</root></filter>
 
                         <!-- Common overlay roots -->
                         <filter><root>/apps/sling</root></filter>
@@ -49,7 +50,7 @@
                         <filter><root>/apps/settings</root></filter>
 
                         <!-- DAM folder root, will be created via repoinit -->
-                        <filter><root>/content/dam/composum-ai</root></filter>
+                        <!-- <filter><root>/content/dam/composum-ai</root></filter> -->
 
                     </filters>
                 </configuration>

--- a/aem/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/aem/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -3,4 +3,5 @@
     <filter root="/apps/composum-ai/clientlibs"/>
     <filter root="/apps/composum-ai/components"/>
     <filter root="/apps/composum-ai/i18n"/>
+    <filter root="/apps/msm/composum-ai"/>
 </workspaceFilter>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          jcr:primaryType="sling:Folder">
+</jcr:root>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/clientlibs/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/clientlibs/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          jcr:primaryType="sling:Folder">
+</jcr:root>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          jcr:primaryType="sling:Folder">
+</jcr:root>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslate/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslate/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          jcr:primaryType="sling:Folder">
+</jcr:root>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslate/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslate/list/list.html
@@ -98,7 +98,7 @@
                                         completed, last run first. Refresh page to update stati.
                                     </span>
                                     <!-- Table with translation runs -->
-                                    <table is="coral-table" style="max-height:300px">
+                                    <table is="coral-table">
                                         <thead is="coral-table-head" sticky>
                                         <tr is="coral-table-row">
                                             <th is="coral-table-headercell">Status</th>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/msm/composum-ai/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/msm/composum-ai/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+        xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+        jcr:primaryType="sling:Folder"
+        jcr:title="Composum AI MSM">
+</jcr:root>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/msm/composum-ai/rolloutconfigs/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/msm/composum-ai/rolloutconfigs/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root
+        xmlns:jcr="http://www.jcp.org/jcr/1.0"
+        xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+        jcr:primaryType="sling:OrderedFolder"
+        jcr:title="Rollout Configurations">
+</jcr:root>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/msm/composum-ai/rolloutconfigs/composumAiAutotranslate/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/msm/composum-ai/rolloutconfigs/composumAiAutotranslate/.content.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="cq:RolloutConfig"
+          cq:trigger="rollout"
+          jcr:description="Triggers the Composum AI automatic translation proof of concept action"
+          jcr:title="Composum AI Autotranslate POC">
+    <composumAiAutoTranslate
+            jcr:primaryType="cq:LiveSyncAction"/>
+</jcr:root>

--- a/aem/ui.content/src/main/content/META-INF/vault/filter.xml
+++ b/aem/ui.content/src/main/content/META-INF/vault/filter.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
     <filter root="/conf/composum-ai"/>
+    <!-- These are not actually used but present in earlier versions than 0.8.0 - remove the content. -->
     <filter root="/content/composum-ai"/>
     <filter root="/content/dam/composum-ai"/>
     <filter root="/content/experience-fragments/composum-ai"/>

--- a/aem/ui.content/src/main/content/jcr_root/content/dam/composum-ai/.content.xml
+++ b/aem/ui.content/src/main/content/jcr_root/content/dam/composum-ai/.content.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="sling:OrderedFolder">
-    <jcr:content
-        cq:conf="/conf/aemgpt"
-        jcr:primaryType="nt:unstructured"
-        jcr:title="Composum AI">
-    </jcr:content>
-</jcr:root>

--- a/backend/base/src/main/resources/chattemplates/chatgpt/singletranslation.txt
+++ b/backend/base/src/main/resources/chattemplates/chatgpt/singletranslation.txt
@@ -1,10 +1,10 @@
 # Translate a single word or phrase
 ---------- system ----------
 You are tasked as an expert translator to translate texts with utmost fidelity, preserving the original style, tone, sentiment, and all formatting elements (markdown, HTML tags, special characters) to the greatest extent possible.
-IMPORTANT: Only provide the translated text, maintaining all original formatting and non-translatable elements. Avoid any extraneous comments or actions not directly related to the translation.
+IMPORTANT: Only provide the translated text, maintaining all original formatting and non-translatable elements. Avoid any extraneous comments or actions not directly related to the translation.  Do not add anything to the original text, or leave out anything.
 ---------- user ----------
 Print the original text you have to translate exactly without any comments.
 ---------- assistant ----------
 ${sourcephrase}
 ---------- user ----------
-Print this complete text translated into ${targetlanguage}. ${addition}
+Print the original text translated into ${targetlanguage}. ${addition}

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationPlugin.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationPlugin.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ResourceResolver;
 
 import com.composum.ai.backend.base.service.chat.GPTConfiguration;
 import com.composum.ai.backend.slingbase.model.GPTPermissionConfiguration;
@@ -34,13 +35,13 @@ public interface AIConfigurationPlugin {
     /**
      * Reads the GPTConfiguration from sling context aware configurations.
      *
-     * @param request     the request
+     * @param resourceResolver the resource resolver
      * @param contentPath if that's given we read the configuration for this path, otherwise we take the requests path, as long as it starts with /content/
      * @return if the configuration could be determined we return it, otherwise null.
      * @throws IllegalArgumentException if none of the paths is a /content/ path.
      */
     @Nullable
-    default GPTConfiguration getGPTConfiguration(@Nonnull SlingHttpServletRequest request, @Nullable String contentPath) throws IllegalArgumentException {
+    default GPTConfiguration getGPTConfiguration(@Nonnull ResourceResolver resourceResolver, @Nullable String contentPath) throws IllegalArgumentException {
         return null;
     }
 

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationService.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIConfigurationService.java
@@ -6,6 +6,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ResourceResolver;
 
 import com.composum.ai.backend.base.service.chat.GPTConfiguration;
 import com.composum.ai.backend.slingbase.model.GPTPermissionInfo;
@@ -32,12 +33,12 @@ public interface AIConfigurationService {
     /**
      * Reads the GPTConfiguration from sling context aware configurations.
      *
-     * @param request     the request
+     * @param resourceResolver the resource resolver
      * @param contentPath if that's given we read the configuration for this path, otherwise we take the requests path, as long as it starts with /content/
      * @throws IllegalArgumentException if none of the paths is a /content/ path.
      */
     @Nullable
-    GPTConfiguration getGPTConfiguration(@Nonnull SlingHttpServletRequest request, @Nullable String contentPath) throws IllegalArgumentException;
+    GPTConfiguration getGPTConfiguration(@Nonnull ResourceResolver resourceResolver, @Nullable String contentPath) throws IllegalArgumentException;
 
     /**
      * Reads the {@link GPTPromptLibrary} from sling context aware configurations, falling back to OSGI configurations, falling back to default values.

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AICreateServlet.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AICreateServlet.java
@@ -258,7 +258,7 @@ public class AICreateServlet extends SlingAllMethodsServlet {
         if ("undefined".equals(inputImagePath) || "null".equals(inputImagePath) || StringUtils.isBlank(inputImagePath)) {
             inputImagePath = null;
         }
-        GPTConfiguration config = configurationService.getGPTConfiguration(request, configBasePath);
+        GPTConfiguration config = configurationService.getGPTConfiguration(request.getResourceResolver(), configBasePath);
         String chat = request.getParameter(PARAMETER_CHAT);
         if (Stream.of(sourcePath, sourceText, inputImagePath).filter(StringUtils::isNotBlank).count() > 1) {
             LOG.warn("More than one of sourcePath and sourceText and " + PARAMETER_INPUT_IMAGE_PATH +

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/AIConfigurationServiceImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/AIConfigurationServiceImpl.java
@@ -15,6 +15,7 @@ import javax.jcr.RepositoryException;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
@@ -79,7 +80,7 @@ public class AIConfigurationServiceImpl implements AIConfigurationService {
     @Override
     @Nullable
     public GPTPermissionInfo allowedServices(@Nonnull SlingHttpServletRequest request, @Nonnull String contentPath, @Nonnull String editorUrl) {
-        GPTConfiguration gptConfiguration = getGPTConfiguration(request, contentPath);
+        GPTConfiguration gptConfiguration = getGPTConfiguration(request.getResourceResolver(), contentPath);
         GPTPermissionInfo result = null;
         if (chatCompletionService.isEnabled(gptConfiguration)) {
             for (AIConfigurationPlugin plugin : plugins) {
@@ -160,10 +161,10 @@ public class AIConfigurationServiceImpl implements AIConfigurationService {
 
 
     @Override
-    public GPTConfiguration getGPTConfiguration(@NotNull SlingHttpServletRequest request, @Nullable String contentPath) throws IllegalArgumentException {
+    public GPTConfiguration getGPTConfiguration(@NotNull ResourceResolver resourceResolver, @Nullable String contentPath) throws IllegalArgumentException {
         for (AIConfigurationPlugin plugin : plugins) {
             try {
-                GPTConfiguration configuration = plugin.getGPTConfiguration(request, contentPath);
+                GPTConfiguration configuration = plugin.getGPTConfiguration(resourceResolver, contentPath);
                 if (configuration != null) {
                     LOG.info("Plugin {} returned configuration {}", plugin.getClass(), configuration);
                     return configuration;

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/AIConfigurationServiceImplTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/impl/AIConfigurationServiceImplTest.java
@@ -108,7 +108,7 @@ public class AIConfigurationServiceImplTest {
         // set up sling configuration for the path with key
         context.create().resource("/conf/global/sling:configs/com.composum.ai.backend.slingbase.model.OpenAIConfig",
                 "openAiApiKey", key);
-        GPTConfiguration config = service.getGPTConfiguration(getRequest(), "/content/allowed/jcr:content/path");
+        GPTConfiguration config = service.getGPTConfiguration(getRequest().getResourceResolver(), "/content/allowed/jcr:content/path");
         assertThat(config, notNullValue());
         assertThat(config.getApiKey(), is(key));
     }

--- a/composum/bundle/src/main/java/com/composum/ai/composum/bundle/AIServlet.java
+++ b/composum/bundle/src/main/java/com/composum/ai/composum/bundle/AIServlet.java
@@ -288,7 +288,7 @@ public class AIServlet extends AbstractServiceServlet {
         public final void doIt(@Nonnull SlingHttpServletRequest request, @Nonnull SlingHttpServletResponse response, @Nullable ResourceHandle resource) throws RepositoryException, IOException, ServletException {
             Status status = new Status(request, response, LOG);
             String configBasePath = request.getParameter(PARAMETER_CONFIGBASEPATH);
-            GPTConfiguration config = configurationService.getGPTConfiguration(request, configBasePath);
+            GPTConfiguration config = configurationService.getGPTConfiguration(request.getResourceResolver(), configBasePath);
 
             try {
                 performOperation(status, request, response, config);

--- a/composum/bundle/src/main/java/com/composum/ai/composum/bundle/model/LabelExtensionModel.java
+++ b/composum/bundle/src/main/java/com/composum/ai/composum/bundle/model/LabelExtensionModel.java
@@ -73,7 +73,7 @@ public class LabelExtensionModel extends AbstractModel {
             widget = context.getAttribute(EditWidgetTag.WIDGET_VAR, EditWidgetTag.class);
             chatCompletionService = context.getService(GPTChatCompletionService.class);
             aiConfigurationService = context.getService(AIConfigurationService.class);
-            GPTConfiguration gptConfig = aiConfigurationService != null ? aiConfigurationService.getGPTConfiguration(context.getRequest(), getPath()) : null;
+            GPTConfiguration gptConfig = aiConfigurationService != null ? aiConfigurationService.getGPTConfiguration(context.getResolver(), getPath()) : null;
             if (widget.getModel() instanceof Model && chatCompletionService != null && chatCompletionService.isEnabled(gptConfig)) {
                 model = (Model) widget.getModel();
                 valid = true;

--- a/featurespecs/8AutomaticTranslation.md
+++ b/featurespecs/8AutomaticTranslation.md
@@ -123,7 +123,7 @@ configuration. This is an additional configuration - to get the pages copied we 
 configuration, and then the translation rollout configuration to get the pages transparently translated.
 
 Rollout of a component or re-enabling the inheritance of the component resets that component completely, which would
-remove the properties we save our translation information in. To avoid that we break inheritance for these 
+remove the properties we save our translation information in. To avoid that we break inheritance for these
 properties selectively.
 
 ### Open points for the rollout configuration
@@ -164,6 +164,40 @@ massively improve the result if an editor has corrected the translation afterwar
 For automatically replacing paths with language copies we follow the same strategy: the original path is stored as
 `lc_(attributeName)_original` and the translated path as `lc_(attributeName)_translated`. Thus we can reinstate the path
 automatically if the user clicks on re-enable inheritance.
+
+### Analysis of saving the original and translated texts
+
+There are the following states for a property:
+
+1. no translation done
+2. original saved as blueprint and saved translation is as the text.
+3. inheritance broken, text changed: saved original is as blueprint and saved translation is the old translation.
+    - if the inheritance is re-enabled, the old translation is reinstated -> 2.
+4. inheritance intact, original changed but not rolled out, saved original and saved
+   automatic translation are out of date
+    - rollout: saved original and saved automatic translation and text are discarded and updated. -> 2.
+5. original changed but not rolled out, inhertance broken. saved original and saved automatic
+   translation are out of date, manual changes.
+    - if the inheritance is re-enabled: synchronize component would normally get the value from blueprint. Right way:
+      differential-translate the blueprint, but takes time. Bad way: roll back to the old translation. -> 2. (We might
+      save the manual changes, though)
+    - rollout: normally no changes -> also do it this way. (Unclear: start manual process with differential 
+      translation?) -> still at 4.
+
+An invariant is that if inheritance is not broken, the saved translation is equal to the text. This is only broken 
+temporarily during a rollout when inheritance is not broken, the text ist reset to the 
+blueprint's state, which has to be fixed during the execution of the translation - either by putting the result of 
+the previous manual translation into the text, or by re-translating the text if the blueprint has changed.
+
+Open point: it's not clear to me when to apply the differential retranslation, nor where the manual translation 
+result should come from.
+- During rollout probably nothing should change if inheritance is broken; if not it could be applied but what would 
+  be the approved manual translation?
+- If the inheritance is re-enabled, the user expects a reset, so the old manual translation is probably not the 
+  approved translation.
+Two thinkable ways:
+- Manual process (possibly supported by a workflow)
+- Automatically during rollout when inheritance is cancelled - that must be switchable, though.
 
 ### Heuristics for translateable attribute recognition.
 

--- a/featurespecs/8AutomaticTranslation.md
+++ b/featurespecs/8AutomaticTranslation.md
@@ -14,9 +14,14 @@ afterwards and fix them.
 For AEM: instead of the language copies mechanism that is often used for site translation we employ the live copy
 mechanism, which might be simpler to use, which would also be a distinguishing feature of the Composum AI translation
 process. The translation would then be a live copy of the original page. The translation process would then go through
-all components of the translated tree, break the inheritance and replace the texts in the text properties. This would
+all components of the translated tree and replace the texts in the text properties. (We opt not to break the 
+inheritance). This would
 provide an initial translation; for updating the translation, the live copy mechanism could be used in conjunction with
 a translation by the content creation dialog, or the translation could be updated by the process.
+
+This process can be triggered separately, or with a special action performed on rollout - e.g. a new 
+[synchronization action](https://experienceleague.adobe.com/docs/experience-manager-65/content/sites/administering/introduction/msm-sync.html?lang=en#installed-synchronization-actions)
+that can be integrated into rollout actions and triggers the translation process.
 
 Translated would normally be properties that "obviously" contain text, like jcr:title, jcr:description, text, title
 etc. (Let's search the wcm core components documentation for that), and properties that heuristically "look like text",
@@ -61,11 +66,14 @@ usage e.g.
 /content/wknd/language-masters/lc/adventures/ski-touring-mont-blanc ->
 /content/dam/wknd/en/adventures/ski-touring-mont-blanc/ski-touring-mont-blanc
 
-??? How to update the text attribute?
+Currently heuristic recognition of text attributes. That will probably need a specific implementation observing the 
+models, possibly a translation of the actual models.
 
 ### Assets (images etc.)
 
-Unclear: they have titles etc, so they are language specific as well. Copy?
+They have titles etc, so they are language specific as well, but these are often not used. If content fragments are 
+used, a live copy of the assets for translating content fragments will copy image assets, too - that might be a 
+problem. 
 
 ### AEM Language copies as comparison
 
@@ -171,12 +179,33 @@ This corresponds to a live copy 'rollout' with integrated translation.
   configuration in what content areas it can be used.
 - If a manual correction was made and the translation is updated, anyway, the manual correction should be saved for 
   later fixing.
+- For content fragments likely the models have to be translated.
+- In general - how to deal with i18n of components? (Probably out of scope, but needs discussion.)
+- rewrite to use 
+  [Sling Jobs](https://medium.com/@jlanssie/translate-entires-websites-in-aem-automatically-with-openai-944875cbfa22) 
+  for the translation
+- If it's a synchronization action - how to check whether it's finished?
+- Custom tool: show only conditionally?
 
 ## Links
 
 https://www.youtube.com/watch?v=MMtS8ag6OUE - AEM automatic translation
 https://experienceleague.adobe.com/docs/experience-manager-learn/sites/multi-site-management/updating-language-copy.html?lang=en -
 Workflow when updating a language copy
+
+https://medium.com/@vsr061/create-custom-aem-menu-tools-with-granite-ui-shell-53c56e435f8a - Custom AEM menu tools
+https://medium.com/@jlanssie/how-to-create-a-custom-tool-in-aem-78d14c1f66d5
+
+### Links for translation on rollout
+https://github.com/AdobeDocs/experience-manager-65.en/blob/main/help/sites-administering/msm-best-practices.md etc.
+https://www.linkedin.com/pulse/aem-msm-custom-rollout-action-nurbek-umirov/
+https://experienceleague.adobe.com/docs/experience-manager-65/content/sites/administering/introduction/msm-sync.html?lang=en
+
+### Links for workflows
+
+https://medium.com/@jlanssie/translate-entires-websites-in-aem-automatically-with-openai-944875cbfa22 workflow to 
+translate pages. Interesting points: translates text in the for of JSON.
+https://medium.com/@jlanssie/create-a-custom-workflow-model-in-aem-with-a-full-code-coverage-unit-test-4178b2263b81
 
 ## Development
 

--- a/featurespecs/8AutomaticTranslation.md
+++ b/featurespecs/8AutomaticTranslation.md
@@ -14,12 +14,12 @@ afterwards and fix them.
 For AEM: instead of the language copies mechanism that is often used for site translation we employ the live copy
 mechanism, which might be simpler to use, which would also be a distinguishing feature of the Composum AI translation
 process. The translation would then be a live copy of the original page. The translation process would then go through
-all components of the translated tree and replace the texts in the text properties. (We opt not to break the 
+all components of the translated tree and replace the texts in the text properties. (We opt not to break the
 inheritance). This would
 provide an initial translation; for updating the translation, the live copy mechanism could be used in conjunction with
 a translation by the content creation dialog, or the translation could be updated by the process.
 
-This process can be triggered separately, or with a special action performed on rollout - e.g. a new 
+This process can be triggered separately, or with a special action performed on rollout - e.g. a new
 [synchronization action](https://experienceleague.adobe.com/docs/experience-manager-65/content/sites/administering/introduction/msm-sync.html?lang=en#installed-synchronization-actions)
 that can be integrated into rollout actions and triggers the translation process.
 
@@ -66,14 +66,14 @@ usage e.g.
 /content/wknd/language-masters/lc/adventures/ski-touring-mont-blanc ->
 /content/dam/wknd/en/adventures/ski-touring-mont-blanc/ski-touring-mont-blanc
 
-Currently heuristic recognition of text attributes. That will probably need a specific implementation observing the 
+Currently heuristic recognition of text attributes. That will probably need a specific implementation observing the
 models, possibly a translation of the actual models.
 
 ### Assets (images etc.)
 
-They have titles etc, so they are language specific as well, but these are often not used. If content fragments are 
-used, a live copy of the assets for translating content fragments will copy image assets, too - that might be a 
-problem. 
+They have titles etc, so they are language specific as well, but these are often not used. If content fragments are
+used, a live copy of the assets for translating content fragments will copy image assets, too - that might be a
+problem.
 
 ### AEM Language copies as comparison
 
@@ -103,7 +103,7 @@ can be created as live copies or just copies and translated with the UI. During 
 check all paths for having a translated language sister path and replace them with the translated paths.
 (Not quite sure whether it's right to cut inheritance or not.)
 
-## UI
+## Triggering the translation with a proof of concept UI
 
 The translation process would be a long running process in the server, translating page by page. Thus, it needs to
 display progress information, allow for cancellation and provide a way to inspect the results. There has to be a form to
@@ -115,6 +115,25 @@ Parameters for the translation process are:
 - the path of the page to translate
 - a `recursive` flag whether to translate all pages recursively or only the named page or resource
 - a parameter `changed` flag that triggers retranslation if the original text has changed.
+
+## Triggering the translation as a rollout action
+
+We define a rollout configuration that triggers the translation process for the pages that are rolled out with that
+configuration. This is an additional configuration - to get the pages copied we need e.g. the standard rollout
+configuration, and then the translation rollout configuration to get the pages transparently translated.
+
+Rollout of a component or re-enabling the inheritance of the component resets that component completely, which would
+remove the properties we save our translation information in. To avoid that we break inheritance for these 
+properties selectively.
+
+### Open points for the rollout configuration
+
+- how to do that in the background
+- is there a way to avoid order dependence with other rollout configurations?
+- how to view statistics
+- configuration?
+- is that triggered on initial copying?
+- are our additional properties kept?
 
 ## Some technical details
 
@@ -162,27 +181,27 @@ of a component.
 
 1. `de` has the same (english) text as `en` - initial state after live copy creation. Source doesn't matter.
 2. `de` has a different text than `en` but still english. (`en` changed after live copy creation.) Unclear.
-3. `de` was already translated, and the saved source is different than the current `en` source. (Normal case for 
-  re-translation.) Likely the source should be the current `en` text.
-   
-Since in the third case the intended source is clearly the current `en` text and in the other ones it's not clear, 
-we always take the current `en` text (that is, the source of the live copy) as source for the translation for now. 
+3. `de` was already translated, and the saved source is different than the current `en` source. (Normal case for
+   re-translation.) Likely the source should be the current `en` text.
+
+Since in the third case the intended source is clearly the current `en` text and in the other ones it's not clear,
+we always take the current `en` text (that is, the source of the live copy) as source for the translation for now.
 This corresponds to a live copy 'rollout' with integrated translation.
 
 ## Open points
 
-- How well do languages with very different character systems (ja, es, ru, chinese zh, korean ko) work? A 
-  translation is performed, looks nicely and when translated back with Deepl the texts make sense, but it'd be 
-  interesting how skilled the translation is. Also, that might need additional instructions for the translator to 
-  choose the right variant, tone etc. (Simplified chinese might be zh-CN , traditional zh-Hant). 
-- Currently the translator can be switched on or off, but there is no configuration for whom it is available and no 
+- How well do languages with very different character systems (ja, es, ru, chinese zh, korean ko) work? A
+  translation is performed, looks nicely and when translated back with Deepl the texts make sense, but it'd be
+  interesting how skilled the translation is. Also, that might need additional instructions for the translator to
+  choose the right variant, tone etc. (Simplified chinese might be zh-CN , traditional zh-Hant).
+- Currently the translator can be switched on or off, but there is no configuration for whom it is available and no
   configuration in what content areas it can be used.
-- If a manual correction was made and the translation is updated, anyway, the manual correction should be saved for 
+- If a manual correction was made and the translation is updated, anyway, the manual correction should be saved for
   later fixing.
 - For content fragments likely the models have to be translated.
 - In general - how to deal with i18n of components? (Probably out of scope, but needs discussion.)
-- rewrite to use 
-  [Sling Jobs](https://medium.com/@jlanssie/translate-entires-websites-in-aem-automatically-with-openai-944875cbfa22) 
+- rewrite to use
+  [Sling Jobs](https://medium.com/@jlanssie/translate-entires-websites-in-aem-automatically-with-openai-944875cbfa22)
   for the translation
 - If it's a synchronization action - how to check whether it's finished?
 - Custom tool: show only conditionally?
@@ -197,13 +216,14 @@ https://medium.com/@vsr061/create-custom-aem-menu-tools-with-granite-ui-shell-53
 https://medium.com/@jlanssie/how-to-create-a-custom-tool-in-aem-78d14c1f66d5
 
 ### Links for translation on rollout
+
 https://github.com/AdobeDocs/experience-manager-65.en/blob/main/help/sites-administering/msm-best-practices.md etc.
 https://www.linkedin.com/pulse/aem-msm-custom-rollout-action-nurbek-umirov/
 https://experienceleague.adobe.com/docs/experience-manager-65/content/sites/administering/introduction/msm-sync.html?lang=en
 
 ### Links for workflows
 
-https://medium.com/@jlanssie/translate-entires-websites-in-aem-automatically-with-openai-944875cbfa22 workflow to 
+https://medium.com/@jlanssie/translate-entires-websites-in-aem-automatically-with-openai-944875cbfa22 workflow to
 translate pages. Interesting points: translates text in the for of JSON.
 https://medium.com/@jlanssie/create-a-custom-workflow-model-in-aem-with-a-full-code-coverage-unit-test-4178b2263b81
 


### PR DESCRIPTION
When adding the rollout configuration "Composum AI Autotranslate POC" to a live copy, the texts are transparently translated to the language for the live copy. When creating the live copy, the translation is done out of the loop - the state of the translation can currently be viewed at /apps/composum-ai/components/autotranslate/list.html . Otherwise the translation is done during the rollout asynchronous process.

Additional instructions can be assigned through the sling ca config "Composum AI Automatic Translation POC Rollout Configuration" (com.composum.ai.aem.core.impl.autotranslate.rollout.AutoTranslateLiveActionConfig) .

For experimenting, the /apps/composum-ai/components/autotranslate/list.html is still easier.

When reenabling inheritance on a translated page, the translation is only done when "synchronize page" is chosen - synchronize component currently just recreates the untranslated state.