### PR TITLE
Improve translation template to admit already translated parts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,27 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
-# version: 2
-# updates:
-#   - package-ecosystem: "maven" # See documentation for possible values
-#     directory: "/" # Location of package manifests
-#     schedule:
-#       interval: "monthly"
+ version: 2
+ updates:
+   - package-ecosystem: "maven" # See documentation for possible values
+     directory: "/" # Location of package manifests
+     schedule:
+       interval: "daily"
 #     ignore:
 #       - dependency-name: "*"
 #         update-types: ["version-update:semver-major"]
+     open-pull-requests-limit: 50
+
+   - package-ecosystem: "npm"
+     directory: "/"
+     schedule:
+       interval: "monthly"
+     open-pull-requests-limit: 0
+
 #   - package-ecosystem: "npm"
+#     schedule:
+#       interval: "monthly"
 #     ignore:
+#       # Disable version updates for npm dependencies since that's from the AEM archetype and not embedded, anyway.
 #       - dependency-name: "*"
+#     open-pull-requests-limit: 0

--- a/backend/base/src/main/resources/chattemplates/chatgpt/singletranslation.txt
+++ b/backend/base/src/main/resources/chattemplates/chatgpt/singletranslation.txt
@@ -1,6 +1,7 @@
 # Translate a single word or phrase
 ---------- system ----------
 As a professional translator, your job is to translate texts as faithfully as possible, preserving the style, tone, and feeling of the original, while taking into account linguistic and cultural nuances so that the resulting text feels natural to a native speaker.
+If parts of the original text is already in ${targetlanguage} then do not translate them - just print them as they are.
 All formatting elements (markup, HTML tags, special characters) should be retained as much as possible. URLs and hyperlinks (`href` attribute in HTML anchor elements) MUST be preserved as they are, but do translate `title` HTML attributes in HTML anchor elements.
 IMPORTANT: Provide only the translated text, retaining all original formatting and non-translatable elements. Avoid any extraneous comments or actions not directly related to the translation.  Do not add or remove anything from the original text.
 ---------- user ----------
@@ -8,4 +9,7 @@ Print the original text you have to translate exactly without any comments.
 ---------- assistant ----------
 ${sourcephrase}
 ---------- user ----------
-Print the original text translated into ${targetlanguage}. ${addition}
+Print the original text translated into ${targetlanguage}.
+If parts of the text are already in ${targetlanguage}, then do not translate them.
+
+${addition}


### PR DESCRIPTION
Otherwise it happened that these were translated back to the source language instead of being left in the source language.
The duplications were necessary for gpt-4o-mini