### PR TITLE
Include already translated texts as additional context for translation

### DIFF
--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
@@ -164,8 +164,7 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
             List<String> translatedValues =
                     translationService.fragmentedTranslation(valuesToTranslate, languageName, configuration,
                             Collections.singletonList(GPTResponseCheck.KEEP_HREF_TRANSLATION_CHECK));
-            translatedValues = remapPaths(translatedValues, relationship.getLiveCopy().getBlueprintPath(), relationship.getLiveCopy().getPath()
-            );
+            translatedValues = remapPaths(translatedValues, relationship.getLiveCopy().getBlueprintPath(), relationship.getLiveCopy().getPath());
 
             // Already translated text is given as example.
             String alreadyTranslatedText = propertiesToTranslate.stream()
@@ -174,7 +173,7 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
                     .collect(Collectors.joining("\n"));
             if (StringUtils.isNotBlank(alreadyTranslatedText)) {
                 configuration = configuration.merge(GPTConfiguration.ofContext(
-                        "This was the result of a previous translation. You can draw on that for translation examples and context of the translation.",
+                        "Print a result of a previous translation of parts of the text. You can draw on that for translation examples and context of the translation.",
                         alreadyTranslatedText));
             }
 

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
@@ -1,5 +1,8 @@
 package com.composum.ai.aem.core.impl.autotranslate;
 
+import static com.composum.ai.backend.base.service.chat.impl.GPTTranslationServiceImpl.LASTID;
+import static com.composum.ai.backend.base.service.chat.impl.GPTTranslationServiceImpl.MULTITRANSLATION_SEPARATOR_END;
+import static com.composum.ai.backend.base.service.chat.impl.GPTTranslationServiceImpl.MULTITRANSLATION_SEPARATOR_START;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -168,8 +171,12 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
                     .collect(Collectors.joining("\n"));
             if (autoTranslateConfigService.includeExistingTranslationsInRetranslation() && StringUtils.isNotBlank(alreadyTranslatedText)) {
                 configuration = configuration.merge(GPTConfiguration.ofContext(
-                        "Print a result of a previous translation of parts of the text. You can draw on that for translation examples and context of the translation.",
-                        alreadyTranslatedText));
+                        "Retrieve the result of a previous translation of parts of the text. You don't need to translate this - this is just contextual information and you can draw on that for translation examples and context of the translation that is done later.",
+                        // we have to follow the final format or that is confusing for the AI
+                        MULTITRANSLATION_SEPARATOR_START + LASTID + MULTITRANSLATION_SEPARATOR_END +
+                                alreadyTranslatedText +
+                                MULTITRANSLATION_SEPARATOR_START + LASTID + MULTITRANSLATION_SEPARATOR_END
+                ));
             }
 
             List<String> translatedValues =

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
@@ -167,6 +167,17 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
             translatedValues = remapPaths(translatedValues, relationship.getLiveCopy().getBlueprintPath(), relationship.getLiveCopy().getPath()
             );
 
+            // Already translated text is given as example.
+            String alreadyTranslatedText = propertiesToTranslate.stream()
+                    .filter(p -> p.isAlreadyCorrectlyTranslated)
+                    .map(PropertyToTranslate::getTargetValue)
+                    .collect(Collectors.joining("\n"));
+            if (StringUtils.isNotBlank(alreadyTranslatedText)) {
+                configuration = configuration.merge(GPTConfiguration.ofContext(
+                        "This was the result of a previous translation. You can draw on that for translation examples and context of the translation.",
+                        alreadyTranslatedText));
+            }
+
             Map<String, LiveRelationship> relationships = new HashMap<>();
 
             for (int i = 0; i < propertiesToTranslate.size(); i++) {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateCaConfig.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateCaConfig.java
@@ -21,4 +21,17 @@ public @interface AutoTranslateCaConfig {
     @Property(label = "Rules that give additional instructions for translation if certain words or phrases are present in the page.")
     AutoTranslateRuleConfig[] rules() default {};
 
+    @Property(label = "Include Full Page during Retranslation",
+            description = "If true we do not only provide changed texts to the AI during re-translating a page with some changes," +
+                    "but give the entire page to provide better context. That is a bit slower and a bit more expensive, but likely" +
+                    "improves the result. This overrides the default from OSGI configuration.")
+    boolean[] includeFullPageInRetranslation();
+
+    @Property(label = "Include Existing Translations in Retranslation",
+            description = "If true, when retranslating a page with some changes we provide" +
+                    "the existing translations of that page to the AI as well as additional context with examples. " +
+                    "That is a bit slower and a bit more expensive, but likely improves the result." +
+                    "This overrides the default from OSGI configuration.")
+    boolean[] includeExistingTranslationsInRetranslation() default true;
+
 }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateConfig.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateConfig.java
@@ -45,11 +45,16 @@ public @interface AutoTranslateConfig {
             description = "If true, the translator will use the 'high-intelligence model' (see OpenAI config) for translation. Default: true.")
     boolean useHighIntelligenceModel() default true;
 
-    @AttributeDefinition(name = "Include Already Translated Values",
-            description = "If a page is re-translated with only a few modified texts: " +
-                    "If true we include the source texts that do not have to be translated, too, " +
-                    "to provide better context to the translation; otherwise " +
-                    "we only include the texts that have to be translated.")
-    boolean includeAlreadyTranslatedValues() default true;
+    @AttributeDefinition(name = "Include Full Page during Retranslation",
+            description = "If true we do not only provide changed texts to the AI during re-translating a page with some changes," +
+                    "but give the entire page to provide better context. That is a bit slower and a bit more expensive, but likely" +
+                    "improves the result.")
+    boolean includeFullPageInRetranslation() default true;
+
+    @AttributeDefinition(name = "Include Existing Translations in Retranslation",
+            description = "If true, when retranslating a page with some changes we provide" +
+                    "the existing translations of that page to the AI as well as additional context with examples. " +
+                    "That is a bit slower and a bit more expensive, but likely improves the result.")
+    boolean includeExistingTranslationsInRetranslation() default true;
 
 }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateConfigService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateConfigService.java
@@ -31,12 +31,16 @@ public interface AutoTranslateConfigService {
     List<String> translateableAttributes(@Nullable Resource resource);
 
     /**
-     * If true, we do not only provide changed texts to the AI during re-translating a page with some changes, but give the entire page to provide better context. That is a bit slower and a bit more expensive, but likely improves the result.
+     * If true, we do not only provide changed texts to the AI during re-translating a page with some changes,
+     * but give the entire page to provide better context.
+     * That is a bit slower and a bit more expensive, but likely improves the result.
      */
     boolean includeFullPageInRetranslation();
 
     /**
-     * If true, we when retranslating a page with some changes we provide the existing translations of that page to the AI as well as additional context with examples. That is a bit slower and a bit more expensive, but likely improves the result."
+     * If true, we when retranslating a page with some changes we provide the existing translations of that page
+     * to the AI as well as additional context with examples.
+     * That is a bit slower and a bit more expensive, but likely improves the result."
      */
     boolean includeExistingTranslationsInRetranslation();
 

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateConfigService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateConfigService.java
@@ -31,11 +31,13 @@ public interface AutoTranslateConfigService {
     List<String> translateableAttributes(@Nullable Resource resource);
 
     /**
-     * If a page is re-translated with only a few modified texts:
-     * If true we include the source texts that do not have to be translated, too,
-     * to provide better context to the translation; otherwise
-     * we only include the texts that have to be translated.
+     * If true, we do not only provide changed texts to the AI during re-translating a page with some changes, but give the entire page to provide better context. That is a bit slower and a bit more expensive, but likely improves the result.
      */
-    boolean includeAlreadyTranslatedValues();
+    boolean includeFullPageInRetranslation();
+
+    /**
+     * If true, we when retranslating a page with some changes we provide the existing translations of that page to the AI as well as additional context with examples. That is a bit slower and a bit more expensive, but likely improves the result."
+     */
+    boolean includeExistingTranslationsInRetranslation();
 
 }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateConfigServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateConfigServiceImpl.java
@@ -168,8 +168,13 @@ public class AutoTranslateConfigServiceImpl implements AutoTranslateConfigServic
     }
 
     @Override
-    public boolean includeAlreadyTranslatedValues() {
-        return config == null || config.includeAlreadyTranslatedValues();
+    public boolean includeFullPageInRetranslation() {
+        return config == null || config.includeFullPageInRetranslation();
+    }
+
+    @Override
+    public boolean includeExistingTranslationsInRetranslation() {
+        return config == null || config.includeExistingTranslationsInRetranslation();
     }
 
     /**

--- a/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImplTest.java
+++ b/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImplTest.java
@@ -2,6 +2,7 @@ package com.composum.ai.aem.core.impl.autotranslate;
 
 
 import static com.composum.ai.aem.core.impl.autotranslate.AutoPageTranslateServiceImpl.compileContentPattern;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -11,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -165,5 +167,48 @@ public class AutoPageTranslateServiceImplTest {
         assertEquals(null,
                 service.remapPaths((String) null, "/content/blueprint", "/content/livecopy"));
     }
+
+    @Test
+    public void expandSelection_includesContextBeforeAndAfter() {
+        boolean[] includeIndizes = {false, false, true, false, false};
+        AutoPageTranslateServiceImpl.expandSelection(includeIndizes, 2);
+        assertArrayEquals(new boolean[]{true, true, true, true, true}, includeIndizes);
+    }
+
+    @Test
+    public void expandSelection_noInitialSelection() {
+        boolean[] includeIndizes = {false, false, false, false, false};
+        AutoPageTranslateServiceImpl.expandSelection(includeIndizes, 2);
+        assertArrayEquals(new boolean[]{false, false, false, false, false}, includeIndizes);
+    }
+
+    @Test
+    public void expandSelection_singleSelectionAtStart() {
+        boolean[] includeIndizes = {true, false, false, false, false};
+        AutoPageTranslateServiceImpl.expandSelection(includeIndizes, 2);
+        assertArrayEquals(new boolean[]{true, true, true, false, false}, includeIndizes);
+    }
+
+    @Test
+    public void expandSelection_singleSelectionAtEnd() {
+        boolean[] includeIndizes = {false, false, false, false, true};
+        AutoPageTranslateServiceImpl.expandSelection(includeIndizes, 2);
+        assertArrayEquals(new boolean[]{false, false, true, true, true}, includeIndizes);
+    }
+
+    @Test
+    public void expandSelection_multipleSelections() {
+        boolean[] includeIndizes = {false, true, false, true, false};
+        AutoPageTranslateServiceImpl.expandSelection(includeIndizes, 2);
+        assertArrayEquals(new boolean[]{true, true, true, true, true}, includeIndizes);
+    }
+
+    @Test
+    public void expandSelection_long() {
+        boolean[] includeIndizes = {false, false, false, true, false, true, false, false, false};
+        AutoPageTranslateServiceImpl.expandSelection(includeIndizes, 2);
+        assertArrayEquals(new boolean[]{false, true, true, true, true, true, true, true, false}, includeIndizes);
+    }
+
 
 }

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTConfiguration.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTConfiguration.java
@@ -227,8 +227,22 @@ public class GPTConfiguration {
         if (other.contexts != null) {
             contextInfos.addAll(other.contexts);
         }
-        contextInfos = contextInfos.isEmpty() ? null : contextInfos;
+        contextInfos = contextInfos.isEmpty() ? null : Collections.unmodifiableList(contextInfos);
         return new GPTConfiguration(apiKey, organizationId, answerType, additionalInstructions, mode, highIntelligenceNeeded, debug, temperature, seed, contextInfos);
+    }
+
+    /**
+     * Additional context information to provide to the AI. Not actual instructions, just background information.
+     */
+    public List<GPTContextInfo> getContexts() {
+        return contexts;
+    }
+
+    /**
+     * Returns a copy with the contexts replaced.
+     */
+    public GPTConfiguration replaceContexts(List<GPTContextInfo> newContexts) {
+        return new GPTConfiguration(apiKey, organizationId, answerType, additionalInstructions, mode, highIntelligenceNeeded, debug, temperature, seed, newContexts);
     }
 
     /**
@@ -258,8 +272,8 @@ public class GPTConfiguration {
     }
 
     @Nonnull
-    public static GPTConfiguration ofContext(@Nonnull String title, @Nonnull String text) {
-        return ofContexts(Collections.singletonList(new GPTContextInfo(title, text)));
+    public static GPTConfiguration ofContext(@Nonnull String usermsg, @Nonnull String assistantmsg) {
+        return ofContexts(Collections.singletonList(new GPTContextInfo(usermsg, assistantmsg)));
     }
 
     @Override
@@ -332,32 +346,31 @@ public class GPTConfiguration {
 
 
     /**
-     * Something that gives background information to the AI that isn't actually an instruction, like informative texts, RAG results, whatnot.
-     * Contains a title and a text.
+     * Gives the conversation a history - additional assistant - user message pair.
      */
     public static class GPTContextInfo {
 
-        private final String title;
-        private final String text;
+        private final String userMsg;
+        private final String assistantMsg;
 
-        public GPTContextInfo(String title, String text) {
-            this.title = title;
-            this.text = text;
+        public GPTContextInfo(String title, String assistantMsg) {
+            this.userMsg = title;
+            this.assistantMsg = assistantMsg;
         }
 
         public String getTitle() {
-            return title;
+            return userMsg;
         }
 
         public String getText() {
-            return text;
+            return assistantMsg;
         }
 
         @Override
         public String toString() {
             return "GPTContextInfo{" +
-                    "title='" + title + '\'' +
-                    ", text='" + text + '\'' +
+                    "userMsg='" + userMsg + '\'' +
+                    ", assistantMsg='" + assistantMsg + '\'' +
                     '}';
         }
 

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTConfiguration.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/GPTConfiguration.java
@@ -1,5 +1,8 @@
 package com.composum.ai.backend.base.service.chat;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
@@ -52,9 +55,12 @@ public class GPTConfiguration {
 
     private final Boolean debug;
 
-    private Double temperature;
+    private final Double temperature;
 
-    private Integer seed;
+    private final Integer seed;
+
+    private final List<GPTContextInfo> contexts;
+
 
     public GPTConfiguration(@Nullable String apiKey, @Nullable String organizationId, @Nullable AnswerType answerType) {
         this(apiKey, organizationId, answerType, null);
@@ -81,6 +87,10 @@ public class GPTConfiguration {
     }
 
     public GPTConfiguration(@Nullable String apiKey, @Nullable String organizationId, @Nullable AnswerType answerType, @Nullable String additionalInstructions, @Nullable Mode mode, @Nullable Boolean highIntelligenceNeeded, @Nullable Boolean debug, @Nullable Double temperature, @Nullable Integer seed) {
+        this(apiKey, organizationId, answerType, additionalInstructions, mode, highIntelligenceNeeded, debug, temperature, seed, null);
+    }
+
+    public GPTConfiguration(@Nullable String apiKey, @Nullable String organizationId, @Nullable AnswerType answerType, @Nullable String additionalInstructions, @Nullable Mode mode, @Nullable Boolean highIntelligenceNeeded, @Nullable Boolean debug, @Nullable Double temperature, @Nullable Integer seed, @Nullable List<GPTContextInfo> contexts) {
         this.apiKey = apiKey;
         this.answerType = answerType;
         this.organizationId = organizationId;
@@ -90,6 +100,7 @@ public class GPTConfiguration {
         this.debug = debug;
         this.temperature = temperature;
         this.seed = seed;
+        this.contexts = contexts;
     }
 
     /**
@@ -209,7 +220,15 @@ public class GPTConfiguration {
         }
         Double temperature = this.temperature != null ? this.temperature : other.temperature;
         Integer seed = this.seed != null ? this.seed : other.seed;
-        return new GPTConfiguration(apiKey, organizationId, answerType, additionalInstructions, mode, highIntelligenceNeeded, debug, temperature, seed);
+        List<GPTContextInfo> contextInfos = new ArrayList<>();
+        if (this.contexts != null) {
+            contextInfos.addAll(this.contexts);
+        }
+        if (other.contexts != null) {
+            contextInfos.addAll(other.contexts);
+        }
+        contextInfos = contextInfos.isEmpty() ? null : contextInfos;
+        return new GPTConfiguration(apiKey, organizationId, answerType, additionalInstructions, mode, highIntelligenceNeeded, debug, temperature, seed, contextInfos);
     }
 
     /**
@@ -231,6 +250,16 @@ public class GPTConfiguration {
     @Nonnull
     public static GPTConfiguration ofAdditionalInstructions(@Nullable String additionalInstructions) {
         return new GPTConfiguration(null, null, null, additionalInstructions);
+    }
+
+    @Nonnull
+    public static GPTConfiguration ofContexts(@Nullable List<GPTContextInfo> contexts) {
+        return new GPTConfiguration(null, null, null, null, null, null, null, null, null, contexts);
+    }
+
+    @Nonnull
+    public static GPTConfiguration ofContext(@Nonnull String title, @Nonnull String text) {
+        return ofContexts(Collections.singletonList(new GPTContextInfo(title, text)));
     }
 
     @Override
@@ -262,6 +291,9 @@ public class GPTConfiguration {
         }
         if (seed != null) {
             sb.append(", seed=").append(seed);
+        }
+        if (contexts != null) {
+            sb.append(", contexts=").append(contexts);
         }
         return sb.append('}').toString();
     }
@@ -297,4 +329,51 @@ public class GPTConfiguration {
     public int hashCode() {
         return Objects.hash(getApiKey(), getAnswerType());
     }
+
+
+    /**
+     * Something that gives background information to the AI that isn't actually an instruction, like informative texts, RAG results, whatnot.
+     * Contains a title and a text.
+     */
+    public static class GPTContextInfo {
+
+        private final String title;
+        private final String text;
+
+        public GPTContextInfo(String title, String text) {
+            this.title = title;
+            this.text = text;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        @Override
+        public String toString() {
+            return "GPTContextInfo{" +
+                    "title='" + title + '\'' +
+                    ", text='" + text + '\'' +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof GPTContextInfo)) return false;
+            GPTContextInfo that = (GPTContextInfo) o;
+            return Objects.equals(getTitle(), that.getTitle()) && Objects.equals(getText(), that.getText());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getTitle(), getText());
+        }
+
+    }
+
 }

--- a/backend/base/src/main/resources/chattemplates/chatgpt/singletranslation.txt
+++ b/backend/base/src/main/resources/chattemplates/chatgpt/singletranslation.txt
@@ -8,6 +8,6 @@ Print the original text you have to translate exactly without any comments.
 ---------- assistant ----------
 ${sourcephrase}
 ---------- user ----------
-Print the original text translated into ${targetlanguage}.
+Translate the original text you just printed into ${targetlanguage}.
 
 ${addition}


### PR DESCRIPTION
If not disabled we will add the already translated text of a page as context to the translation if it's a re-translation where only a few texts are changed, and will also add some surrounding context to the translated text, or even the complete page if that's configured.