### PR TITLE
Check links during translation

### DIFF
--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
@@ -6,6 +6,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -35,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import com.composum.ai.aem.core.impl.SelectorUtils;
 import com.composum.ai.backend.base.service.chat.GPTConfiguration;
+import com.composum.ai.backend.base.service.chat.GPTResponseCheck;
 import com.composum.ai.backend.base.service.chat.GPTTranslationService;
 import com.composum.ai.backend.slingbase.AIConfigurationService;
 import com.day.cq.wcm.api.WCMException;
@@ -147,7 +149,8 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
                 .collect(Collectors.toList());
 
         List<String> translatedValues =
-                translationService.fragmentedTranslation(valuesToTranslate, languageName, configuration);
+                translationService.fragmentedTranslation(valuesToTranslate, languageName, configuration,
+                        Collections.singletonList(GPTResponseCheck.KEEP_HREF_TRANSLATION_CHECK));
 
         Map<String, LiveRelationship> relationships = new HashMap<>();
 

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/_cq_dialog/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/contentcreation/_cq_dialog/.content.xml
@@ -259,11 +259,6 @@
                             sling:resourceType="granite/ui/components/coral/foundation/actionbar">
                         <primary
                                 jcr:primaryType="nt:unstructured">
-                            <dictate
-                                    jcr:primaryType="nt:unstructured" icon="stage"
-                                    sling:resourceType="granite/ui/components/coral/foundation/button"
-                                    granite:title="Dictate your prompt to the AI: while pressed, audio is recorded and after releasing the button it's transcribed and inserted into the prompt."
-                                    text="Dictate" granite:class="composum-ai-dictate-button hide"/>
                             <generate
                                     jcr:primaryType="nt:unstructured" icon="play"
                                     sling:resourceType="granite/ui/components/coral/foundation/button"
@@ -280,6 +275,11 @@
                                     granite:class="composum-ai-reset-button"
                                     granite:title="Resets the form to the state when you opened it."
                                     text="Reset"/>
+                            <dictate
+                                    jcr:primaryType="nt:unstructured" icon="stage"
+                                    sling:resourceType="granite/ui/components/coral/foundation/button"
+                                    granite:title="Dictate your prompt to the AI: while pressed, audio is recorded and after releasing the button it's transcribed and inserted into the prompt."
+                                    text="Dictate" granite:class="composum-ai-dictate-button hide"/>
                             <textlengthLabel
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="granite/ui/components/foundation/text"

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/sidepanel-ai/_cq_dialog/.content.xml
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/sidepanel-ai/_cq_dialog/.content.xml
@@ -103,12 +103,6 @@
                                     sling:resourceType="granite/ui/components/coral/foundation/actionbar">
                                 <primary
                                         jcr:primaryType="nt:unstructured">
-                                    <dictate
-                                            jcr:primaryType="nt:unstructured"
-                                            icon="stage"
-                                            sling:resourceType="granite/ui/components/coral/foundation/button"
-                                            granite:title="Dictate your prompt to the AI: while pressed, audio is recorded and after releasing the button it's transcribed and inserted into the prompt."
-                                            granite:class="composum-ai-dictate-button hide"/>
                                     <generate
                                             jcr:primaryType="nt:unstructured" icon="play"
                                             sling:resourceType="granite/ui/components/coral/foundation/button"
@@ -124,6 +118,12 @@
                                             sling:resourceType="granite/ui/components/coral/foundation/button"
                                             granite:class="composum-ai-reset-button"
                                             granite:title="Resets the form to the state when you opened it."/>
+                                    <dictate
+                                            jcr:primaryType="nt:unstructured"
+                                            icon="stage"
+                                            sling:resourceType="granite/ui/components/coral/foundation/button"
+                                            granite:title="Dictate your prompt to the AI: while pressed, audio is recorded and after releasing the button it's transcribed and inserted into the prompt."
+                                            granite:class="composum-ai-dictate-button hide"/>
                                     <help
                                             jcr:primaryType="nt:unstructured" icon="help"
                                             sling:resourceType="granite/ui/components/coral/foundation/button"

--- a/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
+++ b/aem/ui.frontend/src/main/webpack/site/ContentCreationDialog.js
@@ -61,7 +61,8 @@ class ContentCreationDialog {
         this.bindActions();
         this.createServlet = new AICreate(this.streamingCallback.bind(this), this.doneCallback.bind(this), this.errorCallback.bind(this));
         this.dictate = new AIDictate(this.$dialog.find('.composum-ai-dictate-button'),
-            this.$prompt, this.onPromptChanged.bind(this)
+            this.$prompt, this.onPromptChanged.bind(this),
+            this.showError.bind(this)
         );
         const historyPath = property ? componentPath + '/' + property : componentPath;
         if (!historyMap[historyPath]) {

--- a/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
+++ b/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
@@ -35,7 +35,7 @@ try {
          * Loads the Sidebar Panel AI if it wasn't loaded already and if there's a sidebar present.
          */
         function loadSidebarPanelDialog() {
-            if (true) console.log("loadSidebarPanelDialog", arguments);
+            if (debug) console.log("loadSidebarPanelDialog", arguments);
             try {
                 const url = SIDEPANEL_DIALOG_URL + "?path=" + encodeURIComponent(aiconfig.getContentURL());
                 aiconfig.ifEnabled(SERVICE_SIDEPANEL, undefined, () => {

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTResponseCheck.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTResponseCheck.java
@@ -24,6 +24,23 @@ public interface GPTResponseCheck {
     @Nullable
     String responseProblem(@Nonnull String source, @Nonnull String translation);
 
+    /**
+     * Finds problems of translation wrt. source and any of the checks.
+     */
+    static String collectResponseProblems(@Nullable List<GPTResponseCheck> checks, @Nullable String source, @Nullable String translation) {
+        if (checks == null || source == null || translation == null) {
+            // source / translation null is a doubful thing here, but the problem is not in the response check.
+            return null;
+        }
+        StringBuilder problems = new StringBuilder();
+        for (GPTResponseCheck check : checks) {
+            String problem = check.responseProblem(source, translation);
+            if (problem != null) {
+                problems.append(problem.trim()).append("\n\n");
+            }
+        }
+        return problems.length() > 0 ? "\n\n" + problems.toString() : null;
+    }
 
     /**
      * A check that all href attributes in richtext appear in the translation.

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTResponseCheck.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTResponseCheck.java
@@ -1,0 +1,71 @@
+package com.composum.ai.backend.base.service.chat;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An additional check that verifies whether the translation was carried out right - such as paths in HTML weren't translated.
+ */
+public interface GPTResponseCheck {
+
+    /**
+     * Performs a check, and if the check fails it returns additional instructions with which the request is retried.
+     *
+     * @return null if the response is fine, otherwise the additional instructions to fix the response (possibly an empty string).
+     */
+    @Nullable
+    String responseProblem(@Nonnull String source, @Nonnull String translation);
+
+
+    /**
+     * A check that all href attributes in richtext appear in the translation.
+     * Sometimes the GPT translates paths containing recognizable words, so we check that the set of HREFs in the
+     * original is the same as the set of HREFs in the translation.
+     */
+    static GPTResponseCheck KEEP_HREF_TRANSLATION_CHECK = new GPTResponseCheck() {
+
+        private final Pattern HREF_PATTERN = Pattern.compile("href=\"([^\" ]*)\"");
+
+        @Nullable
+        @Override
+        public String responseProblem(@Nonnull String source, @Nonnull String translation) {
+            Set<String> sourceHrefs = findHrefs(source);
+            if (sourceHrefs.isEmpty()) { // not applicable
+                return null;
+            }
+            Set<String> translationHrefs = findHrefs(translation);
+            if (!sourceHrefs.equals(translationHrefs)) {
+                Set<String> missingHrefs = new HashSet<>(sourceHrefs);
+                missingHrefs.removeAll(translationHrefs);
+                List<String> examples = new ArrayList<>();
+                if (!missingHrefs.isEmpty()) {
+                    missingHrefs.stream().limit(3).sorted().forEach(examples::add);
+                } else { // strange, but we add some random examples from sourceHrefs
+                    sourceHrefs.stream().limit(3).sorted().forEach(examples::add);
+                }
+                return "CAUTION: Do not translate or change absolute or relative URLs in href attributes in HTML links, such as " +
+                        examples.stream().collect(Collectors.joining(", "))
+                        + " .";
+            }
+            return null;
+        }
+
+        private Set<String> findHrefs(String text) {
+            Set<String> hrefs = new HashSet<>();
+            Matcher matcher = HREF_PATTERN.matcher(text);
+            while (matcher.find() && matcher.group().length() < 200) { // if too long then probably something is broken.
+                hrefs.add(matcher.group());
+            }
+            return hrefs;
+        }
+    };
+
+}

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTTranslationService.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTTranslationService.java
@@ -34,6 +34,21 @@ public interface GPTTranslationService {
      * @return the translated texts
      */
     @Nonnull
-    List<String> fragmentedTranslation(@Nonnull List<String> texts, @Nonnull String targetLanguage, @Nullable GPTConfiguration configuration) throws GPTException;
+    default List<String> fragmentedTranslation(@Nonnull List<String> texts, @Nonnull String targetLanguage, @Nullable GPTConfiguration configuration) throws GPTException {
+        return fragmentedTranslation(texts, targetLanguage, configuration, null);
+    }
+
+    /**
+     * Translates the texts into the target language. The texts should belong together, like e.g. the texts of a page,
+     * since the translations might influence each other. (We try to translate them in one request.)
+     *
+     * @param texts             the texts to translate
+     * @param targetLanguage    the language to translate to - human readable name
+     * @param configuration     the configuration to use
+     * @param translationChecks additional checks to verify the translation
+     * @return the translated texts
+     */
+    List<String> fragmentedTranslation(@Nonnull List<String> texts, @Nonnull String targetLanguage, @Nullable GPTConfiguration configuration,
+                                       @Nullable List<GPTResponseCheck> translationChecks) throws GPTException;
 
 }

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTTranslationService.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTTranslationService.java
@@ -14,6 +14,10 @@ public interface GPTTranslationService {
 
     /**
      * Translate the text from the target to destination language, either Java locale name or language name.
+     * @param text the text to translate
+     * @param sourceLanguage the language to translate from - human readable name, or null for autodetect
+     * @param targetLanguage the language to translate to - human readable name
+     * @param configuration the configuration to use
      */
     @Nullable
     String singleTranslation(@Nullable String text, @Nullable String sourceLanguage, @Nullable String targetLanguage, @Nullable GPTConfiguration configuration) throws GPTException;

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/GPTTranslationServiceImpl.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/GPTTranslationServiceImpl.java
@@ -38,6 +38,7 @@ import com.composum.ai.backend.base.service.chat.GPTChatRequest;
 import com.composum.ai.backend.base.service.chat.GPTCompletionCallback;
 import com.composum.ai.backend.base.service.chat.GPTConfiguration;
 import com.composum.ai.backend.base.service.chat.GPTFinishReason;
+import com.composum.ai.backend.base.service.chat.GPTResponseCheck;
 import com.composum.ai.backend.base.service.chat.GPTTranslationService;
 
 /**
@@ -160,7 +161,8 @@ public class GPTTranslationServiceImpl implements GPTTranslationService {
      */
     @Nonnull
     @Override
-    public List<String> fragmentedTranslation(@Nonnull List<String> texts, @Nonnull String targetLanguage, @Nullable GPTConfiguration configuration) throws GPTException {
+    public List<String> fragmentedTranslation(@Nonnull List<String> texts, @Nonnull String targetLanguage, @Nullable GPTConfiguration configuration,
+                                              @Nullable List<GPTResponseCheck> translationChecks) throws GPTException {
         ensureEnabled();
         if (texts == null || texts.isEmpty()) {
             return Collections.emptyList();

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/GPTTranslationServiceImpl.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/GPTTranslationServiceImpl.java
@@ -37,6 +37,7 @@ import com.composum.ai.backend.base.service.chat.GPTChatMessage;
 import com.composum.ai.backend.base.service.chat.GPTChatRequest;
 import com.composum.ai.backend.base.service.chat.GPTCompletionCallback;
 import com.composum.ai.backend.base.service.chat.GPTConfiguration;
+import com.composum.ai.backend.base.service.chat.GPTContentCreationService;
 import com.composum.ai.backend.base.service.chat.GPTFinishReason;
 import com.composum.ai.backend.base.service.chat.GPTResponseCheck;
 import com.composum.ai.backend.base.service.chat.GPTTranslationService;
@@ -178,7 +179,7 @@ public class GPTTranslationServiceImpl implements GPTTranslationService {
         if (config.fakeTranslation()) {
             translatedRealTexts = realTexts.stream().map(GPTTranslationServiceImpl::fakeTranslation).collect(Collectors.toList());
         } else {
-            translatedRealTexts = fragmentedTranslationDivideAndConquer(realTexts, targetLanguage, configuration, new AtomicInteger(10));
+            translatedRealTexts = fragmentedTranslationDivideAndConquer(realTexts, targetLanguage, configuration, new AtomicInteger(10), translationChecks);
         }
 
         Map<String, String> translatedRealTextsMap = new LinkedHashMap<>();
@@ -211,10 +212,10 @@ public class GPTTranslationServiceImpl implements GPTTranslationService {
      * We try to translate the whole lot of texts. If that leads to an exception because we are out of tokens or the response was garbled, we split it into two and translate these individually. If even one text is too long, we are lost and give up.
      */
     protected List<String> fragmentedTranslationDivideAndConquer(@Nonnull List<String> texts, @Nonnull String targetLanguage,
-                                                                 @Nullable GPTConfiguration configuration, @Nonnull AtomicInteger permittedRetries) throws GPTException {
+                                                                 @Nullable GPTConfiguration configuration, @Nonnull AtomicInteger permittedRetries, List<GPTResponseCheck> translationChecks) throws GPTException {
         if (texts.isEmpty()) {
             return Collections.emptyList();
-        } else if (texts.size() == 1) {
+        } else if (texts.size() == 1 && (translationChecks == null || translationChecks.isEmpty())) {
             return Collections.singletonList(singleTranslation(texts.get(0), null, targetLanguage, configuration));
         }
 
@@ -224,7 +225,7 @@ public class GPTTranslationServiceImpl implements GPTTranslationService {
         }
 
         try {
-            return fragmentedTranslation(texts, targetLanguage, configuration, permittedRetries);
+            return fragmentedTranslation(texts, targetLanguage, configuration, permittedRetries, translationChecks);
         } catch (GPTException.GPTRetryableResponseErrorException e) {
             // is hopefully rare - otherwise we likely have to rethink this.
             LOG.info("Splitting translation because of retryable error: {}", e.toString());
@@ -240,13 +241,14 @@ public class GPTTranslationServiceImpl implements GPTTranslationService {
         List<String> firstHalf = texts.subList(0, half);
         List<String> secondHalf = texts.subList(half, texts.size());
         List<String> result = new ArrayList<>();
-        result.addAll(fragmentedTranslationDivideAndConquer(firstHalf, targetLanguage, configuration, permittedRetries));
-        result.addAll(fragmentedTranslationDivideAndConquer(secondHalf, targetLanguage, configuration, permittedRetries));
+        result.addAll(fragmentedTranslationDivideAndConquer(firstHalf, targetLanguage, configuration, permittedRetries, translationChecks));
+        result.addAll(fragmentedTranslationDivideAndConquer(secondHalf, targetLanguage, configuration, permittedRetries, translationChecks));
         return result;
     }
 
     protected List<String> fragmentedTranslation(@Nonnull List<String> texts, @Nonnull String targetLanguage,
-                                                 @Nullable GPTConfiguration configuration, @Nonnull AtomicInteger permittedRetries) throws GPTException {
+                                                 @Nullable GPTConfiguration configuration, @Nonnull AtomicInteger permittedRetries,
+                                                 @Nullable List<GPTResponseCheck> translationChecks) throws GPTException {
         if (texts == null || texts.isEmpty()) {
             return Collections.emptyList();
         }
@@ -255,6 +257,16 @@ public class GPTTranslationServiceImpl implements GPTTranslationService {
         String joinedtexts = joinTexts(texts, ids);
 
         String response = singleTranslation(joinedtexts, null, targetLanguage, configuration);
+        String responseProblems;
+        while((responseProblems = GPTResponseCheck.collectResponseProblems(translationChecks, joinedtexts, response)) != null) {
+            if (permittedRetries.decrementAndGet() <= 0) {
+                LOG.error("Too many retries with response problems for fragmented translation, to {} found problems {} text {}", targetLanguage, responseProblems, texts);
+                throw new GPTException("Too many retries for fragmented translation, response problems: " + responseProblems);
+            }
+            GPTConfiguration fixupInstructions = GPTConfiguration.ofAdditionalInstructions(responseProblems);
+            GPTConfiguration retryConfig = configuration != null ? configuration.merge(fixupInstructions) : fixupInstructions;
+            response = singleTranslation(joinedtexts, null, targetLanguage, retryConfig);
+        }
 
         return separateResultTexts(response, texts, ids, joinedtexts);
     }

--- a/backend/base/src/main/resources/chattemplates/chatgpt/singletranslation.txt
+++ b/backend/base/src/main/resources/chattemplates/chatgpt/singletranslation.txt
@@ -1,7 +1,7 @@
 # Translate a single word or phrase
 ---------- system ----------
 As a professional translator, your job is to translate texts as faithfully as possible, preserving the style, tone, and feeling of the original, while taking into account linguistic and cultural nuances so that the resulting text feels natural to a native speaker.
-All formatting elements (markup, HTML tags, special characters) should be retained as much as possible. URLs and hyperlinks (href attribute in HTML anchor elements) MUST be preserved as they are.
+All formatting elements (markup, HTML tags, special characters) should be retained as much as possible. URLs and hyperlinks (`href` attribute in HTML anchor elements) MUST be preserved as they are, but do translate `title` HTML attributes in HTML anchor elements.
 IMPORTANT: Provide only the translated text, retaining all original formatting and non-translatable elements. Avoid any extraneous comments or actions not directly related to the translation.  Do not add or remove anything from the original text.
 ---------- user ----------
 Print the original text you have to translate exactly without any comments.

--- a/backend/base/src/main/resources/chattemplates/chatgpt/singletranslation.txt
+++ b/backend/base/src/main/resources/chattemplates/chatgpt/singletranslation.txt
@@ -1,7 +1,8 @@
 # Translate a single word or phrase
 ---------- system ----------
-You are tasked as an expert translator to translate texts with utmost fidelity, preserving the original style, tone, sentiment, and all formatting elements (markdown, HTML tags, special characters) to the greatest extent possible.
-IMPORTANT: Only provide the translated text, maintaining all original formatting and non-translatable elements. Avoid any extraneous comments or actions not directly related to the translation.  Do not add anything to the original text, or leave out anything.
+As a professional translator, your job is to translate texts as faithfully as possible, preserving the style, tone, and feeling of the original, while taking into account linguistic and cultural nuances so that the resulting text feels natural to a native speaker.
+All formatting elements (markup, HTML tags, special characters) should be retained as much as possible. URLs and hyperlinks (href attribute in HTML anchor elements) MUST be preserved as they are.
+IMPORTANT: Provide only the translated text, retaining all original formatting and non-translatable elements. Avoid any extraneous comments or actions not directly related to the translation.  Do not add or remove anything from the original text.
 ---------- user ----------
 Print the original text you have to translate exactly without any comments.
 ---------- assistant ----------

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/GPTResponseCheckTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/GPTResponseCheckTest.java
@@ -8,9 +8,12 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+/**
+ * Mostly tests for {@link GPTResponseCheck#KEEP_HREF_TRANSLATION_CHECK}.
+ */
 public class GPTResponseCheckTest {
 
-    public static final String CAUTIONMSG = "CAUTION: Do not translate or change absolute or relative URLs in href attributes in HTML links, such as";
+    public static final String CAUTIONMSG = "CAUTION: Do not translate or change absolute or relative URLs in href attributes in HTML links, such as ";
 
     @Test
     public void responseProblem_noHrefsInSource_returnsNull() {
@@ -33,7 +36,7 @@ public class GPTResponseCheckTest {
         String result = KEEP_HREF_TRANSLATION_CHECK.responseProblem(source, translation);
         assertNotNull(result);
         assertTrue(result.contains(CAUTIONMSG));
-        assertEquals( CAUTIONMSG + " href=\"http://example.com\" .", result);
+        assertEquals(CAUTIONMSG + " href=\"http://example.com\" .", result);
     }
 
     @Test
@@ -48,7 +51,7 @@ public class GPTResponseCheckTest {
     @Test
     public void responseProblem_longHref_ignoresHref() {
         String longlong = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        String source = "<a href=\"" + longlong + longlong + longlong  + "\">Link</a>";
+        String source = "<a href=\"" + longlong + longlong + longlong + "\">Link</a>";
         String translation = "Missing but no report";
         assertNull(KEEP_HREF_TRANSLATION_CHECK.responseProblem(source, translation));
     }

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/GPTResponseCheckTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/GPTResponseCheckTest.java
@@ -1,0 +1,69 @@
+package com.composum.ai.backend.base.service.chat;
+
+import static com.composum.ai.backend.base.service.chat.GPTResponseCheck.KEEP_HREF_TRANSLATION_CHECK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class GPTResponseCheckTest {
+
+    public static final String CAUTIONMSG = "CAUTION: Do not translate or change absolute or relative URLs in href attributes in HTML links, such as";
+
+    @Test
+    public void responseProblem_noHrefsInSource_returnsNull() {
+        String source = "<p>No links here</p>";
+        String translation = "<p>Keine Links hier</p>";
+        assertNull(KEEP_HREF_TRANSLATION_CHECK.responseProblem(source, translation));
+    }
+
+    @Test
+    public void responseProblem_matchingHrefs_returnsNull() {
+        String source = "<a href=\"http://example.com\">Link</a>";
+        String translation = "<a href=\"http://example.com\">Link</a>";
+        assertNull(KEEP_HREF_TRANSLATION_CHECK.responseProblem(source, translation));
+    }
+
+    @Test
+    public void responseProblem_missingHrefs_returnsWarning() {
+        String source = "<a href=\"http://example.com\">Link</a>";
+        String translation = "<a href=\"http://beispiel.com\">Link</a>";
+        String result = KEEP_HREF_TRANSLATION_CHECK.responseProblem(source, translation);
+        assertNotNull(result);
+        assertTrue(result.contains(CAUTIONMSG));
+        assertEquals( CAUTIONMSG + " href=\"http://example.com\" .", result);
+    }
+
+    @Test
+    public void responseProblem_extraHrefsInTranslation_returnsWarning() {
+        String source = "<a href=\"http://example.com\">Link</a>";
+        String translation = "<a href=\"http://example.com\">Link</a><a href=\"http://extra.com\">Extra</a>";
+        String result = KEEP_HREF_TRANSLATION_CHECK.responseProblem(source, translation);
+        assertNotNull(result);
+        assertTrue(result.contains(CAUTIONMSG));
+    }
+
+    @Test
+    public void responseProblem_longHref_ignoresHref() {
+        String longlong = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        String source = "<a href=\"" + longlong + longlong + longlong  + "\">Link</a>";
+        String translation = "Missing but no report";
+        assertNull(KEEP_HREF_TRANSLATION_CHECK.responseProblem(source, translation));
+    }
+
+    @Test
+    public void realExampleReport() {
+        String source = "<h2>Strong focus on customer orientation</h2><p>We combine <a title=\"Automation, manufacturing and connection technologies\" href=\"/content/site/es/es-es/technologies.html\" target=\"_self\" rel=\"noopener noreferrer\">resources</a>, technology and <a href=\"http://www.example.net/intelligent/products/and/solutions\" target=\"_blank\" title=\"intelligent products and solutions\">people</a> to jointly create a positive change</p>";
+        String correctTranslation = "<h2>Starke Fokussierung auf Kundenorientierung</h2><p>Wir verbinden <a title=\"Automations-, Fertigungs- und Verbindungstechnologien\" href=\"/content/site/es/es-es/technologies.html\" target=\"_self\" rel=\"noopener noreferrer\">Ressourcen</a>, Technologie und <a href=\"http://www.example.net/intelligent/products/and/solutions\" target=\"_blank\" title=\"intelligenter Produkte und Lösungen\">Menschen</a>, um gemeinsam einen positiven Wandel</p>";
+        String result = KEEP_HREF_TRANSLATION_CHECK.responseProblem(source, correctTranslation);
+        assertNull(result);
+
+        String brokenTranslation = "<h2>Starke Fokussierung auf Kundenorientierung</h2><p>Wir verbinden <a title=\"Automations-, Fertigungs- und Verbindungstechnologien\" href=\"/content/site/es/es-es/Technologien.html\" target=\"_self\" rel=\"noopener noreferrer\">Ressourcen</a>, Technologie und <a href=\"http://www.example.net/intelligent/produkte/und/loesungen\" target=\"_blank\" title=\"intelligenter Produkte und Lösungen\">Menschen</a>, um gemeinsam einen positiven Wandel</p>";
+        result = KEEP_HREF_TRANSLATION_CHECK.responseProblem(source, brokenTranslation);
+        assertEquals(CAUTIONMSG +
+                " href=\"/content/site/es/es-es/technologies.html\", href=\"http://www.example.net/intelligent/products/and/solutions\" .", result);
+    }
+
+}

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/GPTResponseCheckTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/GPTResponseCheckTest.java
@@ -36,7 +36,7 @@ public class GPTResponseCheckTest {
         String result = KEEP_HREF_TRANSLATION_CHECK.responseProblem(source, translation);
         assertNotNull(result);
         assertTrue(result.contains(CAUTIONMSG));
-        assertEquals(CAUTIONMSG + " href=\"http://example.com\" .", result);
+        assertEquals(CAUTIONMSG + "href=\"http://example.com\" .", result);
     }
 
     @Test
@@ -66,7 +66,7 @@ public class GPTResponseCheckTest {
         String brokenTranslation = "<h2>Starke Fokussierung auf Kundenorientierung</h2><p>Wir verbinden <a title=\"Automations-, Fertigungs- und Verbindungstechnologien\" href=\"/content/site/es/es-es/Technologien.html\" target=\"_self\" rel=\"noopener noreferrer\">Ressourcen</a>, Technologie und <a href=\"http://www.example.net/intelligent/produkte/und/loesungen\" target=\"_blank\" title=\"intelligenter Produkte und Lösungen\">Menschen</a>, um gemeinsam einen positiven Wandel</p>";
         result = KEEP_HREF_TRANSLATION_CHECK.responseProblem(source, brokenTranslation);
         assertEquals(CAUTIONMSG +
-                " href=\"/content/site/es/es-es/technologies.html\", href=\"http://www.example.net/intelligent/products/and/solutions\" .", result);
+                "href=\"/content/site/es/es-es/technologies.html\", href=\"http://www.example.net/intelligent/products/and/solutions\" .", result);
     }
 
 }

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/RunGPTMultiTranslationServiceImpl.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/RunGPTMultiTranslationServiceImpl.java
@@ -28,7 +28,7 @@ public class RunGPTMultiTranslationServiceImpl extends AbstractGPTRunner {
         // checkTranslation(Arrays.asList());
         // checkTranslation(Arrays.asList("Hi!", "Good morning"));
         checkTranslation(Arrays.asList("Hi!", "Good morning", "How are you?", "More", "Let's translate as translate can."), null);
-        String richtext = "<h2>Strong focus on customer orientation</h2><p>We combine <a title=\"Automation, manufacturing and connection technologies\" href=\"/content/site/es/es-es/technologies.html\" target=\"_self\" rel=\"noopener noreferrer\">resources</a>, technology and <a href=\"http://www.example.net/intelligent/products/and/solutions\" target=\"_blank\" title=\"intelligent products and solutions\">people</a> to jointly create a positive change</p>";
+        String richtext = "<h2>Strong focus on customer orientation</h2><p>We combine <a title=\"Automation, manufacturing and connection technologies\" href=\"/content/site/es/es-es/technologies.html\" title=\"our technologies summary page\" target=\"_self\" rel=\"noopener noreferrer\">resources</a>, technology and <a href=\"http://www.example.net/intelligent/products/and/solutions\" target=\"_blank\" title=\"intelligent products and solutions\">people</a> to jointly create a positive change</p>";
         checkTranslation(Arrays.asList(richtext), GPTResponseCheck.KEEP_HREF_TRANSLATION_CHECK);
         if (0 == 1) {
             List<String> veryLongArray = new ArrayList<>();

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/RunGPTMultiTranslationServiceImpl.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/RunGPTMultiTranslationServiceImpl.java
@@ -3,9 +3,12 @@ package com.composum.ai.backend.base.service.chat.impl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.mockito.Mockito;
+
+import com.composum.ai.backend.base.service.chat.GPTResponseCheck;
 
 /**
  * Tries an actual call to ChatGPT. Since that costs money (though much less than a cent), needs a secret key and takes a couple of seconds,
@@ -24,21 +27,23 @@ public class RunGPTMultiTranslationServiceImpl extends AbstractGPTRunner {
     private void run() {
         // checkTranslation(Arrays.asList());
         // checkTranslation(Arrays.asList("Hi!", "Good morning"));
-        checkTranslation(Arrays.asList("Hi!", "Good morning", "How are you?", "More", "Let's translate as translate can."));
+        checkTranslation(Arrays.asList("Hi!", "Good morning", "How are you?", "More", "Let's translate as translate can."), null);
         String richtext = "<h2>Strong focus on customer orientation</h2><p>We combine <a title=\"Automation, manufacturing and connection technologies\" href=\"/content/site/es/es-es/technologies.html\" target=\"_self\" rel=\"noopener noreferrer\">resources</a>, technology and <a href=\"http://www.example.net/intelligent/products/and/solutions\" target=\"_blank\" title=\"intelligent products and solutions\">people</a> to jointly create a positive change</p>";
-        checkTranslation(Arrays.asList(richtext));
+        checkTranslation(Arrays.asList(richtext), GPTResponseCheck.KEEP_HREF_TRANSLATION_CHECK);
         if (0 == 1) {
             List<String> veryLongArray = new ArrayList<>();
             for (int i = 0; i < 30; i++) { // Well, it doesn't hit the token limit anymore.
                 veryLongArray.add("This is a very long text intended to hit the token limit and lead to a complaint by ChatGPT and see what happens then.");
             }
-            checkTranslation(veryLongArray);
+            checkTranslation(veryLongArray, null);
         }
         System.out.println("DONE");
     }
 
-    private List<String> checkTranslation(List<String> totranslate) {
-        List<String> result = translationService.fragmentedTranslation(totranslate, "de", null);
+    private List<String> checkTranslation(List<String> totranslate, GPTResponseCheck responseCheck) {
+        List<GPTResponseCheck> checks = responseCheck != null ? Collections.singletonList(responseCheck) : null;
+        List<String> result = translationService.fragmentedTranslation(totranslate, "de",
+                null, checks);
         System.out.println("translation of\n" + totranslate + "\nto de:\n" + result + "\n\n");
         return result;
     }

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/RunGPTMultiTranslationServiceImpl.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/RunGPTMultiTranslationServiceImpl.java
@@ -7,8 +7,6 @@ import java.util.List;
 
 import org.mockito.Mockito;
 
-import com.composum.ai.backend.base.service.chat.GPTConfiguration;
-
 /**
  * Tries an actual call to ChatGPT. Since that costs money (though much less than a cent), needs a secret key and takes a couple of seconds,
  * we don't do that as an JUnit test.
@@ -27,9 +25,11 @@ public class RunGPTMultiTranslationServiceImpl extends AbstractGPTRunner {
         // checkTranslation(Arrays.asList());
         // checkTranslation(Arrays.asList("Hi!", "Good morning"));
         checkTranslation(Arrays.asList("Hi!", "Good morning", "How are you?", "More", "Let's translate as translate can."));
-        if (0 == 0) {
+        String richtext = "<h2>Strong focus on customer orientation</h2><p>We combine <a title=\"Automation, manufacturing and connection technologies\" href=\"/content/site/es/es-es/technologies.html\" target=\"_self\" rel=\"noopener noreferrer\">resources</a>, technology and <a href=\"http://www.example.net/intelligent/products/and/solutions\" target=\"_blank\" title=\"intelligent products and solutions\">people</a> to jointly create a positive change</p>";
+        checkTranslation(Arrays.asList(richtext));
+        if (0 == 1) {
             List<String> veryLongArray = new ArrayList<>();
-            for (int i = 0; i < 30; i++) {
+            for (int i = 0; i < 30; i++) { // Well, it doesn't hit the token limit anymore.
                 veryLongArray.add("This is a very long text intended to hit the token limit and lead to a complaint by ChatGPT and see what happens then.");
             }
             checkTranslation(veryLongArray);

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIDictationServlet.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/AIDictationServlet.java
@@ -122,6 +122,7 @@ public class AIDictationServlet extends SlingAllMethodsServlet {
      */
     @Override
     protected void doPost(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws ServletException, IOException {
+        LOG.info(">>> Dictation request on " + request.getRequestPathInfo().getSuffix());
         try {
             String suffix = request.getRequestPathInfo().getSuffix();
             GPTConfiguration config = null;
@@ -151,6 +152,8 @@ public class AIDictationServlet extends SlingAllMethodsServlet {
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             response.setContentType("text/plain");
             response.getWriter().write("Error: " + e);
+        } finally {
+            LOG.info("<<< Dictation request on " + request.getRequestPathInfo().getSuffix());
         }
     }
 


### PR DESCRIPTION
When there are links in translated richtext we check that they are also present in the output since it happened in some cases that the links themselves (relative links containing english words) were translated. If there are differences we add an instruction such as

`CAUTION: Do not translate or change absolute or relative URLs in href attributes in HTML links, such as href="http://www.example.net/"`

while the URL is replaced by the actual missing URL(s) from the text.

There are also some fixes for the dictation mechanism.