### PR TITLE
Add a browser-global prompt history for last applied prompts to AEM Content Creation Dialog

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -8,15 +8,15 @@ BUG: initial loading is strange in content dialog - unclear what to do, this is 
                 const lastEntry = localStorage.getItem(LOCALSTORAGE_KEY_LASTDIALOGSTATE);
                 historyMap[historyPath] = lastEntry ? [JSON.parse(lastEntry)] : [];
             }
-BUG: reset preset selector when entering prompt
 
 Image description from URL?
 
 AEM for content fragments?
 URL as base text , inner links
 Append button for AEM
-Multi-lingual?
 https://cloud.composum.com/bin/pages.html/content/ist/composum/home/blog/pages/composumAI/composumAI-AEM
+
+?? BM25 + WAND search?
 
 Done:
 Markdown to HTML transformation in sidebar -> not necessary, white-space: break-spaces is enough.

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/_cq_dialog/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/_cq_dialog/.content.xml
@@ -279,7 +279,7 @@
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="granite/ui/components/foundation/text"
                                     granite:class="_coral-Tool"
-                                    text="Text Length"/>
+                                    text="Text Length:"/>
                             <textLengthSelector jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                                 fieldDescription="The desired approximate length of the generated text."
@@ -290,6 +290,17 @@
                                         sling:resourceType="cq/gui/components/common/wcm/datasources/childresources"
                                         path="/conf/composum-ai/settings/dialogs/contentcreation/textlengths"/>
                             </textLengthSelector>
+                            <lastPromptsLabel
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/foundation/text"
+                                    granite:class="_coral-Tool"
+                                    text="Last Prompts:"/>
+                            <lastPromptsSelector jcr:primaryType="nt:unstructured"
+                                                 sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                 fieldDescription="The last prompts you used on this or other resources."
+                                                 name="./lastPromptsSelector"
+                                                 emptyOption="{Boolean}true"
+                                                 granite:class="composum-ai-last-propmt-selector _coral-Tool"/>
                             <loading
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="granite/ui/components/coral/foundation/container"

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/_cq_dialog/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/_cq_dialog/.content.xml
@@ -300,7 +300,7 @@
                                                  fieldDescription="The last prompts you used on this or other resources."
                                                  name="./lastPromptsSelector"
                                                  emptyOption="{Boolean}true"
-                                                 granite:class="composum-ai-last-propmt-selector _coral-Tool"/>
+                                                 granite:class="composum-ai-last-prompt-selector _coral-Tool"/>
                             <loading
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="granite/ui/components/coral/foundation/container"

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/help/help.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/help/help.html
@@ -32,6 +32,10 @@
     settings and will usually get a different suggestion, but you can also modify your prompt and try again.
     When you're done press "Done", and the content suggestion will be copied into the editor from which you called the
     dialog.</p>
+<p>There is also a "Last prompts" drop down menu that sets the prompt and content selector (if applicable) to the last
+    values that have been used to generate content. In contrast to the history this feature retains its data across
+    sessions in the current browser and is independent of the currently edited component, making it a useful tool for
+    applying similar prompts to different components or pages.</p>
 <h2>Caution</h2>
 <p>
     As with all artificial intelligence based services, please be aware that AIs currently sometimes create content that

--- a/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
+++ b/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
@@ -317,9 +317,11 @@ class ContentCreationDialog {
             contentSelector: status.contentSelector,
             url: status.url
         };
-        console.log("maybeStoreLastPrompt storing ", entry)
+        if (this.debug) console.log("maybeStoreLastPrompt entry", entry);
         const entryString = JSON.stringify(entry);
         if (!this.lastPrompts || entryString !== JSON.stringify(this.lastPrompts[0])) {
+            // delete entries that are the same as the new one
+            this.lastPrompts = this.lastPrompts.filter((oldentry) => JSON.stringify(oldentry) !== entryString);
             this.lastPrompts.unshift(entry);
             if (this.lastPrompts.length > MAX_LAST_PROMPTS) {
                 this.lastPrompts.pop();
@@ -329,7 +331,6 @@ class ContentCreationDialog {
     }
 
     entryItem(entry) {
-        console.log("entryItem", entry);
         let promptName = entry.promptSelectorKey;
         // the promptSelectorKey is empty if the prompt was entered or changed manually -> use actual prompt.
         if (!promptName || promptName === '-') {

--- a/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
+++ b/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
@@ -7,8 +7,6 @@ import {HelpPage} from './HelpPage.js';
 
 const APPROXIMATED_MARKDOWN_SERVLET = '/bin/cpm/ai/approximated';
 
-const LOCALSTORAGE_KEY_LASTDIALOGSTATE = 'aem-composumAI-contentcreation-lastDialogState';
-
 /** Keeps dialog histories per path. */
 const historyMap = {};
 
@@ -58,8 +56,7 @@ class ContentCreationDialog {
         this.createServlet = new AICreate(this.streamingCallback.bind(this), this.doneCallback.bind(this), this.errorCallback.bind(this));
         const historyPath = property ? componentPath + '/' + property : componentPath;
         if (!historyMap[historyPath]) {
-            const lastEntry = localStorage.getItem(LOCALSTORAGE_KEY_LASTDIALOGSTATE);
-            historyMap[historyPath] = lastEntry ? [JSON.parse(lastEntry)] : [];
+            historyMap[historyPath] = [];
         }
         this.history = new DialogHistory(this.$dialog, () => this.getDialogStatus(), (status) => this.setDialogStatus(status), historyMap[historyPath]);
 
@@ -137,7 +134,6 @@ class ContentCreationDialog {
             predefinedPrompts: this.$predefinedPromptsSelector.val(),
             response: this.getResponse()
         };
-        localStorage.setItem(LOCALSTORAGE_KEY_LASTDIALOGSTATE, JSON.stringify(status));
         return status;
     }
 

--- a/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
+++ b/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
@@ -143,6 +143,7 @@ class ContentCreationDialog {
             textLength: this.$textLengthSelector.val(),
             contentSelector: this.$contentSelector.val(),
             predefinedPrompts: this.$predefinedPromptsSelector.val(),
+            predefinedPromptsKey: this.$predefinedPromptsSelector.find('option:selected').text(),
             url: this.$urlField.val(),
             response: this.getResponse()
         };
@@ -312,9 +313,11 @@ class ContentCreationDialog {
         const entry = {
             prompt: status.prompt,
             promptSelector: status.predefinedPrompts,
+            promptSelectorKey: status.predefinedPromptsKey,
             contentSelector: status.contentSelector,
             url: status.url
         };
+        console.log("maybeStoreLastPrompt storing ", entry)
         const entryString = JSON.stringify(entry);
         if (!this.lastPrompts || entryString !== JSON.stringify(this.lastPrompts[0])) {
             this.lastPrompts.unshift(entry);
@@ -326,7 +329,9 @@ class ContentCreationDialog {
     }
 
     entryItem(entry) {
-        let promptName = this.$predefinedPromptsSelector.val();
+        console.log("entryItem", entry);
+        let promptName = entry.promptSelectorKey;
+        // the promptSelectorKey is empty if the prompt was entered or changed manually -> use actual prompt.
         if (!promptName || promptName === '-') {
             promptName = entry.prompt.length < 40 ? entry.prompt :
                 entry.prompt.substring(0, 30) + ' ... ' + entry.prompt.substring(entry.prompt.length - 10);

--- a/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
+++ b/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
@@ -143,6 +143,7 @@ class ContentCreationDialog {
             textLength: this.$textLengthSelector.val(),
             contentSelector: this.$contentSelector.val(),
             predefinedPrompts: this.$predefinedPromptsSelector.val(),
+            url: this.$urlField.val(),
             response: this.getResponse()
         };
         this.maybeStoreLastPrompt(status);
@@ -160,6 +161,9 @@ class ContentCreationDialog {
             this.setSourceContent(this.oldContent);
         }
         this.setResponse(status.response);
+        if (status.url) {
+            this.$urlField.val(status.url);
+        }
         this.onPredefinedPromptsChanged();
         this.onContentSelectorChanged();
         this.onPromptChanged();
@@ -307,7 +311,9 @@ class ContentCreationDialog {
         if (this.debug) console.log("maybeStoreLastPrompt", arguments);
         const entry = {
             prompt: status.prompt,
-            contentSelector: status.contentSelector
+            promptSelector: status.predefinedPrompts,
+            contentSelector: status.contentSelector,
+            url: status.url
         };
         const entryString = JSON.stringify(entry);
         if (!this.lastPrompts || entryString !== JSON.stringify(this.lastPrompts[0])) {
@@ -320,8 +326,11 @@ class ContentCreationDialog {
     }
 
     entryItem(entry) {
-        const promptName = entry.prompt.length < 40 ? entry.prompt :
-            entry.prompt.substring(0, 30) + ' ... ' + entry.prompt.substring(entry.prompt.length - 10);
+        let promptName = this.$predefinedPromptsSelector.val();
+        if (!promptName || promptName === '-') {
+            promptName = entry.prompt.length < 40 ? entry.prompt :
+                entry.prompt.substring(0, 30) + ' ... ' + entry.prompt.substring(entry.prompt.length - 10);
+        }
         return {
             value: JSON.stringify(entry),
             content: {
@@ -349,6 +358,15 @@ class ContentCreationDialog {
             if (entry.contentSelector) {
                 this.$contentSelector.val(entry.contentSelector);
                 this.onContentSelectorChanged();
+            }
+            if (entry.promptSelector) {
+                this.$predefinedPromptsSelector.val(entry.promptSelector);
+            }
+            if (entry.url) {
+                this.$urlField.val(entry.url);
+                if (entry.contentSelector === 'url') {
+                    this.onUrlChanged();
+                }
             }
         }
         this.$predefinedPromptsSelector.get(0).scrollIntoView();

--- a/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
+++ b/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
@@ -326,6 +326,7 @@ class ContentCreationDialog {
             if (this.lastPrompts.length > MAX_LAST_PROMPTS) {
                 this.lastPrompts.pop();
             }
+            localStorage.setItem(LOCALSTORAGE_KEY_CONTENTCREATION_PROMPTHISTORY, JSON.stringify(this.lastPrompts));
             this.restoreLastPrompts();
         }
     }

--- a/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
+++ b/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
@@ -225,6 +225,7 @@ class ContentCreationDialog {
         } else {
             this.$generateButton.attr('disabled', 'disabled');
         }
+        this.$lastPromptsSelector.val('');
     }
 
     onContentSelectorChanged(event) {
@@ -319,8 +320,8 @@ class ContentCreationDialog {
     }
 
     entryItem(entry) {
-        const promptName = entry.prompt.length < 20 ? entry.prompt :
-            entry.prompt.substring(0, 10) + '...' + entry.prompt.substring(entry.prompt.length - 10);
+        const promptName = entry.prompt.length < 40 ? entry.prompt :
+            entry.prompt.substring(0, 30) + ' ... ' + entry.prompt.substring(entry.prompt.length - 10);
         return {
             value: JSON.stringify(entry),
             content: {

--- a/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
+++ b/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
@@ -171,6 +171,9 @@ try {
          */
         function prepareDialog(event) {
             if (debug) console.log("prepareDialog", event.type, event.target);
+            if (!event || !event.target || event.target.localName === 'coral-tooltip') {
+                return;
+            }
             try {
                 aiconfig.ifEnabled(SERVICE_CREATE, undefined, () => {
                     Coral.commons.ready(event.target, function () {

--- a/aem/ui.frontend/src/main/webpack/site/styles/composum-ai.scss
+++ b/aem/ui.frontend/src/main/webpack/site/styles/composum-ai.scss
@@ -51,3 +51,15 @@
 #composumAI-sidebar-panel .betty-ActionBar {
     min-height: 48px;
 }
+
+.composum-ai-dialog {
+
+    coral-tooltip {
+        min-width: 75px;
+    }
+
+    .composum-ai-last-prompt-selector {
+        max-width: 20ex;
+    }
+
+}

--- a/src/site/markdown/aem-variant/usage.md
+++ b/src/site/markdown/aem-variant/usage.md
@@ -81,10 +81,15 @@ or just describe what you need without providing any additional base text.
 
 Then you can either select one from a range of predefined prompts, like Summarize, Introduction, Conclusion, Expand,
 Headline suggestions, Improve, ..., and apply these. You are invited to modify or extend the prompt you selected, or
-create your entirely own request to the AI.
+create your entirely own request to the AI. 
 
 A history in the dialog supports you to switch back and forth between your requests, so it's easy to retry and switch
 back if the first generated text was better.
+
+There is also a "Last prompts" drop down menu that sets the prompt and content selector (if applicable) to the last 
+values that have been used to generate content. In contrast to the history this feature retains its data across sessions
+in the current browser and is independent of the currently edited component, making it a useful tool for applying 
+similar prompts to different components or pages.
 
 As the last step, you can replace the edited component field by the generated text, or cancel the operation. The calling
 dialog / the richtext editor from which the content creation was called will still be open for editing.


### PR DESCRIPTION
To support the user if (s)he wants to apply the same or similar prompts to different components on a page or components on several pages, all last executed prompts (up to a maximum number of 20) are stored and placed in a menu "Last prompts" just next to the text length selector.

Choosing a prompt from this menu also sets the content source to the value used when executing this prompt - except if that value isn't available (e.g. because it was a linked page that isn't linked in the current page.)