### PR TITLE
Make automatic translation model switchable

### DIFF
--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateCaConfig.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateCaConfig.java
@@ -9,7 +9,15 @@ import org.apache.sling.caconfig.annotation.Property;
 // is also added to Sling-ContextAware-Configuration-Classes bnd header in pom.xml
 public @interface AutoTranslateCaConfig {
 
+    enum RequiredModel {
+        HIGH_INTELLIGENCE_MODEL,
+        STANDARD_MODEL
+    }
+
     @Property(label = "Additional Instructions", description = "Additional instructions for the automatic translation.")
     String additionalInstructions();
+
+    @Property(label = "Model", description = "If set, this model will be used for translation. If not set, a default will be used.")
+    RequiredModel model();
 
 }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateListModel.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateListModel.java
@@ -60,6 +60,12 @@ public class AutoTranslateListModel {
             String additionalInstructions = request.getParameter("additionalInstructions");
             boolean breakInheritance = request.getParameter("breakInheritance") != null;
             GPTConfiguration configuration = configurationService.getGPTConfiguration(request.getResourceResolver(), path);
+            String translationmodel = request.getParameter("translationmodel");
+            if ("standard".equals(translationmodel)) {
+                configuration = GPTConfiguration.STANDARD_INTELLIGENCE.merge(configuration);
+            } else if ("highintelligence".equals(translationmodel)) {
+                configuration = GPTConfiguration.HIGH_INTELLIGENCE.merge(configuration);
+            }
             AutoTranslateService.TranslationParameters parms = new AutoTranslateService.TranslationParameters();
             parms.recursive = recursive;
             parms.translateWhenChanged = changed;

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateServiceImpl.java
@@ -222,7 +222,7 @@ public class AutoTranslateServiceImpl implements AutoTranslateService {
                     mergedConfiguration = new GPTConfiguration(null, null, null,
                             translationParameters.additionalInstructions).merge(configuration);
                 }
-                if (autoTranslateConfigService.isUseHighIntelligenceModel()) {
+                if (autoTranslateConfigService.isUseHighIntelligenceModel() && mergedConfiguration.isHighIntelligenceNeeded() == null) {
                     mergedConfiguration = GPTConfiguration.HIGH_INTELLIGENCE.merge(mergedConfiguration);
                 }
                 for (TranslationPageImpl page : translatedPages) {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateServiceImpl.java
@@ -222,7 +222,8 @@ public class AutoTranslateServiceImpl implements AutoTranslateService {
                     mergedConfiguration = new GPTConfiguration(null, null, null,
                             translationParameters.additionalInstructions).merge(configuration);
                 }
-                if (autoTranslateConfigService.isUseHighIntelligenceModel() && mergedConfiguration.isHighIntelligenceNeeded() == null) {
+                if (autoTranslateConfigService.isUseHighIntelligenceModel() &&
+                        (mergedConfiguration == null || mergedConfiguration.isHighIntelligenceNeeded() == null)) {
                     mergedConfiguration = GPTConfiguration.HIGH_INTELLIGENCE.merge(mergedConfiguration);
                 }
                 for (TranslationPageImpl page : translatedPages) {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/rollout/AutoTranslateLiveActionImpl.java
@@ -72,6 +72,11 @@ public class AutoTranslateLiveActionImpl extends BaseAction implements AutoTrans
         ConfigurationBuilder confBuilder = Objects.requireNonNull(target.adaptTo(ConfigurationBuilder.class));
         AutoTranslateCaConfig autoTranslateCaConfig = confBuilder.as(AutoTranslateCaConfig.class);
         parms.additionalInstructions = autoTranslateCaConfig.additionalInstructions();
+        if (autoTranslateCaConfig != null && autoTranslateCaConfig.model() == AutoTranslateCaConfig.RequiredModel.HIGH_INTELLIGENCE_MODEL) {
+            config = GPTConfiguration.HIGH_INTELLIGENCE.merge(config, true);
+        } else if (autoTranslateCaConfig != null && autoTranslateCaConfig.model() == AutoTranslateCaConfig.RequiredModel.STANDARD_MODEL) {
+            config = GPTConfiguration.STANDARD_INTELLIGENCE.merge(config, true);
+        }
         // parms.translateWhenChanged probably only makes sense when differential translation is integrated.
         try {
             boolean duringLiveCopyCreation = liveRelationship.getStatus() == null || liveRelationship.getStatus().getLastRolledOut() == null;

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/workflow/AutoTranslateWorkflowProcess.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/workflow/AutoTranslateWorkflowProcess.java
@@ -143,6 +143,12 @@ public class AutoTranslateWorkflowProcess implements WorkflowProcess {
 
             try {
                 GPTConfiguration config = configurationService.getGPTConfiguration(contentResource.getResourceResolver(), contentResource.getPath());
+                if (autoTranslateCaConfig != null && autoTranslateCaConfig.model() == AutoTranslateCaConfig.RequiredModel.HIGH_INTELLIGENCE_MODEL) {
+                    config = GPTConfiguration.HIGH_INTELLIGENCE.merge(config, true);
+                } else if (autoTranslateCaConfig != null && autoTranslateCaConfig.model() == AutoTranslateCaConfig.RequiredModel.STANDARD_MODEL) {
+                    config = GPTConfiguration.STANDARD_INTELLIGENCE.merge(config, true);
+                }
+
                 if (parms.additionalInstructions != null) {
                     config = GPTConfiguration.merge(config,
                             new GPTConfiguration(null, null, null, parms.additionalInstructions));

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslate/list/create.jsp
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslate/list/create.jsp
@@ -3,8 +3,41 @@
 <%@page session="false" pageEncoding="UTF-8" %>
 <%-- Redirects to page displaying the run --%>
 <%
-    SlingHttpServletRequest slingRequest = (SlingHttpServletRequest) request;
-    AutoTranslateListModel model = slingRequest.adaptTo(AutoTranslateListModel.class);
-    String id = model.createRun().id;
-    response.sendRedirect("run.html/" + id);
+    try {
+        SlingHttpServletRequest slingRequest = (SlingHttpServletRequest) request;
+        AutoTranslateListModel model = slingRequest.adaptTo(AutoTranslateListModel.class);
+        String id = model.createRun().id;
+        response.sendRedirect("run.html/" + id);
+    } catch (Exception e) {
+%>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Error during translation</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body class="coral--light foundation-layout-util-maximized-alt">
+<div class="foundation-layout-panel">
+    <div class="foundation-layout-panel-bodywrapper spectrum-ready">
+        <div class="foundation-layout-panel-body">
+            <div class="foundation-layout-panel-content foundation-layout-form foundation-layout-form-mode-edit">
+                <div class="cq-dialog-content-page">
+                    <p>Error: <%= e.toString() %>
+                    </p>
+                    <pre>
+                        <%
+                            out.flush();
+                            e.printStackTrace(response.getWriter());
+                        %>
+                    </pre>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>
+<%
+    }
 %>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslate/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslate/list/list.html
@@ -83,9 +83,17 @@
                                                           name="additionalInstructions" value=""
                                                           labelledby="label-vertical-textarea-1"></textarea>
                                             </div>
-                                            <button type="submit" class="coral-Button coral-Button--primary">Start
-                                                Translation
-                                                Process
+                                            <div class="coral-Form-fieldwrapper">
+                                                <label class="coral-Form-fieldlabel" for="selectmodel">Model</label>
+                                                <coral-select class="coral-Form-field _coral-Dropdown" name="translationmodel"
+                                                              placeholder="" variant="default">
+                                                    <coral-select-item value="default" selected="">default</coral-select-item>
+                                                    <coral-select-item value="standard">Standard</coral-select-item>
+                                                    <coral-select-item value="highintelligence">High</coral-select-item>
+                                                </coral-select>
+                                            </div>
+                                            <button type="submit" class="coral-Button coral-Button--primary">
+                                                Start Translation Process
                                             </button>
                                         </div>
                                     </section>

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTConfiguration.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTConfiguration.java
@@ -119,22 +119,35 @@ public class GPTConfiguration {
     /**
      * Creates a configuration that joins the values.
      *
-     * @throws IllegalArgumentException if values conflict
+     * @throws IllegalArgumentException if values conflict - that's checked for apiKey and organizationId and answerType.
      */
     public GPTConfiguration merge(@Nullable GPTConfiguration other) throws IllegalArgumentException {
+        return merge(other, false);
+    }
+
+    /**
+     * Creates a configuration that joins the values.
+     *
+     * @param override if true, values set in this configuration will override values set in the other configuration.
+     *                 Otherwise, a conflict will throw an exception.
+     * @param other    the other configuration to merge with (optional)
+     * @throws IllegalArgumentException if values conflict
+     * @return a new configuration
+     */
+    public GPTConfiguration merge(@Nullable GPTConfiguration other, boolean override) throws IllegalArgumentException {
         if (other == null) {
             return this;
         }
         String apiKey = this.apiKey != null ? this.apiKey : other.apiKey;
-        if (this.apiKey != null && other.apiKey != null && !this.apiKey.equals(other.apiKey)) {
+        if (!override && this.apiKey != null && other.apiKey != null && !this.apiKey.equals(other.apiKey)) {
             throw new IllegalArgumentException("Cannot merge conflicting API keys: " + this.apiKey + " vs. " + other.apiKey);
         }
         String organizationId = this.organizationId != null ? this.organizationId : other.organizationId;
-        if (this.organizationId != null && other.organizationId != null && !this.organizationId.equals(other.organizationId)) {
+        if (!override && this.organizationId != null && other.organizationId != null && !this.organizationId.equals(other.organizationId)) {
             throw new IllegalArgumentException("Cannot merge conflicting organization ids: " + this.organizationId + " vs. " + other.organizationId);
         }
         AnswerType answerType = this.answerType != null ? this.answerType : other.answerType;
-        if (this.answerType != null && other.answerType != null && !this.answerType.equals(other.answerType)) {
+        if (!override && this.answerType != null && other.answerType != null && !this.answerType.equals(other.answerType)) {
             throw new IllegalArgumentException("Cannot merge conflicting answer types: " + this.answerType + " vs. " + other.answerType);
         }
         String additionalInstructions = this.additionalInstructions == null ? other.additionalInstructions :
@@ -193,6 +206,10 @@ public class GPTConfiguration {
      * Requests slower and more expensive "high intelligence" model - use sparingly.
      */
     public static final GPTConfiguration HIGH_INTELLIGENCE = new GPTConfiguration(null, null, null, null, null, true);
+    /**
+     * Requests faster and less expensive "normal intelligence" model.
+     */
+    public static final GPTConfiguration STANDARD_INTELLIGENCE = new GPTConfiguration(null, null, null, null, null, false);
 
     @Override
     public boolean equals(Object o) {


### PR DESCRIPTION
This adds an option in the POC UI and the CA configuration for automatic translation to use the normal or "high intelligence" model, to be able to easily compare GPT-3.5 / GPT-4 translations on one system.