### PR TITLE
Translation Review Tool

### DIFF
--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePlugin.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/AemApproximateMarkdownServicePlugin.java
@@ -409,7 +409,7 @@ public class AemApproximateMarkdownServicePlugin implements ApproximateMarkdownS
             return Collections.emptyList();
         }
         try {
-            LiveRelationship liveRelationship = liveRelationshipManager.getLiveRelationship(resource, false);
+            LiveRelationship liveRelationship = liveRelationshipManager.getLiveRelationship(resource, true);
             if (liveRelationship != null) {
                 String masterPath = liveRelationship.getSourcePath();
                 Resource master = masterPath != null ? resource.getResourceResolver().getResource(masterPath) : null;

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/ComponentCancellationHelper.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/ComponentCancellationHelper.java
@@ -121,7 +121,7 @@ public class ComponentCancellationHelper {
             LOG.warn("Bug: source resource {} not found for {}", relationship.getSourcePath(), resource.getPath());
             return;
         }
-        if (isContainer(resource)) {
+        if (!isContainer(resource)) {
             for (Resource child : resource.getChildren()) {
                 adjustPropertiesReenableInheritance(liveRelationshipManager, child);
             }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/ComponentCancellationHelper.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/ComponentCancellationHelper.java
@@ -5,8 +5,10 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import org.apache.commons.collections4.IterableUtils;
+import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,6 +123,16 @@ public class ComponentCancellationHelper {
             LOG.warn("Bug: source resource {} not found for {}", relationship.getSourcePath(), resource.getPath());
             return;
         }
+
+        ValueMap sourceValueMap = source.getValueMap();
+        ModifiableValueMap targetValueMap = resource.adaptTo(ModifiableValueMap.class);
+        for (AITranslatePropertyWrapper wrapper : AITranslatePropertyWrapper.allProps(sourceValueMap, targetValueMap)) {
+            if (!relationship.getStatus().isCancelled() &&
+                    !relationship.getStatus().getCanceledProperties().contains(wrapper.getPropertyName())) {
+                wrapper.adjustForReenableInheritance();
+            }
+        }
+
         if (!isContainer(resource)) {
             for (Resource child : resource.getChildren()) {
                 adjustPropertiesReenableInheritance(liveRelationshipManager, child);

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/ComponentCancellationHelper.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/ComponentCancellationHelper.java
@@ -1,0 +1,118 @@
+package com.composum.ai.aem.core.impl;
+
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.collections4.IterableUtils;
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.composum.ai.aem.core.impl.autotranslate.AITranslatePropertyWrapper;
+import com.day.cq.wcm.api.WCMException;
+import com.day.cq.wcm.msm.api.LiveRelationship;
+import com.day.cq.wcm.msm.api.LiveRelationshipManager;
+
+/**
+ * Wrapper around {@link org.apache.sling.api.resource.Resource} that wraps operations around cancelling / reenabling inheritance.
+ */
+public class ComponentCancellationHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ComponentCancellationHelper.class);
+
+    /**
+     * Checks whether a resource has a sling:resourceType that is of type cq:Component.
+     */
+    public static boolean isComponent(@Nonnull Resource resource) {
+        return "cq:Component".equals(resource.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE, String.class));
+    }
+
+    public static boolean isPageContent(@Nonnull Resource resource) {
+        return "cq:PageContent".equals(resource.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE, String.class));
+    }
+
+    public static boolean isPage(@Nonnull Resource resource) {
+        return "cq:Page".equals(resource.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE, String.class));
+    }
+
+    /**
+     * Finds next higher cq:Component in the resource tree, or the cq:PageContent if that is the next higher component.
+     */
+    public static Resource findNextHigherCancellableComponent(@Nonnull Resource resource) {
+        if (isComponent(resource) || isPageContent(resource)) {
+            return resource;
+        }
+        if (isPage(resource)) {
+            return null;
+        }
+        Resource parent = resource.getParent();
+        return parent == null ? null : findNextHigherCancellableComponent(parent);
+    }
+
+    /**
+     * Tries to guess whether the resource is actually a container (where inheritance cancelling is shallow only.)
+     * We guess this if the sling:resourceType has "cq:isContainer" true, or heuristics match:
+     * if it has a lonely "items" child or one of its children or childrens children is a component.
+     */
+    public static boolean isContainer(@Nonnull Resource resource) {
+        if (!isComponent(resource)) {
+            return false;
+        }
+        List<Resource> children = IterableUtils.toList(resource.getChildren());
+        if (children.size() == 1 && children.get(0).getName().equals("items")) {
+            return true; // this is a guess, but likely right.
+        }
+        String resourceType = resource.getValueMap().get("sling:resourceType", String.class);
+        ResourceResolver resolver = resource.getResourceResolver();
+        Resource resourceTypeResource = resolver.getResource(resourceType);
+        if (resourceTypeResource == null) { // should be impossible
+            LOG.warn("Bug: Resource type {} not found for ", resourceType, resource.getPath());
+            return false;
+        }
+        Resource overrideResource = resolver.getResource("/mnt/override" + resourceTypeResource.getPath());
+        if (overrideResource == null) {
+            LOG.warn("Bug: can't find override resource for {}", resourceTypeResource.getPath());
+            overrideResource = resourceTypeResource;
+        }
+        boolean hasIsContainer = overrideResource.getValueMap().get("cq:isContainer", false);
+        if (hasIsContainer) {
+            return true;
+        }
+        // if one of the children is a component, we assume this is a container.
+        for (Resource child : children) {
+            if (isComponent(child)) {
+                return true;
+            }
+        }
+        // if one of the children's children is a component, we assume this is a container.
+        for (Resource child : children) {
+            if (IterableUtils.matchesAny(child.getChildren(), ComponentCancellationHelper::isComponent)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * We call {@link AITranslatePropertyWrapper#adjustForReenableInheritance()} on all properties that are *not* cancelled now.
+     */
+    public static void adjustPropertiesReenableInheritance(LiveRelationshipManager liveRelationshipManager, Resource resource) throws WCMException {
+        LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, true);
+        if (relationship == null) {
+            return;
+        }
+        Resource source = resource.getResourceResolver().getResource(relationship.getSourcePath());
+        if (source == null) { // shouldn't happen
+            LOG.warn("Bug: source resource {} not found for {}", relationship.getSourcePath(), resource.getPath());
+            return;
+        }
+        if (isContainer(resource)) {
+            for (Resource child : resource.getChildren()) {
+                adjustPropertiesReenableInheritance(liveRelationshipManager, child);
+            }
+        }
+    }
+}

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapper.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapper.java
@@ -387,9 +387,9 @@ public class AITranslatePropertyWrapper {
     }
 
     @Nonnull
-    public List<AITranslatePropertyWrapper> allProps(@Nonnull ValueMap sourceValueMap, @Nonnull ModifiableValueMap targetValueMap) {
+    public static List<AITranslatePropertyWrapper> allProps(@Nonnull ValueMap sourceValueMap, @Nonnull ModifiableValueMap targetValueMap) {
         return targetValueMap.keySet().stream()
-                .filter(key -> !isAiTranslateProperty(key))
+                .filter(key -> isAiTranslateProperty(key))
                 .map(key -> decodePropertyName(AI_PREFIX, key, AI_ORIGINAL_SUFFIX, targetValueMap))
                 .filter(Objects::nonNull)
                 .map(key -> new AITranslatePropertyWrapper(sourceValueMap, targetValueMap, key))

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapper.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapper.java
@@ -84,7 +84,7 @@ public class AITranslatePropertyWrapper {
     public static final String AI_NEW_TRANSLATED_SUFFIX = "_new_translated";
 
     /**
-     * Suffix for the property name of a property with uncancelled inheritance that saves the source language for the
+     * Suffix for the property name of a property with enabled inheritance that saves the source language for the
      * value the user has last accepted in the AI merge tool.
      *
      * @see #AI_ACCEPTED_TRANSLATION_SUFFIX
@@ -92,7 +92,7 @@ public class AITranslatePropertyWrapper {
     public static final String AI_ACCEPTED_SOURCE_SUFFIX = "_accepted_source";
 
     /**
-     * Suffix for the property name of a property with uncancelled inheritance that saves the (auto translated)
+     * Suffix for the property name of a property with enabled inheritance that saves the (auto translated)
      * property value when the user last accepted it in the AI merge tool.
      *
      * @see #AI_ACCEPTED_SOURCE_SUFFIX

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapper.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapper.java
@@ -12,6 +12,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
@@ -333,4 +334,9 @@ public class AITranslatePropertyWrapper {
         return null;
     }
 
+
+    @Override
+    public String toString() {
+        return "AITranslatePropertyWrapper(" + propertyName + ')';
+    }
 }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapper.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapper.java
@@ -12,7 +12,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
@@ -70,14 +69,35 @@ public class AITranslatePropertyWrapper {
 
     /**
      * Suffix for the property name of an inheritance cancelled property that saves the original value of the property
-     * as it is currently in the translation source, as an indicator what needs to be merged.
+     * as it is currently in the translation source during rollout, heping with the merge.
+     *
+     * @see #AI_NEW_TRANSLATED_SUFFIX
      */
     public static final String AI_NEW_ORIGINAL_SUFFIX = "_new_original";
 
     /**
-     * Suffix for the property name of an inheritance cancelled property that saves the
+     * Suffix for the property name of an inheritance cancelled property that saves the auto-translated value of the
+     * property during rollout - needs to be merged with the current value.
+     *
+     * @see #AI_NEW_ORIGINAL_SUFFIX
      */
     public static final String AI_NEW_TRANSLATED_SUFFIX = "_new_translated";
+
+    /**
+     * Suffix for the property name of a property with uncancelled inheritance that saves the source language for the
+     * value the user has last accepted in the AI merge tool.
+     *
+     * @see #AI_ACCEPTED_TRANSLATION_SUFFIX
+     */
+    public static final String AI_ACCEPTED_SOURCE_SUFFIX = "_accepted_source";
+
+    /**
+     * Suffix for the property name of a property with uncancelled inheritance that saves the (auto translated)
+     * property value when the user last accepted it in the AI merge tool.
+     *
+     * @see #AI_ACCEPTED_SOURCE_SUFFIX
+     */
+    public static final String AI_ACCEPTED_TRANSLATION_SUFFIX = "_accepted_translation";
 
     /**
      * Attribute that is set on jcr:content of a page when the translation of a page failed, to make it easy to find such pages. Not set by {@link AITranslatePropertyWrapper}, but since all property names are defined here...
@@ -162,6 +182,34 @@ public class AITranslatePropertyWrapper {
      */
     public void setNewTranslatedCopy(String value) {
         setValue(encodePropertyName(AI_PREFIX, propertyName, AI_NEW_TRANSLATED_SUFFIX), value);
+    }
+
+    /**
+     * @see #AI_ACCEPTED_SOURCE_SUFFIX
+     */
+    public String getAcceptedSource() {
+        return targetValueMap.get(encodePropertyName(AI_PREFIX, propertyName, AI_ACCEPTED_SOURCE_SUFFIX), String.class);
+    }
+
+    /**
+     * @see #AI_ACCEPTED_SOURCE_SUFFIX
+     */
+    public void setAcceptedSource(String value) {
+        setValue(encodePropertyName(AI_PREFIX, propertyName, AI_ACCEPTED_SOURCE_SUFFIX), value);
+    }
+
+    /**
+     * @see #AI_ACCEPTED_TRANSLATION_SUFFIX
+     */
+    public String getAcceptedTranslation() {
+        return targetValueMap.get(encodePropertyName(AI_PREFIX, propertyName, AI_ACCEPTED_TRANSLATION_SUFFIX), String.class);
+    }
+
+    /**
+     * @see #AI_ACCEPTED_TRANSLATION_SUFFIX
+     */
+    public void setAcceptedTranslation(String value) {
+        setValue(encodePropertyName(AI_PREFIX, propertyName, AI_ACCEPTED_TRANSLATION_SUFFIX), value);
     }
 
     private void setValue(String key, String value) {
@@ -279,6 +327,8 @@ public class AITranslatePropertyWrapper {
                 encodePropertyName(AI_PREFIX, propertyName, AI_TRANSLATED_SUFFIX),
                 encodePropertyName(AI_PREFIX, propertyName, AI_NEW_ORIGINAL_SUFFIX),
                 encodePropertyName(AI_PREFIX, propertyName, AI_NEW_TRANSLATED_SUFFIX),
+                encodePropertyName(AI_PREFIX, propertyName, AI_ACCEPTED_SOURCE_SUFFIX),
+                encodePropertyName(AI_PREFIX, propertyName, AI_ACCEPTED_TRANSLATION_SUFFIX)
         };
     }
 

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoPageTranslateServiceImpl.java
@@ -105,7 +105,7 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
             resource = child;
         }
         Stats stats = new Stats();
-        LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, false);
+        LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, true);
         if (relationship == null) {
             throw new IllegalArgumentException("No live relationship for " + resource.getPath());
         }
@@ -196,7 +196,7 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
 
                     LiveRelationship liveRelationship = relationships.get(propertyToTranslate.targetResource.getPath());
                     if (liveRelationship == null) {
-                        liveRelationship = liveRelationshipManager.getLiveRelationship(propertyToTranslate.targetResource, false);
+                        liveRelationship = liveRelationshipManager.getLiveRelationship(propertyToTranslate.targetResource, true);
                         relationships.put(propertyToTranslate.targetResource.getPath(), liveRelationship);
                     }
 
@@ -211,7 +211,7 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
 
             if (additionalInstructionsChanged) {
                 ModifiableValueMap mvm = requireNonNull(resource.adaptTo(ModifiableValueMap.class));
-                LiveRelationship liveRelationship = liveRelationshipManager.getLiveRelationship(resource, false);
+                LiveRelationship liveRelationship = liveRelationshipManager.getLiveRelationship(resource, true);
                 liveRelationshipManager.cancelPropertyRelationship(resource.getResourceResolver(),
                         liveRelationship, new String[]{AITranslatePropertyWrapper.PROPERTY_AI_ADDINSTRUCTIONS}, false);
                 if (additionalInstructions == null) {
@@ -225,7 +225,7 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
             boolean pathsChanged = migratePathsToLanguageCopy(resource, language, stats);
             changed = pathsChanged || changed;
             if (changed) {
-                markAsAiTranslated(resource, liveRelationshipManager.getLiveRelationship(resource, false), translationParameters, configuration);
+                markAsAiTranslated(resource, liveRelationshipManager.getLiveRelationship(resource, true), translationParameters, configuration);
             }
             if (translationParameters.autoSave) {
                 resource.getResourceResolver().commit();
@@ -457,7 +457,7 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
                                 targetWrapper.setLcOriginal(value);
                             }
                             targetWrapper.setLcTranslated(languageCopy.getPath());
-                            LiveRelationship liveRelationship = liveRelationshipManager.getLiveRelationship(resource, false);
+                            LiveRelationship liveRelationship = liveRelationshipManager.getLiveRelationship(resource, true);
                             liveRelationshipManager.cancelPropertyRelationship(resource.getResourceResolver(),
                                     liveRelationship, targetWrapper.allLcKeys(), false);
                             changed = true;
@@ -474,7 +474,7 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
 
     protected void cancelInheritance(Resource resource, Resource resourceToTranslate, PropertyToTranslate propertyToTranslate) throws WCMException {
         try {
-            LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resourceToTranslate, false);
+            LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resourceToTranslate, true);
             if (relationship == null) {
                 // a bit doubtful, but this way everything is revertable.
                 throw new IllegalArgumentException("No live relationship for translated path " + resourceToTranslate.getPath());
@@ -552,7 +552,7 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
             }
             if (reenable) {
                 if (relationship == null) { // on demand since expensive calculation
-                    relationship = liveRelationshipManager.getLiveRelationship(resource, false);
+                    relationship = liveRelationshipManager.getLiveRelationship(resource, true);
                 }
                 reenableInheritance(resource, key, relationship);
             }
@@ -586,7 +586,7 @@ public class AutoPageTranslateServiceImpl implements AutoPageTranslateService {
             @Nonnull Resource resource, @Nonnull List<PropertyToTranslate> propertiesToTranslate, @Nonnull Stats stats,
             @Nonnull AutoTranslateService.TranslationParameters translationParameters, boolean force) throws WCMException {
         boolean changed = false;
-        LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, false);
+        LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, true);
         if (relationship == null) {
             LOG.warn("No live relationship for {}", resource.getPath());
             return false;

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
@@ -81,7 +81,7 @@ public class AutoTranslateMergeModel {
             case INHERITANCE_CANCELLED:
                 properties.removeIf(property -> !property.isCancelled());
                 break;
-            case INHERITANCE_UNCANCELLED:
+            case INHERITANCE_ENABLED:
                 properties.removeIf(AutoTranslateMergeService.AutoTranslateProperty::isCancelled);
                 break;
             case ALL_PROPERTIES:
@@ -223,7 +223,7 @@ public class AutoTranslateMergeModel {
     public enum PropertyFilter {
         ALL_PROPERTIES("allstati"),
         INHERITANCE_CANCELLED("cancelled"),
-        INHERITANCE_UNCANCELLED("uncancelled");
+        INHERITANCE_ENABLED("inheritanceenabled");
 
         private final String value;
 

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
@@ -1,8 +1,13 @@
 package com.composum.ai.aem.core.impl.autotranslate;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.request.RequestPathInfo;
 import org.apache.sling.api.resource.Resource;
@@ -40,6 +45,19 @@ public class AutoTranslateMergeModel {
         return autoTranslateMergeService.getProperties(getPageResource());
     }
 
+    public List<AutoTranslateComponent> getPageComponents() {
+        Map<String, AutoTranslateComponent> components = new LinkedHashMap<>();
+        for (AutoTranslateMergeService.AutoTranslateProperty property : getProperties()) {
+            AutoTranslateComponent component = components.get(property.getComponentPath());
+            if (component == null) {
+                component = new AutoTranslateComponent(property.getComponentPath());
+                components.put(component.getComponentPathInPage(), component);
+            }
+            component.getCheckableProperties().add(property);
+        }
+        return new ArrayList<>(components.values());
+    }
+
     public String getPageLanguage() {
         String language = SelectorUtils.findLanguage(getPageResource());
         return language != null ? SelectorUtils.getLanguageName(language, Locale.ENGLISH) : null;
@@ -64,6 +82,32 @@ public class AutoTranslateMergeModel {
 
     public String getPagePath() {
         return getPageResource() != null ? getPageResource().getParent().getPath() : null;
+    }
+
+    public static class AutoTranslateComponent {
+        private final String componentPath;
+        private final List<AutoTranslateMergeService.AutoTranslateProperty> properties = new ArrayList<>();
+
+        public AutoTranslateComponent(String componentPath) {
+            this.componentPath = componentPath;
+        }
+
+        public String getComponentName() {
+            return properties.isEmpty() ? null : properties.get(0).getComponentName();
+        }
+
+        public String getComponentTitle() {
+            return properties.isEmpty() ? null : properties.get(0).getComponentTitle();
+        }
+
+        public String getComponentPathInPage() {
+            return StringUtils.substringAfter(componentPath, "/jcr:content/");
+        }
+
+        public List<AutoTranslateMergeService.AutoTranslateProperty> getCheckableProperties() {
+            return properties;
+        }
+
     }
 
 }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
@@ -54,6 +54,13 @@ public class AutoTranslateMergeModel {
      */
     protected static final String PARAM_COMPONENTPATH = "componentpath";
 
+    /**
+     * Parameter that limits output to just that property - for specific reloading.
+     *
+     * @see #PARAM_COMPONENTPATH
+     */
+    protected static final String PARAM_PROPERTYNAME = "propertyname";
+
     protected PropertyFilter getPropertyFilter(SlingHttpServletRequest request) {
         return PropertyFilter.fromValue(request.getParameter(PARAM_PROPERTY_FILTER));
     }
@@ -90,6 +97,10 @@ public class AutoTranslateMergeModel {
         String componentPath = request.getParameter(PARAM_COMPONENTPATH);
         if (StringUtils.isNotBlank(componentPath)) {
             properties.removeIf(p -> !p.getComponentPath().equals(componentPath));
+        }
+        String propertyname = request.getParameter(PARAM_PROPERTYNAME);
+        if (StringUtils.isNotBlank(propertyname)) {
+            properties.removeIf(p -> !p.getWrapper().getPropertyName().equals(propertyname));
         }
         return properties;
     }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
@@ -5,7 +5,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -106,6 +105,11 @@ public class AutoTranslateMergeModel {
 
         public List<AutoTranslateMergeService.AutoTranslateProperty> getCheckableProperties() {
             return properties;
+        }
+
+        /** Size of {@link #getCheckableProperties()} times 3 + 1 since HTL cannot calculate :-( */
+        public int getCalculatedComponentRowspan() {
+            return properties.size() * 3 + 1;
         }
 
     }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.request.RequestPathInfo;
 import org.apache.sling.api.resource.Resource;
@@ -48,6 +49,11 @@ public class AutoTranslateMergeModel {
      */
     protected static final String PARAM_SCOPE = "scope";
 
+    /**
+     * Parameter that limits output to just that component - for specific reloading.
+     */
+    protected static final String PARAM_COMPONENTPATH = "componentpath";
+
     protected PropertyFilter getPropertyFilter(SlingHttpServletRequest request) {
         return PropertyFilter.fromValue(request.getParameter(PARAM_PROPERTY_FILTER));
     }
@@ -80,6 +86,10 @@ public class AutoTranslateMergeModel {
                 break;
             case ALL_PROPERTIES:
                 break;
+        }
+        String componentPath = request.getParameter(PARAM_COMPONENTPATH);
+        if (StringUtils.isNotBlank(componentPath)) {
+            properties.removeIf(p -> !p.getComponentPath().equals(componentPath));
         }
         return properties;
     }
@@ -144,6 +154,20 @@ public class AutoTranslateMergeModel {
 
         public String getComponentTitle() {
             return properties.isEmpty() ? null : properties.get(0).getComponentTitle();
+        }
+
+        public String getComponentPath() {
+            return componentPath;
+        }
+
+        /**
+         * For pages properties are cancelled individually. If it's a page we return the property name here, else nothing.
+         */
+        public String getCancelPropertyName() {
+            if (componentPath.endsWith("/jcr:content")) {
+                return properties.get(0).getWrapper().getPropertyName();
+            }
+            return null;
         }
 
         public String getComponentPathInPage() {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
@@ -1,5 +1,8 @@
 package com.composum.ai.aem.core.impl.autotranslate;
 
+import static org.apache.commons.lang3.StringUtils.substringAfter;
+import static org.apache.commons.lang3.StringUtils.substringBefore;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -62,77 +65,86 @@ public class AutoTranslateMergeModel {
             component.getCheckableProperties().add(property);
         }
         return pageComponents;
-}
-
-public String getPageLanguage() {
-    String language = SelectorUtils.findLanguage(getPageResource());
-    return language != null ? SelectorUtils.getLanguageName(language, Locale.ENGLISH) : null;
-}
-
-/**
- * Finds the content resource for the page that is in the request suffix.
- */
-protected Resource getPageResource() {
-    if (pageResource == null && !isDisabled()) {
-        ResourceResolver resolver = request.getResourceResolver();
-        PageManager pageManager = resolver.adaptTo(PageManager.class);
-
-        RequestPathInfo requestPathInfo = request.getRequestPathInfo();
-        String suffix = requestPathInfo.getSuffix();
-        if (suffix != null) {
-            pageResource = pageManager.getContainingPage(suffix).getContentResource();
-        }
-    }
-    return pageResource;
-}
-
-public String getPagePath() {
-    return getPageResource() != null ? getPageResource().getParent().getPath() : null;
-}
-
-public static class AutoTranslateComponent {
-    private final String componentPath;
-    private final List<AutoTranslateMergeService.AutoTranslateProperty> properties = new ArrayList<>();
-
-    public AutoTranslateComponent(String componentPath) {
-        this.componentPath = componentPath;
     }
 
-    public String getComponentName() {
-        return properties.isEmpty() ? null : properties.get(0).getComponentName();
-    }
-
-    public String getComponentTitle() {
-        return properties.isEmpty() ? null : properties.get(0).getComponentTitle();
-    }
-
-    public String getComponentPathInPage() {
-        return StringUtils.substringAfter(componentPath, "/jcr:content/");
-    }
-
-    public List<AutoTranslateMergeService.AutoTranslateProperty> getCheckableProperties() {
-        return properties;
-    }
-
-    public boolean isCancelled() {
-        return properties.get(0).isCancelled();
-    }
-
-    public String cancelledClass() {
-        return properties.get(0).cancelledClass();
+    public String getPageLanguage() {
+        String language = SelectorUtils.findLanguage(getPageResource());
+        return language != null ? SelectorUtils.getLanguageName(language, Locale.ENGLISH) : null;
     }
 
     /**
-     * Size of {@link #getCheckableProperties()} times 3 + 1 since HTL cannot calculate :-(
+     * Finds the content resource for the page that is in the request suffix.
      */
-    public int getCalculatedComponentRowspan() {
-        return properties.size() * 3 + 1;
+    protected Resource getPageResource() {
+        if (pageResource == null && !isDisabled()) {
+            ResourceResolver resolver = request.getResourceResolver();
+            PageManager pageManager = resolver.adaptTo(PageManager.class);
+
+            RequestPathInfo requestPathInfo = request.getRequestPathInfo();
+            String suffix = requestPathInfo.getSuffix();
+            if (suffix != null) {
+                pageResource = pageManager.getContainingPage(suffix).getContentResource();
+            }
+        }
+        return pageResource;
     }
 
-    @Override
-    public String toString() {
-        return "AutoTranslateComponent(" + componentPath + ')';
+    public String getPagePath() {
+        return getPageResource() != null ? getPageResource().getParent().getPath() : null;
     }
-}
+
+    public static class AutoTranslateComponent {
+        private final String componentPath;
+        private final List<AutoTranslateMergeService.AutoTranslateProperty> properties = new ArrayList<>();
+
+        public AutoTranslateComponent(String componentPath) {
+            this.componentPath = componentPath;
+        }
+
+        public String getComponentName() {
+            return properties.isEmpty() ? null : properties.get(0).getComponentName();
+        }
+
+        public String getComponentTitle() {
+            return properties.isEmpty() ? null : properties.get(0).getComponentTitle();
+        }
+
+        public String getComponentPathInPage() {
+            return substringAfter(componentPath, "/jcr:content/");
+        }
+
+        public String getLinkToComponent() {
+            if (componentPath.endsWith("/jcr:content")) {
+                return "/mnt/overlay/wcm/core/content/sites/properties.html?item=" +
+                substringBefore(componentPath, "/jcr:content");
+            }
+            return "/editor.html" + substringBefore(componentPath, "/jcr:content") +
+                    ".html#scrolltocomponent-" + substringAfter(componentPath, "/jcr:content/");
+        }
+
+        public List<AutoTranslateMergeService.AutoTranslateProperty> getCheckableProperties() {
+            return properties;
+        }
+
+        public boolean isCancelled() {
+            return properties.get(0).isCancelled();
+        }
+
+        public String cancelledClass() {
+            return properties.get(0).cancelledClass();
+        }
+
+        /**
+         * Size of {@link #getCheckableProperties()} times 3 + 1 since HTL cannot calculate :-(
+         */
+        public int getCalculatedComponentRowspan() {
+            return properties.size() * 3 + 1;
+        }
+
+        @Override
+        public String toString() {
+            return "AutoTranslateComponent(" + componentPath + ')';
+        }
+    }
 
 }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
@@ -114,6 +114,10 @@ public static class AutoTranslateComponent {
         return properties;
     }
 
+    public boolean isCancelled() {
+        return properties.get(0).isCancelled();
+    }
+
     /**
      * Size of {@link #getCheckableProperties()} times 3 + 1 since HTL cannot calculate :-(
      */

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
@@ -118,6 +118,10 @@ public static class AutoTranslateComponent {
         return properties.get(0).isCancelled();
     }
 
+    public String cancelledClass() {
+        return properties.get(0).cancelledClass();
+    }
+
     /**
      * Size of {@link #getCheckableProperties()} times 3 + 1 since HTL cannot calculate :-(
      */

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -66,8 +66,9 @@ public interface AutoTranslateMergeService {
         private final String componentTitle;
         private final String componentPath;
         private final boolean cancelled;
+        private final boolean processingNeeded;
 
-        public AutoTranslateProperty(String path, String componentPath, AITranslatePropertyWrapper wrapper, String componentName, String componentTitle, @Nonnull LiveRelationship relationship) {
+        public AutoTranslateProperty(String path, String componentPath, AITranslatePropertyWrapper wrapper, String componentName, String componentTitle, @Nonnull LiveRelationship relationship, boolean processingNeeded) {
             this.path = path;
             this.componentPath = componentPath;
             this.wrapper = wrapper;
@@ -75,6 +76,7 @@ public interface AutoTranslateMergeService {
             this.componentTitle = componentTitle;
             this.cancelled = relationship.getStatus().isCancelled() ||
                     relationship.getStatus().getCanceledProperties().contains(wrapper.getPropertyName());
+            this.processingNeeded = processingNeeded;
         }
 
         public String getPath() {
@@ -99,6 +101,10 @@ public interface AutoTranslateMergeService {
 
         public boolean isCancelled() {
             return cancelled;
+        }
+
+        public boolean isProcessingNeeded() {
+            return processingNeeded;
         }
 
         public String cancelledClass() {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.sling.api.resource.Resource;
 
 import com.day.cq.wcm.api.WCMException;
+import com.day.cq.wcm.msm.api.LiveRelationship;
 
 /**
  * Service for handling merge operations related to auto-translation.
@@ -64,13 +65,16 @@ public interface AutoTranslateMergeService {
         private final String componentName;
         private final String componentTitle;
         private final String componentPath;
+        private final boolean cancelled;
 
-        public AutoTranslateProperty(String path, String componentPath, AITranslatePropertyWrapper wrapper, String componentName, String componentTitle) {
+        public AutoTranslateProperty(String path, String componentPath, AITranslatePropertyWrapper wrapper, String componentName, String componentTitle, @Nonnull LiveRelationship relationship) {
             this.path = path;
             this.componentPath = componentPath;
             this.wrapper = wrapper;
             this.componentName = componentName;
             this.componentTitle = componentTitle;
+            this.cancelled = relationship.getStatus().isCancelled() ||
+                    relationship.getStatus().getCanceledProperties().contains(wrapper.getPropertyName());
         }
 
         public String getPath() {
@@ -91,6 +95,10 @@ public interface AutoTranslateMergeService {
 
         public AITranslatePropertyWrapper getWrapper() {
             return wrapper;
+        }
+
+        public boolean isCancelled() {
+            return cancelled;
         }
 
         public String getOriginalCopyDiffsHTML() {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -41,7 +41,7 @@ public interface AutoTranslateMergeService {
      * @return a map containing "saved" and the text saved in the resource, to verify that it went OK, otherwise empty.
      */
     Map<String, String> saveTranslation(@Nonnull Resource resource, @Nonnull String propertyName,
-                          @Nonnull String content, @Nonnull boolean markAsMerged) throws WCMException;
+                                        @Nonnull String content, @Nonnull boolean markAsMerged) throws WCMException;
 
     /*
      * Try an intelligent merge: combine the original source, the new source, the new translation and the current text into a new text trying to keep the spirit of the translation.
@@ -55,6 +55,29 @@ public interface AutoTranslateMergeService {
     String intelligentMerge(String language, @Nonnull Resource resource, @Nonnull String originalSource,
                             @Nonnull String newSource, @Nonnull String newTranslation,
                             @Nonnull String currentText);
+
+    /**
+     * Approves a translation for the specified property of the given resource, marking it as accepted.
+     *
+     * @param resource     the resource containing the property to approve
+     * @param propertyName the name of the property for which the translation is to be approved
+     */
+    void approveTranslation(Resource resource, String propertyName) throws WCMException;
+
+    /**
+     * Cancels a translation for the specified property of the given resource, marking it as cancelled.
+     *
+     * @param resource     the resource containing the property to cancel
+     * @param propertyName the name of the property for which the translation is to be cancelled
+     * @param kind         whether to cancel or reenable the property
+     */
+    void changeInheritance(Resource resource, String propertyName, CancelOrReenable kind) throws WCMException;
+
+
+    enum CancelOrReenable {
+        CANCEL,
+        REENABLE
+    }
 
     /**
      * Represents a translated property associated with a resource.
@@ -190,7 +213,9 @@ public interface AutoTranslateMergeService {
             return html;
         }
 
-        /** Remove stuff that makes trouble with diffs. Currently rel="noopener noreferrer" */
+        /**
+         * Remove stuff that makes trouble with diffs. Currently rel="noopener noreferrer"
+         */
         protected String normalizeForDiff(String text) {
             return text != null ? text.replaceAll(" rel=\"noopener noreferrer\"", " ").trim() : "";
         }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -130,7 +130,7 @@ public interface AutoTranslateMergeService {
         }
 
         public String cancelledClass() {
-            return isCancelled() ? "cancelled" : "uncancelled";
+            return isCancelled() ? "cancelled" : "inheritanceenabled";
         }
 
         public boolean isProcessingNeeded() {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -115,11 +115,12 @@ public interface AutoTranslateMergeService {
             return isProcessingNeeded() ? "" : "processed";
         }
 
-        public String getOriginalCopyDiffsHTML() {
-            String original = wrapper.getOriginalCopy();
-            String newOriginal = wrapper.getNewOriginalCopy();
+        public String getDiffsHTML() {
+            String src = normalizeForDiff(cancelled ? wrapper.getOriginalCopy() : wrapper.getOriginal());
+            String dst = normalizeForDiff(cancelled ? wrapper.getNewOriginalCopy() : wrapper.getAcceptedSource());
+
             DiffMatchPatch dmp = new DiffMatchPatch();
-            LinkedList<DiffMatchPatch.Diff> diffs = dmp.diff_main(original, newOriginal);
+            LinkedList<DiffMatchPatch.Diff> diffs = dmp.diff_main(src, dst);
             dmp.diff_cleanupSemanticLossless(diffs);
 
             StringBuilder htmlBuf = new StringBuilder();
@@ -141,9 +142,10 @@ public interface AutoTranslateMergeService {
             return html;
         }
 
-        public String getOriginalCopyInsertionsMarked() {
-            String src = normalizeForDiff(wrapper.getNewOriginalCopy());
-            String dst = normalizeForDiff(wrapper.getOriginalCopy());
+        public String getDiffsSrcInsertionsMarked() {
+            String src = normalizeForDiff(cancelled ? wrapper.getNewOriginalCopy() : wrapper.getAcceptedSource());
+            String dst = normalizeForDiff(cancelled ? wrapper.getOriginalCopy() : wrapper.getOriginal());
+
             DiffMatchPatch dmp = new DiffMatchPatch();
             LinkedList<DiffMatchPatch.Diff> diffs = dmp.diff_main(src, dst);
             dmp.diff_cleanupSemanticLossless(diffs);
@@ -164,9 +166,10 @@ public interface AutoTranslateMergeService {
             return html;
         }
 
-        public String getNewOriginalCopyInsertionsMarked() {
-            String src = normalizeForDiff(wrapper.getOriginalCopy());
-            String dst = normalizeForDiff(wrapper.getNewOriginalCopy());
+        public String getDiffsDstInsertionsMarked() {
+            String src = normalizeForDiff(cancelled ? wrapper.getOriginalCopy() : wrapper.getOriginal());
+            String dst = normalizeForDiff(cancelled ? wrapper.getNewOriginalCopy() : wrapper.getAcceptedSource());
+
             DiffMatchPatch dmp = new DiffMatchPatch();
             LinkedList<DiffMatchPatch.Diff> diffs = dmp.diff_main(src, dst);
             dmp.diff_cleanupSemanticLossless(diffs);

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -90,7 +90,7 @@ public interface AutoTranslateMergeService {
         }
 
         public String getComponentTitle() {
-            return StringUtils.abbreviate(StringUtils.defaultString(componentTitle), 40);
+            return StringUtils.abbreviate(StringUtils.defaultString(componentTitle), 120);
         }
 
         public AITranslatePropertyWrapper getWrapper() {
@@ -99,6 +99,10 @@ public interface AutoTranslateMergeService {
 
         public boolean isCancelled() {
             return cancelled;
+        }
+
+        public String cancelledClass() {
+            return isCancelled() ? "cancelled" : "uncancelled";
         }
 
         public String getOriginalCopyDiffsHTML() {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -145,7 +145,7 @@ public interface AutoTranslateMergeService {
         }
 
         public String processingNeededClass() {
-            return isProcessingNeeded() ? "toprocess" : "processed";
+            return isProcessingNeeded() ? "" : "processed";
         }
 
         public String getDiffsHTML() {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -142,8 +142,8 @@ public interface AutoTranslateMergeService {
         }
 
         public String getDiffsHTML() {
-            String src = normalizeForDiff(cancelled ? wrapper.getOriginalCopy() : wrapper.getOriginal());
-            String dst = normalizeForDiff(cancelled ? wrapper.getNewOriginalCopy() : wrapper.getAcceptedSource());
+            String src = normalizeForDiff(cancelled ? wrapper.getOriginalCopy() : wrapper.getAcceptedSource());
+            String dst = normalizeForDiff(cancelled ? wrapper.getNewOriginalCopy() : wrapper.getOriginal());
 
             DiffMatchPatch dmp = new DiffMatchPatch();
             LinkedList<DiffMatchPatch.Diff> diffs = dmp.diff_main(src, dst);
@@ -169,8 +169,8 @@ public interface AutoTranslateMergeService {
         }
 
         public String getDiffsSrcInsertionsMarked() {
-            String src = normalizeForDiff(cancelled ? wrapper.getNewOriginalCopy() : wrapper.getAcceptedSource());
-            String dst = normalizeForDiff(cancelled ? wrapper.getOriginalCopy() : wrapper.getOriginal());
+            String src = normalizeForDiff(cancelled ? wrapper.getNewOriginalCopy() : wrapper.getOriginal());
+            String dst = normalizeForDiff(cancelled ? wrapper.getOriginalCopy() : wrapper.getAcceptedSource());
 
             DiffMatchPatch dmp = new DiffMatchPatch();
             LinkedList<DiffMatchPatch.Diff> diffs = dmp.diff_main(src, dst);
@@ -193,8 +193,8 @@ public interface AutoTranslateMergeService {
         }
 
         public String getDiffsDstInsertionsMarked() {
-            String src = normalizeForDiff(cancelled ? wrapper.getOriginalCopy() : wrapper.getOriginal());
-            String dst = normalizeForDiff(cancelled ? wrapper.getNewOriginalCopy() : wrapper.getAcceptedSource());
+            String src = normalizeForDiff(cancelled ? wrapper.getOriginalCopy() : wrapper.getAcceptedSource());
+            String dst = normalizeForDiff(cancelled ? wrapper.getNewOriginalCopy() : wrapper.getOriginal());
 
             DiffMatchPatch dmp = new DiffMatchPatch();
             LinkedList<DiffMatchPatch.Diff> diffs = dmp.diff_main(src, dst);

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -145,7 +145,7 @@ public interface AutoTranslateMergeService {
         }
 
         public String processingNeededClass() {
-            return isProcessingNeeded() ? "" : "processed";
+            return isProcessingNeeded() ? "toprocess" : "processed";
         }
 
         public String getDiffsHTML() {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -26,6 +26,9 @@ public interface AutoTranslateMergeService {
     /** Checks whether there are any unmerged or unaccepted properties. */
     boolean isProcessingNeeded(Resource resource);
 
+    /** Checks whether this is an automatically translated resource. */
+    boolean isAutomaticallyTranslated(Resource resource);
+
     /**
      * Recursively finds all properties from the given resource and its children that have names starting with
      * {@link AITranslatePropertyWrapper#AI_NEW_TRANSLATED_SUFFIX} and creates the AI Translate Property Wrapper for each.

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -1,5 +1,7 @@
 package com.composum.ai.aem.core.impl.autotranslate;
 
+import static org.apache.commons.lang3.StringUtils.removeStart;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -103,6 +105,11 @@ public interface AutoTranslateMergeService {
             this.cancelled = relationship.getStatus().isCancelled() ||
                     relationship.getStatus().getCanceledProperties().contains(wrapper.getPropertyName());
             this.processingNeeded = processingNeeded;
+        }
+
+        public String getPropertyPathInComponent() {
+            String relpath = removeStart(removeStart(path, componentPath), "/");
+            return relpath.isEmpty() ? wrapper.getPropertyName() : relpath + "/" + wrapper.getPropertyName();
         }
 
         public String getPath() {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -103,12 +103,16 @@ public interface AutoTranslateMergeService {
             return cancelled;
         }
 
+        public String cancelledClass() {
+            return isCancelled() ? "cancelled" : "uncancelled";
+        }
+
         public boolean isProcessingNeeded() {
             return processingNeeded;
         }
 
-        public String cancelledClass() {
-            return isCancelled() ? "cancelled" : "uncancelled";
+        public String processingNeededClass() {
+            return isProcessingNeeded() ? "" : "processed";
         }
 
         public String getOriginalCopyDiffsHTML() {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -21,6 +21,9 @@ import com.day.cq.wcm.msm.api.LiveRelationship;
  */
 public interface AutoTranslateMergeService {
 
+    /** Checks whether there are any unmerged or unaccepted properties. */
+    boolean isProcessingNeeded(Resource resource);
+
     /**
      * Recursively finds all properties from the given resource and its children that have names starting with
      * {@link AITranslatePropertyWrapper#AI_NEW_TRANSLATED_SUFFIX} and creates the AI Translate Property Wrapper for each.

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeService.java
@@ -27,6 +27,7 @@ public interface AutoTranslateMergeService {
      * @param resource the root resource to start property extraction from.
      * @return a list of AutoTranslateProperty instances with translation details.
      */
+    @Nonnull
     List<AutoTranslateProperty> getProperties(Resource resource);
 
     /**
@@ -62,9 +63,11 @@ public interface AutoTranslateMergeService {
         private final AITranslatePropertyWrapper wrapper;
         private final String componentName;
         private final String componentTitle;
+        private final String componentPath;
 
-        public AutoTranslateProperty(String path, AITranslatePropertyWrapper wrapper, String componentName, String componentTitle) {
+        public AutoTranslateProperty(String path, String componentPath, AITranslatePropertyWrapper wrapper, String componentName, String componentTitle) {
             this.path = path;
+            this.componentPath = componentPath;
             this.wrapper = wrapper;
             this.componentName = componentName;
             this.componentTitle = componentTitle;
@@ -76,6 +79,10 @@ public interface AutoTranslateMergeService {
 
         public String getComponentName() {
             return componentName;
+        }
+
+        public String getComponentPath() {
+            return componentPath;
         }
 
         public String getComponentTitle() {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
@@ -65,6 +65,25 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
         return props.stream().anyMatch(AutoTranslateProperty::isProcessingNeeded);
     }
 
+    @Override
+    public boolean isAutomaticallyTranslated(Resource resource) {
+        try {
+            Resource contentResource = resource;
+            if (!contentResource.getName().equals("jcr:content")) {
+                while (contentResource != null && !contentResource.getName().equals("jcr:content")) {
+                    contentResource = contentResource.getParent();
+                }
+            }
+            LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(contentResource, true);
+            if (relationship == null) {
+                return false;
+            }
+            return contentResource.getValueMap().get(AITranslatePropertyWrapper.PROPERTY_AI_TRANSLATED_DATE) != null;
+        } catch (WCMException e) {
+            LOG.error("Could not determine relationships of " + resource.getPath(), e);
+            return false;
+        }
+    }
 
     @Override
     @Nonnull

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
@@ -11,7 +11,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
 import org.apache.commons.collections4.IterableUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -67,15 +66,11 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
                         for (String key : properties.keySet()) {
                             String propertyName = AITranslatePropertyWrapper.decodePropertyName(
                                     AITranslatePropertyWrapper.AI_PREFIX, key,
-                                    AITranslatePropertyWrapper.AI_NEW_TRANSLATED_SUFFIX, res);
+                                    AITranslatePropertyWrapper.AI_ORIGINAL_SUFFIX, res);
                             if (propertyName != null) {
                                 LOG.debug("Found property: {}", propertyName);
                                 AITranslatePropertyWrapper wrapper = new AITranslatePropertyWrapper(sourceResource.getValueMap(), properties, propertyName);
-                                if (StringUtils.isNotBlank(wrapper.getNewOriginalCopy()) && StringUtils.isNotBlank(wrapper.getNewTranslatedCopy())) {
-                                    list.add(new AutoTranslateProperty(res.getPath(), wrapper, getComponentName(res), getComponentTitle(res)));
-                                } else {
-                                    LOG.warn("Property {} has empty original or translated copy", propertyName);
-                                }
+                                list.add(new AutoTranslateProperty(res.getPath(), wrapper, getComponentName(res), getComponentTitle(res)));
                             }
                         }
                     }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
@@ -53,6 +53,7 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
     protected AIConfigurationService configurationService;
 
     @Override
+    @Nonnull
     public List<AutoTranslateProperty> getProperties(Resource pageResource) {
         List<AutoTranslateProperty> list = new ArrayList<>();
         descendantsStream(pageResource).forEach(res -> {
@@ -70,7 +71,7 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
                             if (propertyName != null) {
                                 LOG.debug("Found property: {}", propertyName);
                                 AITranslatePropertyWrapper wrapper = new AITranslatePropertyWrapper(sourceResource.getValueMap(), properties, propertyName);
-                                list.add(new AutoTranslateProperty(res.getPath(), wrapper, getComponentName(res), getComponentTitle(res)));
+                                list.add(new AutoTranslateProperty(res.getPath(), relationship.getTargetPath(), wrapper, getComponentName(res), getComponentTitle(res)));
                             }
                         }
                     }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
@@ -63,7 +63,7 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
         descendantsStream(pageResource).forEach(res -> {
             ModifiableValueMap properties = res.adaptTo(ModifiableValueMap.class);
             try {
-                LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(res, false);
+                LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(res, true);
                 if (relationship != null) {
                     String sourcePath = relationship.getSourcePath();
                     Resource sourceResource = res.getResourceResolver().getResource(sourcePath);
@@ -100,7 +100,7 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
     @Override
     public Map<String, String> saveTranslation(@Nonnull Resource resource, @Nonnull String propertyName, @Nonnull String content, @Nonnull boolean markAsMerged) throws WCMException {
         ModifiableValueMap properties = Objects.requireNonNull(resource.adaptTo(ModifiableValueMap.class));
-        LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, false);
+        LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, true);
         if (relationship != null) {
             String sourcePath = relationship.getSourcePath();
             Resource sourceResource = resource.getResourceResolver().getResource(sourcePath);
@@ -123,7 +123,7 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
     @Override
     public void approveTranslation(Resource resource, String propertyName) throws WCMException {
         ModifiableValueMap properties = resource.adaptTo(ModifiableValueMap.class);
-        LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, false);
+        LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, true);
         if (relationship != null) {
             String sourcePath = relationship.getSourcePath();
             Resource sourceResource = resource.getResourceResolver().getResource(sourcePath);
@@ -136,7 +136,7 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
     @Override
     public void changeInheritance(Resource resource, String propertyName, CancelOrReenable kind) throws WCMException {
         ModifiableValueMap properties = resource.adaptTo(ModifiableValueMap.class);
-        LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, false);
+        LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, true);
         if (relationship != null) {
             String sourcePath = relationship.getSourcePath();
             Resource sourceResource = resource.getResourceResolver().getResource(sourcePath);

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
@@ -159,7 +159,7 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
                 // also reset values that have no meaning anymore.
                 case CANCEL:
                     if (StringUtils.isBlank(propertyName)) {
-                        boolean deep = ComponentCancellationHelper.isContainer(componentResource);
+                        boolean deep = !ComponentCancellationHelper.isContainer(componentResource);
                         liveRelationshipManager.cancelRelationship(componentResource.getResourceResolver(), relationship, deep, true);
                     } else {
                         liveRelationshipManager.cancelPropertyRelationship(componentResource.getResourceResolver(), relationship, new String[]{propertyName}, true);

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
@@ -71,7 +71,7 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
                             if (propertyName != null) {
                                 LOG.debug("Found property: {}", propertyName);
                                 AITranslatePropertyWrapper wrapper = new AITranslatePropertyWrapper(sourceResource.getValueMap(), properties, propertyName);
-                                list.add(new AutoTranslateProperty(res.getPath(), getComponentResource(res).getPath(), wrapper,  getComponentName(res), getComponentTitle(res)));
+                                list.add(new AutoTranslateProperty(res.getPath(), getComponentResource(res).getPath(), wrapper,  getComponentName(res), getComponentTitle(res), relationship));
                             }
                         }
                     }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
@@ -56,6 +56,15 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
     @Reference
     protected AIConfigurationService configurationService;
 
+    public boolean isProcessingNeeded(Resource pageResource) {
+        if (pageResource == null) {
+            return false;
+        }
+        List<AutoTranslateProperty> props = getProperties(pageResource);
+        return props.stream().anyMatch(AutoTranslateProperty::isProcessingNeeded);
+    }
+
+
     @Override
     @Nonnull
     public List<AutoTranslateProperty> getProperties(Resource pageResource) {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/workflow/TriggerRolloutWorkflowProcess.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/workflow/TriggerRolloutWorkflowProcess.java
@@ -121,7 +121,7 @@ public class TriggerRolloutWorkflowProcess implements WorkflowProcess {
         for (String path : pathsToRollout) {
             Resource contentResource = resourceResolver.getResource(path);
             if (contentResource != null && contentResource.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE).equals("cq:PageContent")) {
-                LiveRelationship liveRelationship = liveRelationshipManager.getLiveRelationship(contentResource, false);
+                LiveRelationship liveRelationship = liveRelationshipManager.getLiveRelationship(contentResource, true);
                 if (liveRelationship != null) {
                     Resource source = resource.getResourceResolver().getResource(liveRelationship.getSourcePath());
                     if (source != null) {
@@ -154,7 +154,7 @@ public class TriggerRolloutWorkflowProcess implements WorkflowProcess {
     protected void performRolloutForPage(Resource contentResource, TriggerRolloutParameters parms)
             throws PersistenceException, WCMException {
         if (contentResource != null && contentResource.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE).equals("cq:PageContent")) {
-            LiveRelationship liveRelationship = liveRelationshipManager.getLiveRelationship(contentResource, false);
+            LiveRelationship liveRelationship = liveRelationshipManager.getLiveRelationship(contentResource, true);
             if (liveRelationship != null) {
                 Resource source = contentResource.getResourceResolver().getResource(liveRelationship.getSourcePath());
                 if (source != null) {

--- a/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapperTest.java
+++ b/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AITranslatePropertyWrapperTest.java
@@ -73,7 +73,7 @@ class AITranslatePropertyWrapperTest {
     void testDecodePropertyName() {
         String encoded = "ai_exampleProperty_suffix";
         Resource resource = new MockResource("/content/example", Collections.singletonMap("exampleProperty", "Original text"), null);
-        String decoded = AITranslatePropertyWrapper.decodePropertyName("ai_", encoded, "_suffix", resource);
+        String decoded = AITranslatePropertyWrapper.decodePropertyName("ai_", encoded, "_suffix", resource.getValueMap());
         assertEquals("exampleProperty", decoded);
     }
 

--- a/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslatePropertyTest.java
+++ b/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslatePropertyTest.java
@@ -2,12 +2,17 @@ package com.composum.ai.aem.core.impl.autotranslate;
 
 import static com.composum.ai.aem.core.impl.autotranslate.AutoTranslateMergeService.AutoTranslateProperty.wrapExcludingHTMLTags;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 
 import org.apache.sling.api.wrappers.ModifiableValueMapDecorator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import com.day.cq.wcm.msm.api.LiveRelationship;
+import com.day.cq.wcm.msm.api.LiveStatus;
 
 class AutoTranslatePropertyTest {
 
@@ -21,7 +26,9 @@ class AutoTranslatePropertyTest {
         sourceMap = new ModifiableValueMapDecorator(new HashMap<>());
         targetMap = new ModifiableValueMapDecorator(new HashMap<>());
         wrapper = new AITranslatePropertyWrapper(sourceMap, targetMap, "exampleProperty");
-        property = new AutoTranslateMergeService.AutoTranslateProperty("/content/example", "/content/example", wrapper, "component", "component text");
+        LiveRelationship relationship = mock(LiveRelationship.class);
+        when(relationship.getStatus()).thenReturn(mock(LiveStatus.class));
+        property = new AutoTranslateMergeService.AutoTranslateProperty("/content/example", "/content/example", wrapper, "component", "component text", relationship);
     }
 
     @Test

--- a/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslatePropertyTest.java
+++ b/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslatePropertyTest.java
@@ -28,7 +28,7 @@ class AutoTranslatePropertyTest {
         wrapper = new AITranslatePropertyWrapper(sourceMap, targetMap, "exampleProperty");
         LiveRelationship relationship = mock(LiveRelationship.class);
         when(relationship.getStatus()).thenReturn(mock(LiveStatus.class));
-        property = new AutoTranslateMergeService.AutoTranslateProperty("/content/example", "/content/example", wrapper, "component", "component text", relationship);
+        property = new AutoTranslateMergeService.AutoTranslateProperty("/content/example", "/content/example", wrapper, "component", "component text", relationship, true);
     }
 
     @Test

--- a/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslatePropertyTest.java
+++ b/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslatePropertyTest.java
@@ -27,18 +27,20 @@ class AutoTranslatePropertyTest {
         targetMap = new ModifiableValueMapDecorator(new HashMap<>());
         wrapper = new AITranslatePropertyWrapper(sourceMap, targetMap, "exampleProperty");
         LiveRelationship relationship = mock(LiveRelationship.class);
-        when(relationship.getStatus()).thenReturn(mock(LiveStatus.class));
+        LiveStatus liveStatus = mock(LiveStatus.class);
+        when(relationship.getStatus()).thenReturn(liveStatus);
+        when(liveStatus.isCancelled()).thenReturn(true);
         property = new AutoTranslateMergeService.AutoTranslateProperty("/content/example", "/content/example", wrapper, "component", "component text", relationship, true);
     }
 
     @Test
-    void testGetOriginalCopyDiffsHTML() {
+    void testGetDiffsHTML() {
         wrapper.setOriginalCopy("Original text");
         wrapper.setNewOriginalCopy("New original text with additions");
 
-        assertEquals("<del>O</del><span class=\"ins\">New o</span>riginal text<span class=\"ins\"> with additions</span>", property.getOriginalCopyDiffsHTML());
-        assertEquals("<del>O</del>riginal text", property.getOriginalCopyInsertionsMarked());
-        assertEquals("<span class=\"ins\">New o</span>riginal text<span class=\"ins\"> with additions</span>", property.getNewOriginalCopyInsertionsMarked());
+        assertEquals("<del>O</del><span class=\"ins\">New o</span>riginal text<span class=\"ins\"> with additions</span>", property.getDiffsHTML());
+        assertEquals("<del>O</del>riginal text", property.getDiffsSrcInsertionsMarked());
+        assertEquals("<span class=\"ins\">New o</span>riginal text<span class=\"ins\"> with additions</span>", property.getDiffsDstInsertionsMarked());
     }
 
     @Test
@@ -46,7 +48,7 @@ class AutoTranslatePropertyTest {
         wrapper.setOriginalCopy("<b>o</b>riginal");
         wrapper.setNewOriginalCopy("The <b>o</b>rriginal");
 
-        String diffsHtml = property.getOriginalCopyDiffsHTML();
+        String diffsHtml = property.getDiffsHTML();
 
         assertEquals("<span class=\"ins\">The </span><b>o</b><span class=\"ins\">r</span>riginal", diffsHtml);
     }

--- a/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslatePropertyTest.java
+++ b/aem/core/src/test/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslatePropertyTest.java
@@ -2,14 +2,12 @@ package com.composum.ai.aem.core.impl.autotranslate;
 
 import static com.composum.ai.aem.core.impl.autotranslate.AutoTranslateMergeService.AutoTranslateProperty.wrapExcludingHTMLTags;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
 import org.apache.sling.api.wrappers.ModifiableValueMapDecorator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class AutoTranslatePropertyTest {
 
@@ -23,7 +21,7 @@ class AutoTranslatePropertyTest {
         sourceMap = new ModifiableValueMapDecorator(new HashMap<>());
         targetMap = new ModifiableValueMapDecorator(new HashMap<>());
         wrapper = new AITranslatePropertyWrapper(sourceMap, targetMap, "exampleProperty");
-        property = new AutoTranslateMergeService.AutoTranslateProperty("/content/example", wrapper, "component", "component text");
+        property = new AutoTranslateMergeService.AutoTranslateProperty("/content/example", "/content/example", wrapper, "component", "component text");
     }
 
     @Test

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/bottombar-template.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/bottombar-template.html
@@ -1,0 +1,65 @@
+<template data-sly-template.bottombarTemplate="${@ model}">
+    <section class="coral-Form-fieldset bottombar coral--light">
+        <p class="errormessage" hidden>
+            <coral-alert variant="error">
+                <coral-alert-content class="alertcontent"></coral-alert-content>
+            </coral-alert>
+        </p>
+        <a>
+            <button is="coral-button" variant="secondary" class="toggle-diffs">
+                Toggle Diffs Column
+            </button>
+            <coral-tooltip placement="top" target=".toggle-diffs">
+                <span slot="content">Toggle the visibility of the diffs column versus showing the old and new version of the source text separately.</span>
+            </coral-tooltip>
+        </a>
+        <a>
+            <button is="coral-button" variant="secondary" class="toggle-current">
+                Toggle Current Text Column
+            </button>
+            <coral-tooltip placement="top" target=".toggle-current">
+                <span slot="content">Toggle the visibility of the current text column, to compare the current status of the page.</span>
+            </coral-tooltip>
+        </a>
+        <select id="propertyfilter" class="_coral-FieldButton _coral-ActionButton">
+            <option value="allstati">All Properties</option>
+            <option value="cancelled">Inheritance Cancelled</option>
+            <option value="uncancelled">Inheritance Uncancelled</option>
+        </select>
+        <coral-tooltip placement="top" target="#propertyfilter">
+            <span slot="content">Filter the properties by inheritance status.</span>
+        </coral-tooltip>
+        <select id="scope" class="_coral-FieldButton _coral-ActionButton">
+            <option value="unfinished">Unfinished Properties</option>
+            <option value="allprops">All Properties</option>
+        </select>
+        <coral-tooltip placement="top" target="#scope">
+            <span slot="content">Filter the properties by their status in the translation process.</span>
+        </coral-tooltip>
+        <a href="/editor.html${model.pagePath}.html" target="_blank">
+            <button is="coral-button" variant="secondary" class="open-in-editor">
+                Open in Editor
+            </button>
+            <coral-tooltip placement="top" target=".open-in-editor">
+                <span slot="content">Opens the page in the editor.</span>
+            </coral-tooltip>
+        </a>
+        <a href="${model.pagePath}.html?wcmmode=preview" target="_blank">
+            <button is="coral-button" variant="secondary" class="open-as-preview">
+                Open as Preview
+            </button>
+            <coral-tooltip placement="top" target=".open-as-preview">
+                <span slot="content">Opens the page in preview mode.</span>
+            </coral-tooltip>
+        </a>
+        <a href="/apps/composum-ai/components/tool/comparetool.html${model.pagePath}"
+           target="_blank">
+            <button is="coral-button" variant="secondary" class="open-in-compare">
+                Open in Compare Blueprint Tool
+            </button>
+            <coral-tooltip placement="top" target=".open-in-compare">
+                <span slot="content">Opens a tool to compare the blueprint and this page side by side.</span>
+            </coral-tooltip>
+        </a>
+    </section>
+</template>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/bottombar-template.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/bottombar-template.html
@@ -24,7 +24,7 @@
         <select id="propertyfilter" class="_coral-FieldButton _coral-ActionButton">
             <option value="allstati">All Properties</option>
             <option value="cancelled">Inheritance Cancelled</option>
-            <option value="uncancelled">Inheritance Uncancelled</option>
+            <option value="inheritanceenabled">Inheritance Enabled</option>
         </select>
         <coral-tooltip placement="top" target="#propertyfilter">
             <span slot="content">Filter the properties by inheritance status.</span>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/link-modal.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/link-modal.html
@@ -1,0 +1,34 @@
+<div id="edit-link-modal" class="modal-backdrop hidden">
+    <div class="modal-content wide">
+        <h3>Edit Link</h3>
+        <label>Text</label>
+        <input type="text" id="edit-anchor-text" class="_coral-Textfield">
+
+        <label>Path / Link</label>
+        <div class="path-link-wrapper">
+            <input type="text" id="edit-anchor-href" class="_coral-Textfield">
+            <span class="coral-InputGroup-button">
+                <button is="coral-button" icon="FolderOpenOutline" iconsize="S" size="M" variant="default"
+                        id="choose-path-btn"></button>
+            </span>
+        </div>
+
+        <label>Alternative text</label>
+        <input type="text" id="edit-anchor-title" class="_coral-Textfield">
+
+        <select id="edit-anchor-target" class="_coral-FieldButton _coral-ActionButton">
+            <option value="">Target</option>
+            <option value="_self">Same tab</option>
+            <option value="_blank">New tab</option>
+            <option value="_parent">Parent frame</option>
+            <option value="_top">Top frame</option>
+        </select>
+
+        <input type="hidden" id="edit-anchor-rel">
+
+        <div class="modal-actions">
+            <button is="coral-button" variant="secondary" id="cancel-link-btn">Cancel</button>
+            <button is="coral-button" variant="primary" id="save-link-btn">Save</button>
+        </div>
+    </div>
+</div>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -55,11 +55,15 @@ td.cancelcol {
     top: 5px;
 }
 
-.toprocess .done-icon, .processed .todo-icon {
+.coral--light .done-icon, .processed .todo-icon {
     display: none;
 }
 
-.done-icon {
+.processed .done-icon {
+    display: inline-flex;
+}
+
+.coral--light .done-icon {
     color: green;
 }
 

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -26,6 +26,20 @@ td.cancelcol {
     border-top: 1px solid #e1e1e1;
 }
 
+.previoussrc, .srcdiffs { /* position reference for .propertyname */
+    position: relative;
+}
+
+.propertyname {
+    position: absolute;
+    display: inline-block;
+    transform: rotate(90deg);
+    left: -19px;
+    top: 40%;
+    transform-origin: left top;
+    text-transform: none;
+}
+
 .cancelled .onlyuncancelled, .uncancelled .onlycancelled  {
     display: none;
 }

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -13,12 +13,12 @@ tr.row-separator td.row-separator {
 }
 
 td.cancelcol, th.cancelcol {
+    vertical-align: top;
     text-align: center;
 }
 
 tr.property-row td {
     vertical-align: top;
-    /* width: 15%; */
 }
 
 body.show-diffs .previoussrc, body.show-diffs .newsrc {

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -176,8 +176,8 @@ body.hide-currenttext .currenttext {
     margin: 0px;
 }
 
-.bottombar a {
-    padding-right: 14px;
+.bottombar a, .bottombar select {
+    margin-right: 14px;
 }
 
 .merged td {

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -12,6 +12,10 @@ tr.row-separator td.row-separator {
     background-color: lightgray;
 }
 
+tr.component-spacer {
+    height: 9px;
+}
+
 .coral--light tr.component-head td {
     background-color: lightgray;
 }
@@ -48,7 +52,7 @@ td.cancelcol {
     float: right;
 }
 
-.cancelled .onlyenabled, .inheritanceenabled .onlycancelled {
+.cancelled .onlyenabled, .inheritanceenabled .onlycancelled, .processed .accept-translation {
     display: none;
 }
 
@@ -206,6 +210,8 @@ body.hide-currenttext .currenttext {
 
 textarea {
     width: 100%;
+    resize: vertical;
+    height: fit-content;
     margin-top: 1em;
 }
 

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -12,9 +12,13 @@ tr.row-separator td.row-separator {
     background-color: lightgray;
 }
 
+td.cancelcol, th.cancelcol {
+    text-align: center;
+}
+
 tr.property-row td {
     vertical-align: top;
-    width: 15%;
+    /* width: 15%; */
 }
 
 body.show-diffs .previoussrc, body.show-diffs .newsrc {
@@ -26,7 +30,7 @@ body.hide-diffs .srcdiffs {
 }
 
 body.hide-currenttext .currenttext {
-    display:none;
+    display: none;
 }
 
 .rte-container {

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -26,6 +26,10 @@ td.cancelcol {
     border-top: 1px solid #e1e1e1;
 }
 
+.cancelled .onlyuncancelled, .uncancelled .onlycancelled  {
+    display: none;
+}
+
 tr.property-row td {
     vertical-align: top;
 }

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -48,7 +48,7 @@ td.cancelcol {
     float: right;
 }
 
-.cancelled .onlyuncancelled, .uncancelled .onlycancelled {
+.cancelled .onlyenabled, .inheritanceenabled .onlycancelled {
     display: none;
 }
 

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -15,6 +15,15 @@ tr.row-separator td.row-separator {
 td.cancelcol, th.cancelcol {
     vertical-align: top;
     text-align: center;
+    background-color: white;
+}
+
+td.cancelcol button {
+    margin-top: 9px;
+}
+
+td.cancelcol {
+    border-top: 1px solid #e1e1e1;
 }
 
 tr.property-row td {

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -42,10 +42,29 @@ td.cancelcol {
     position: absolute;
     display: inline-block;
     transform: rotate(90deg);
-    left: -19px;
-    top: 40%;
+    left: -8px;
+    top: 28%;
     transform-origin: left top;
     text-transform: none;
+}
+
+.workflow-icons {
+    transform: rotate(-90deg);
+    margin-top: 3px;
+    position: relative;
+    top: 5px;
+}
+
+.toprocess .done-icon, .processed .todo-icon {
+    display: none;
+}
+
+.done-icon {
+    color: green;
+}
+
+.todo-icon {
+    color: yellow;
 }
 
 .right-aligned {
@@ -193,7 +212,7 @@ body.hide-currenttext .currenttext {
 }
 
 .coral--light .processed td {
-    background-color: palegreen;
+    background-color: #efe;
     /* opacity: 40%; */
 }
 

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -56,6 +56,10 @@ tr.property-row td {
     vertical-align: top;
 }
 
+coral-tooltip {
+    text-transform: none;
+}
+
 body.show-diffs .previoussrc, body.show-diffs .newsrc {
     display: none;
 }

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -40,7 +40,11 @@ td.cancelcol {
     text-transform: none;
 }
 
-.cancelled .onlyuncancelled, .uncancelled .onlycancelled  {
+.right-aligned {
+    float: right;
+}
+
+.cancelled .onlyuncancelled, .uncancelled .onlycancelled {
     display: none;
 }
 

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -12,10 +12,14 @@ tr.row-separator td.row-separator {
     background-color: lightgray;
 }
 
+.coral--light tr.component-head td {
+    background-color: lightgray;
+}
+
 td.cancelcol, th.cancelcol {
     vertical-align: top;
     text-align: center;
-    background-color: white;
+    background-color: lightgray;
 }
 
 td.cancelcol button {

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -184,9 +184,9 @@ body.hide-currenttext .currenttext {
     margin-right: 14px;
 }
 
-.processed td {
-    background-color: #e6ffe6 !important;
-    opacity: 40%;
+.coral--light .processed td {
+    background-color: palegreen;
+    /* opacity: 40%; */
 }
 
 .spinner {

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -180,7 +180,7 @@ body.hide-currenttext .currenttext {
     margin-right: 14px;
 }
 
-.merged td {
+.processed td {
     background-color: #e6ffe6 !important;
     opacity: 40%;
 }

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -28,10 +28,13 @@ td.cancelcol, th.cancelcol {
 
 td.cancelcol button {
     margin-top: 9px;
+    min-width: 32px;
+    padding: 5px;
 }
 
 td.cancelcol {
     border-top: 1px solid #e1e1e1;
+    width: 50px;
 }
 
 .previoussrc, .srcdiffs { /* position reference for .propertyname */

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -49,7 +49,9 @@
 
                             <!--/* Component start */-->
 
-                            <tr is="coral-table-row" class="component-spacer"></tr>
+                            <tr is="coral-table-row" class="component-spacer"
+                                data-componentpath="${pageComponent.componentPath}"
+                                data-cancelpropertyname="${pageComponent.cancelPropertyName}"></tr>
 
                             <tr is="coral-table-row" class="component-head ${pageComponent.cancelledClass}"
                                 id="component-${pageComponentList.index}"

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Translation Merge UI</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <sly data-sly-use.clientLib="/libs/granite/sightly/templates/clientlib.html"/>
+    <sly data-sly-use.clientLib="/libs/granite/sightly/templates/clientlib.html"></sly>
     <sly data-sly-call="${clientLib.css @ categories='cq.authoring.editor.core'}"></sly>
-    <link rel="stylesheet" href="${resource.path @ context='uri'}/list.css">
+    <link rel="stylesheet" href="${resource.path}/list.css">
 </head>
 <body class="coral--light coral-Body foundation-layout-util-maximized-alt show-diffs hide-currenttext"
       data-page-path="${model.pagePath}">
@@ -56,7 +56,7 @@
                                     </coral-tooltip>
                                 </td>
                                 <td is="coral-table-cell" colspan="6">
-                                    <span class="componentName" data-sly-text="${pageComponent.componentName}"/>
+                                    <span class="componentName" data-sly-text="${pageComponent.componentName}"></span>
                                     <sly data-sly-test="${pageComponent.componentPathInPage}">
                                         | <span class="componentPath"
                                                 data-sly-text="${pageComponent.componentPathInPage}"/>
@@ -74,7 +74,7 @@
                                 </td>
                             </tr>
                             <sly data-sly-list.property="${pageComponent.checkableProperties}">
-                                <tr is="coral-table-row" class="row-separator ${property.cancelledClass}"
+                                <tr is="coral-table-row" class="row-separator ${property.cancelledClass} ${property.processingNeededClass}"
                                     id="row-${propertyList.index}">
                                     <th is="coral-table-headercell" class="previoussrc">
                                         <span class="propertyname">${property.wrapper.propertyName}</span>
@@ -108,7 +108,7 @@
                                     </coral-tooltip>
                                 </tr>
                                 <!-- Data row -->
-                                <tr is="coral-table-row" class="property-row datarow ${property.cancelledClass}"
+                                <tr is="coral-table-row" class="property-row datarow ${property.cancelledClass} ${property.processingNeededClass}"
                                     id="datarow-${propertyList.index}"
                                     data-path="${property.path}"
                                     data-propertyname="${property.wrapper.propertyName}"
@@ -135,7 +135,6 @@
                                         class="srcdiffs diffscolor">
                                         <p data-sly-unwrap="${property.wrapper.isRichText}">
                                         ${property.originalCopyDiffsHTML @ context='html'}</td>
-                                    </p>
                                     <td is="coral-table-cell"
                                         class="newtrans">
                                         <div class="newtrans-text">
@@ -143,7 +142,7 @@
                                                 ${property.wrapper.newTranslatedCopy @ context='html'}
                                             </sly>
                                             <sly data-sly-test="${!isrichtext}">
-                                                <p>${property.wrapper.newTranslatedCopy @ context='text'}</p>
+                                                <p>${property.wrapper.newTranslatedCopy}</p>
                                             </sly>
                                         </div>
                                     </td>
@@ -206,7 +205,7 @@
                                     </td>
                                 </tr>
                                 <!-- Action buttons TR -->
-                                <tr is="coral-table-row" class="property-row actionrow ${property.cancelledClass}"
+                                <tr is="coral-table-row" class="property-row actionrow ${property.cancelledClass} ${property.processingNeededClass}"
                                     id="actionrow-${propertyList.index}">
                                     <td is="coral-table-cell" class="previoussrc diffscolor">
                                     </td>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -77,7 +77,15 @@
                                         <span slot="content">Re-enables the inheritance for the whole component.</span>
                                     </coral-tooltip>
                                 </td>
-                                <td is="coral-table-cell" colspan="6">Component header</td>
+                                <td is="coral-table-cell" colspan="6">
+                                    <span class="componentName" data-sly-text="${pageComponent.componentName}"/>
+                                    <sly data-sly-test="${pageComponent.componentPathInPage}">
+                                        | <span class="componentPath" data-sly-text="${pageComponent.componentPathInPage}"/>
+                                    </sly>
+                                    <sly data-sly-test="${pageComponent.componentTitle}">
+                                        | ${pageComponent.componentTitle}
+                                    </sly>
+                                </td>
                             </tr>
                             <sly data-sly-list.property="${pageComponent.checkableProperties}">
                                 <tr is="coral-table-row" class="row-separator" id="row-${propertyList.index}">
@@ -93,11 +101,7 @@
                                             <button is="coral-button" size="S" variant="minimal"
                                                     icon="arrowDown" class="move-down" title="Down"></button>
                                         </a> -->
-                                        ${property.componentName} | ${property.pathInPage} |
                                         ${property.wrapper.propertyName}
-                                        <sly data-sly-test="${property.componentTitle}">
-                                            | ${property.componentTitle}
-                                        </sly>
                                     </td>
                                 </tr>
                                 <!-- Data row -->

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -39,56 +39,61 @@
                         <h2 class="coral-Form-fieldset-legend">Translation Merge Tool for page
                             <a target="_blank" href="/editor.html${model.pagePath}.html">${model.pagePath}</a>
                         </h2>
-                        <span class="coral-Form-field foundation-layout-util-breakword">
-                                This tool displays the texts of components where the inheritance was cancelled for manual modification, so that the translations are not automatically updated, and for which there are changes in the source page that have been noted during rollout. You can review and edit translations for modified properties below.
-                                Only component properties where the inheritance has been cancelled and where
-                                the blueprint was modified after cancelling inheritance or the last merging are displayed
-                                - until they are saved and marked as merged.
-                            </span>
+                        <!--/* <span class="coral-Form-field foundation-layout-util-breakword">
+                            </span> */-->
                     </section>
 
                     <section class="coral-Form-fieldset propertytable">
                         <table is="coral-table">
+
                             <colgroup>
-                                <col is="coral-table-column" fixedwidth>
+                                <col is="coral-table-column" fixedwidth class="cancelcol">
+                                <col is="coral-table-column" class="previoussrc">
+                                <col is="coral-table-column" class="newsrc">
+                                <col is="coral-table-column" class="srcdiffs">
+                                <col is="coral-table-column" class="translation">
+                                <col is="coral-table-column" class="editor">
+                                <col is="coral-table-column" class="currenttext">
                             </colgroup>
-                            <tbody is="coral-table-body" class="propertiestable"
-                                   data-sly-list.pageComponent="${model.pageComponents}">
 
-                            <!--/* Component start */-->
+                            <tbody is="coral-table-body" class="propertiestable">
+                            <sly data-sly-list.pageComponent="${model.pageComponents}">
 
-                            <tr is="coral-table-row" class="component-spacer"
-                                data-componentpath="${pageComponent.componentPath}"
-                                data-cancelpropertyname="${pageComponent.cancelPropertyName}"></tr>
+                                <!--/* Component start */-->
 
-                            <tr is="coral-table-row" class="component-head ${pageComponent.cancelledClass}"
-                                id="component-${pageComponentList.index}"
-                                data-componentpath="${pageComponent.componentPath}"
-                                data-cancelpropertyname="${pageComponent.cancelPropertyName}">
-                                <td class="cancelcol" rowspan="${pageComponent.calculatedComponentRowspan}">
-                                    <button class="cancelinheritance onlyenabled" is="coral-button"
-                                            variant="minimal"
-                                            size="M" icon="link"></button>
-                                    <coral-tooltip placement="right" target="_prev">
-                                        <span slot="content">Cancels the inheritance for the whole component.</span>
-                                    </coral-tooltip>
-                                    <button class="reenableinheritance onlycancelled" is="coral-button"
-                                            variant="minimal" icon="linkOff"></button>
-                                    <coral-tooltip placement="right" target="_prev">
+                                <tr is="coral-table-row" class="component-spacer"
+                                    data-componentpath="${pageComponent.componentPath}"
+                                    data-cancelpropertyname="${pageComponent.cancelPropertyName}"></tr>
+
+                                <tr is="coral-table-row" class="component-head ${pageComponent.cancelledClass}"
+                                    id="component-${pageComponentList.index}"
+                                    data-componentpath="${pageComponent.componentPath}"
+                                    data-cancelpropertyname="${pageComponent.cancelPropertyName}">
+                                    <td class="cancelcol" rowspan="${pageComponent.calculatedComponentRowspan}">
+                                        <button class="cancelinheritance onlyenabled" is="coral-button"
+                                                variant="minimal"
+                                                size="M" icon="link"></button>
+                                        <coral-tooltip placement="right" target="_prev">
+                                            <span slot="content">Cancels the inheritance for the whole component.</span>
+                                        </coral-tooltip>
+                                        <button class="reenableinheritance onlycancelled" is="coral-button"
+                                                variant="minimal" icon="linkOff"></button>
+                                        <coral-tooltip placement="right" target="_prev">
                                         <span slot="content">Re-enables the inheritance for the whole component. If
                                         there was a new translation, this is written into the page.</span>
-                                    </coral-tooltip>
-                                </td>
-                                <td is="coral-table-cell" colspan="6">
-                                    <span class="componentName" data-sly-text="${pageComponent.componentName}"></span>
-                                    <sly data-sly-test="${pageComponent.componentPathInPage}">
-                                        | <span class="componentPath"
-                                                data-sly-text="${pageComponent.componentPathInPage}"/>
-                                    </sly>
-                                    <sly data-sly-test="${pageComponent.componentTitle}">
-                                        | ${pageComponent.componentTitle}
-                                    </sly>
-                                    <span class="linktocomponent right-aligned">
+                                        </coral-tooltip>
+                                    </td>
+                                    <td is="coral-table-cell" colspan="6">
+                                        <span class="componentName"
+                                              data-sly-text="${pageComponent.componentName}"></span>
+                                        <sly data-sly-test="${pageComponent.componentPathInPage}">
+                                            | <span class="componentPath"
+                                                    data-sly-text="${pageComponent.componentPathInPage}"/>
+                                        </sly>
+                                        <sly data-sly-test="${pageComponent.componentTitle}">
+                                            | ${pageComponent.componentTitle}
+                                        </sly>
+                                        <span class="linktocomponent right-aligned">
                                         <a href="${pageComponent.linkToComponent}" target="_blank"
                                            rel="noopener noreferrer">
                                             <coral-icon icon="linkOut" size="XS"
@@ -97,307 +102,309 @@
                                             <span slot="content">Opens the page in the editor and scrolls to this component.</span>
                                         </coral-tooltip>
                                     </span>
-                                </td>
-                            </tr>
-                            <sly data-sly-list.property="${pageComponent.checkableProperties}">
-                                <sly data-sly-test.cancelled="${pageComponent.cancelled}"></sly>
-                                <sly data-sly-test.isRichText="${property.wrapper.isRichText}"></sly>
-                                <sly data-sly-test.hasNewCopy="${property.wrapper.newTranslatedCopy}"></sly>
-                                <sly data-sly-test.hasAccepted="${property.wrapper.acceptedTranslation}"></sly>
-                                <sly data-sly-test.hasData="${cancelled && hasNewCopy || !cancelled && hasAccepted}"></sly>
+                                    </td>
+                                </tr>
+                                <sly data-sly-list.property="${pageComponent.checkableProperties}">
+                                    <sly data-sly-test.cancelled="${pageComponent.cancelled}"></sly>
+                                    <sly data-sly-test.isRichText="${property.wrapper.isRichText}"></sly>
+                                    <sly data-sly-test.hasNewCopy="${property.wrapper.newTranslatedCopy}"></sly>
+                                    <sly data-sly-test.hasAccepted="${property.wrapper.acceptedTranslation}"></sly>
+                                    <sly data-sly-test.hasData="${cancelled && hasNewCopy || !cancelled && hasAccepted}"></sly>
 
-                                <!--/* Property start - title row */-->
+                                    <!--/* Property start - title row */-->
 
-                                <tr is="coral-table-row"
-                                    class="row-separator ${property.cancelledClass} ${property.processingNeededClass}"
-                                    data-componentpath="${pageComponent.componentPath}"
-                                    data-cancelpropertyname="${pageComponent.cancelPropertyName}"
-                                    id="row-${pageComponentList.index}-${propertyList.index}">
-                                    <sly data-sly-test="${cancelled}">
-                                        <th is="coral-table-headercell" class="previoussrc">
+                                    <tr is="coral-table-row"
+                                        class="row-separator ${property.cancelledClass} ${property.processingNeededClass}"
+                                        data-componentpath="${pageComponent.componentPath}"
+                                        data-cancelpropertyname="${pageComponent.cancelPropertyName}"
+                                        id="row-${pageComponentList.index}-${propertyList.index}">
+                                        <sly data-sly-test="${cancelled}">
+                                            <th is="coral-table-headercell" class="previoussrc">
                                             <span class="propertyname">
                                                 <sly data-sly-call="${todoIcon}"></sly>
                                                 ${property.propertyPathInComponent}
                                             </span>
-                                            <sly data-sly-test="${hasNewCopy}">
-                                                <span>Previously Translated Text</span>
-                                                <coral-tooltip placement="bottom" target="_prev">
-                                                    <span slot="content">The source text on which the translation currently shown in the current page was based.</span>
-                                                </coral-tooltip>
-                                            </sly>
-                                        </th>
-                                        <th is="coral-table-headercell" class="newsrc">
-                                            <span>New Source Text</span>
-                                            <coral-tooltip placement="bottom" target="_prev">
-                                                <span slot="content">The new source text as it was during the last rollout.</span>
-                                            </coral-tooltip>
-                                        </th>
-                                        <th is="coral-table-headercell" class="srcdiffs">
-                                            <span class="propertyname">
-                                                <sly data-sly-call="${todoIcon}"></sly>
-                                                ${property.propertyPathInComponent}
-                                            </span>
-                                            <sly data-sly-test="${hasNewCopy}">
-                                                <span>Original Diffs</span>
-                                                <coral-tooltip placement="bottom" target="_prev">
-                                                    <span slot="content">This shows the differences between the source text on which the translation currently shown in the current page was based and the new source text as it was during the last rollout.</span>
-                                                </coral-tooltip>
-                                            </sly>
-                                            <sly data-sly-test="${!hasNewCopy}">
+                                                <sly data-sly-test="${hasNewCopy}">
+                                                    <span>Previously Translated Text</span>
+                                                    <coral-tooltip placement="bottom" target="_prev">
+                                                        <span slot="content">The source text on which the translation currently shown in the current page was based.</span>
+                                                    </coral-tooltip>
+                                                </sly>
+                                            </th>
+                                            <th is="coral-table-headercell" class="newsrc">
                                                 <span>New Source Text</span>
                                                 <coral-tooltip placement="bottom" target="_prev">
                                                     <span slot="content">The new source text as it was during the last rollout.</span>
                                                 </coral-tooltip>
-                                            </sly>
-                                        </th>
-                                        <th is="coral-table-headercell" class="newtrans">
-                                            <sly data-sly-test="${hasNewCopy}">
-                                                <span>New Text Translation</span>
+                                            </th>
+                                            <th is="coral-table-headercell" class="srcdiffs">
+                                            <span class="propertyname">
+                                                <sly data-sly-call="${todoIcon}"></sly>
+                                                ${property.propertyPathInComponent}
+                                            </span>
+                                                <sly data-sly-test="${hasNewCopy}">
+                                                    <span>Original Diffs</span>
+                                                    <coral-tooltip placement="bottom" target="_prev">
+                                                        <span slot="content">This shows the differences between the source text on which the translation currently shown in the current page was based and the new source text as it was during the last rollout.</span>
+                                                    </coral-tooltip>
+                                                </sly>
+                                                <sly data-sly-test="${!hasNewCopy}">
+                                                    <span>New Source Text</span>
+                                                    <coral-tooltip placement="bottom" target="_prev">
+                                                        <span slot="content">The new source text as it was during the last rollout.</span>
+                                                    </coral-tooltip>
+                                                </sly>
+                                            </th>
+                                            <th is="coral-table-headercell" class="newtrans">
+                                                <sly data-sly-test="${hasNewCopy}">
+                                                    <span>New Text Translation</span>
+                                                    <coral-tooltip placement="bottom" target="_prev">
+                                                        <span slot="content">The AI translation of the new source text.</span>
+                                                    </coral-tooltip>
+                                                </sly>
+                                            </th>
+                                            <th is="coral-table-headercell" class="editor">
+                                                <span>Editor for Current Text</span>
                                                 <coral-tooltip placement="bottom" target="_prev">
-                                                    <span slot="content">The AI translation of the new source text.</span>
+                                                    <span slot="content">Edit the current text on the page and save it when done.</span>
                                                 </coral-tooltip>
-                                            </sly>
-                                        </th>
-                                        <th is="coral-table-headercell" class="editor">
-                                            <span>Editor for Current Text</span>
-                                            <coral-tooltip placement="bottom" target="_prev">
-                                                <span slot="content">Edit the current text on the page and save it when done.</span>
-                                            </coral-tooltip>
-                                        </th>
-                                        <th is="coral-table-headercell" class="currenttext">
-                                            <span>Current Text on Page</span>
-                                            <coral-tooltip placement="bottom" target="_prev">
-                                                <span slot="content">The current text displayed on the page, for comparison purposes.</span>
-                                            </coral-tooltip>
-                                        </th>
-                                    </sly>
-                                    <sly data-sly-test="${!cancelled}">
-                                        <th is="coral-table-headercell" class="previoussrc">
-                                            <span class="propertyname">
-                                                <sly data-sly-call="${todoIcon}"></sly>
-                                                ${property.propertyPathInComponent}
-                                            </span>
-                                            <span>Last accepted original text</span>
-                                            <coral-tooltip placement="bottom" target="_prev">
-                                                <span slot="content">The original when the translation was accepted last time</span>
-                                            </coral-tooltip>
-                                        </th>
-                                        <th is="coral-table-headercell" class="newsrc">
-                                            <span>Current original</span>
-                                            <coral-tooltip placement="bottom" target="_prev">
-                                                <span slot="content">The current original text.</span>
-                                            </coral-tooltip>
-                                        </th>
-                                        <th is="coral-table-headercell" class="srcdiffs">
-                                            <span class="propertyname">
-                                                <sly data-sly-call="${todoIcon}"></sly>
-                                                ${property.propertyPathInComponent}
-                                            </span>
-                                            <span>Diffs from last accepted original</span>
-                                            <coral-tooltip placement="bottom" target="_prev">
-                                                <span slot="content">This shows the differences between the source text where the translation was last accepted
-                                                    and the current source text.</span>
-                                            </coral-tooltip>
-                                        </th>
-                                        <th is="coral-table-headercell" class="newtrans">
-                                            <span>Last accepted translation</span>
-                                            <coral-tooltip placement="bottom" target="_prev">
-                                                <span slot="content">The AI translation of the original where the translation was last accepted.</span>
-                                            </coral-tooltip>
-                                        </th>
-                                        <th is="coral-table-headercell" class="editor">
-                                            <span>The current text</span>
-                                            <coral-tooltip placement="bottom" target="_prev">
-                                                <span slot="content">The current text on the page - AI translation of the current original.</span>
-                                            </coral-tooltip>
-                                        </th>
-                                        <th is="coral-table-headercell" class="currenttext">
-                                            <!-- Deliberately empty - no meaning here. --></th>
-                                    </sly>
-                                </tr>
-
-                                <!--/* Property data row */-->
-
-                                <tr is="coral-table-row"
-                                    class="property-row datarow ${property.cancelledClass} ${property.processingNeededClass}"
-                                    data-componentpath="${pageComponent.componentPath}"
-                                    data-cancelpropertyname="${pageComponent.cancelPropertyName}"
-                                    id="datarow-${pageComponentList.index}-${propertyList.index}"
-                                    data-path="${property.path}"
-                                    data-propertyname="${property.wrapper.propertyName}"
-                                    data-language="${model.pageLanguage}"
-                                    data-os="${property.wrapper.originalCopy}"
-                                    data-ot="${property.wrapper.translatedCopy}"
-                                    data-ns="${property.wrapper.newOriginalCopy}"
-                                    data-nt="${property.wrapper.newTranslatedCopy}"
-                                    data-as="${property.wrapper.acceptedSource}"
-                                    data-at="${property.wrapper.acceptedTranslation}"
-                                    data-sd="${property.diffsHTML}"
-                                    data-e="${property.wrapper.currentValue}"
-                                    data-id="${pageComponentList.index}-${propertyList.index}"
-                                    data-isrich="${property.wrapper.isRichText}">
-                                    <td is="coral-table-cell" class="previoussrc diffscolor">
-                                        <sly data-sly-test="${hasData}">
-                                            <sly data-sly-call="${maybeHTML @ text=property.diffsSrcInsertionsMarked, richtext=true}"></sly>
-                                        </sly>
-                                    </td>
-                                    <td is="coral-table-cell" class="newsrc diffscolor">
-                                        <sly data-sly-test="${!hasData}">
-                                            <sly data-sly-call="${maybeHTML @ text=property.wrapper.originalCopy, richtext=isRichText}"></sly>
-                                        </sly>
-                                        <sly data-sly-test="${hasData}">
-                                            <sly data-sly-call="${maybeHTML @ text=property.diffsDstInsertionsMarked, richtext=true}"></sly>
-                                        </sly>
-                                    </td>
-                                    <td is="coral-table-cell" class="srcdiffs diffscolor">
-                                        <sly data-sly-test="${!hasData}">
-                                            <sly data-sly-call="${maybeHTML @ text=property.wrapper.originalCopy, richtext=isRichText}"></sly>
-                                        </sly>
-                                        <sly data-sly-test="${hasData}">
-                                            <sly data-sly-call="${maybeHTML @ text=property.diffsHTML, richtext=true}"></sly>
-                                        </sly>
-                                    </td>
-                                    <td is="coral-table-cell" class="translation">
-                                        <div class="translation-text">
-                                            <sly data-sly-test="${hasData}">
-                                                <sly data-sly-test="${!cancelled}">
-                                                    <sly data-sly-call="${maybeHTML @ text=property.wrapper.acceptedTranslation, richtext=true}"></sly>
-                                                </sly>
-                                                <sly data-sly-test="${cancelled}">
-                                                    <sly data-sly-call="${maybeHTML @ text=property.wrapper.newTranslatedCopy, richtext=true}"></sly>
-                                                </sly>
-                                            </sly>
-                                        </div>
-                                    </td>
-                                    <td is="coral-table-cell" class="editor">
-                                        <sly data-sly-test="${cancelled}">
-                                            <div class="rte-container"
-                                                 data-sly-test.isrichtext="${property.wrapper.isRichText}">
-                                                <div class="rte-toolbar">
-                                                    <button class="rte-btn" is="coral-button" variant="minimal"
-                                                            title="Bold" icon="textBold"
-                                                            data-command="bold"></button>
-                                                    <!-- <coral-tooltip placement="bottom" target="_prev">
-                                                        <span slot="content">Make the text bold.</span>
-                                                    </coral-tooltip> -->
-                                                    <button is="coral-button" variant="minimal" title="Italic"
-                                                            icon="textItalic"
-                                                            data-command="italic"></button>
-                                                    <!-- <coral-tooltip placement="bottom" target="_prev">
-                                                        <span slot="content">Make the text italic.</span>
-                                                    </coral-tooltip> -->
-                                                    <button is="coral-button" variant="minimal" title="Underline"
-                                                            icon="textUnderline"
-                                                            data-command="underline"></button>
-                                                    <!-- <coral-tooltip placement="bottom" target="_prev">
-                                                        <span slot="content">Underline the text.</span>
-                                                    </coral-tooltip> -->
-                                                    <button is="coral-button" variant="minimal" title="Edit Link"
-                                                            icon="link" class="edit-link-btn"></button>
-                                                    <button is="coral-button" variant="minimal" title="Remove Link"
-                                                            icon="unlink" class="remove-link-btn"></button>
-                                                    <button is="coral-button" variant="minimal" title="Bullet List"
-                                                            icon="textBulleted"
-                                                            data-command="insertUnorderedList"></button>
-                                                    <!-- <coral-tooltip placement="bottom"
-                                                                   target="_prev">
-                                                        <span slot="content">Create a bullet list.</span>
-                                                    </coral-tooltip> -->
-                                                    <button is="coral-button" variant="minimal" title="Numbered List"
-                                                            icon="textNumbered"
-                                                            data-command="insertOrderedList"></button>
-                                                    <!-- <coral-tooltip placement="bottom"
-                                                                   target="_prev">
-                                                        <span slot="content">Create a numbered list.</span>
-                                                    </coral-tooltip> -->
-                                                </div>
-                                                <div class="rte-editor" contenteditable="true">
-                                                    ${property.wrapper.currentValue @ context='html'}
-                                                </div>
-                                            </div>
-                                            <div class="text-container" data-sly-test="${!isrichtext}">
-                                                <textarea class="text-editor" rows="3"
-                                                          data-sly-text="${property.wrapper.currentValue}"></textarea>
-                                            </div>
+                                            </th>
+                                            <th is="coral-table-headercell" class="currenttext">
+                                                <span>Current Text on Page</span>
+                                                <coral-tooltip placement="bottom" target="_prev">
+                                                    <span slot="content">The current text displayed on the page, for comparison purposes.</span>
+                                                </coral-tooltip>
+                                            </th>
                                         </sly>
                                         <sly data-sly-test="${!cancelled}">
-                                            <sly data-sly-call="${maybeHTML @ text=property.wrapper.currentValue, richtext=isRichText}"></sly>
+                                            <th is="coral-table-headercell" class="previoussrc">
+                                            <span class="propertyname">
+                                                <sly data-sly-call="${todoIcon}"></sly>
+                                                ${property.propertyPathInComponent}
+                                            </span>
+                                                <span>Last accepted original text</span>
+                                                <coral-tooltip placement="bottom" target="_prev">
+                                                    <span slot="content">The original when the translation was accepted last time</span>
+                                                </coral-tooltip>
+                                            </th>
+                                            <th is="coral-table-headercell" class="newsrc">
+                                                <span>Current original</span>
+                                                <coral-tooltip placement="bottom" target="_prev">
+                                                    <span slot="content">The current original text.</span>
+                                                </coral-tooltip>
+                                            </th>
+                                            <th is="coral-table-headercell" class="srcdiffs">
+                                            <span class="propertyname">
+                                                <sly data-sly-call="${todoIcon}"></sly>
+                                                ${property.propertyPathInComponent}
+                                            </span>
+                                                <span>Diffs from last accepted original</span>
+                                                <coral-tooltip placement="bottom" target="_prev">
+                                                <span slot="content">This shows the differences between the source text where the translation was last accepted
+                                                    and the current source text.</span>
+                                                </coral-tooltip>
+                                            </th>
+                                            <th is="coral-table-headercell" class="newtrans">
+                                                <span>Last accepted translation</span>
+                                                <coral-tooltip placement="bottom" target="_prev">
+                                                    <span slot="content">The AI translation of the original where the translation was last accepted.</span>
+                                                </coral-tooltip>
+                                            </th>
+                                            <th is="coral-table-headercell" class="editor">
+                                                <span>The current text</span>
+                                                <coral-tooltip placement="bottom" target="_prev">
+                                                    <span slot="content">The current text on the page - AI translation of the current original.</span>
+                                                </coral-tooltip>
+                                            </th>
+                                            <th is="coral-table-headercell" class="currenttext">
+                                                <!-- Deliberately empty - no meaning here. --></th>
                                         </sly>
-                                    </td>
-                                    <td is="coral-table-cell" class="currenttext">
-                                        <div class="current-text" data-sly-test="${cancelled}">
-                                            <sly data-sly-call="${maybeHTML @ text=property.wrapper.currentValue, richtext=isRichText}"></sly>
-                                        </div>
-                                    </td>
-                                </tr>
+                                    </tr>
 
-                                <!--/* Action buttons */-->
+                                    <!--/* Property data row */-->
 
-                                <tr is="coral-table-row"
-                                    class="property-row actionrow ${property.cancelledClass} ${property.processingNeededClass}"
-                                    data-componentpath="${pageComponent.componentPath}"
-                                    data-cancelpropertyname="${pageComponent.cancelPropertyName}"
-                                    id="actionrow-${pageComponentList.index}-${propertyList.index}">
-                                    <td is="coral-table-cell" class="previoussrc diffscolor">
-                                    </td>
-                                    <td is="coral-table-cell" class="newsrc diffscolor">
-                                    </td>
-                                    <td is="coral-table-cell" class="srcdiffs diffscolor"></td>
-                                    <td is="coral-table-cell" class="newtrans">
-                                        <div class="row-actions" data-sly-test="${cancelled && hasNewCopy}">
-                                            <button is="coral-button" variant="secondary"
-                                                    class="intelligent-merge onlycancelled">AI Merge
-                                                <coral-wait size="S" class="spinner"></coral-wait>
-                                            </button>
-                                            <coral-tooltip placement="right" target="_prev">
-                                                    <span slot="content">
-                                                        This takes the current text, inspects the differences between the previously translated source text and the new source text and incorporates the corresponding changes from the new text translation. Thus this tries to keep manual changes that have been done to the current text of the component as much as possible.</span>
-                                            </coral-tooltip>
-                                            <button is="coral-button" variant="secondary"
-                                                    class="copy-to-editor">Copy to Editor
-                                            </button>
-                                            <coral-tooltip placement="right" target="_prev">
-                                                <span slot="content">Copy the new translation as it is to the editor, replacing the editor content.</span>
-                                            </coral-tooltip>
-                                            <!-- <button is="coral-button" variant="secondary"
-                                                    class="append-to-editor">Append to Editor
-                                            </button> -->
-                                        </div>
-                                    </td>
-                                    <td is="coral-table-cell" class="editor">
-                                        <div class="editor-actions">
+                                    <tr is="coral-table-row"
+                                        class="property-row datarow ${property.cancelledClass} ${property.processingNeededClass}"
+                                        data-componentpath="${pageComponent.componentPath}"
+                                        data-cancelpropertyname="${pageComponent.cancelPropertyName}"
+                                        id="datarow-${pageComponentList.index}-${propertyList.index}"
+                                        data-path="${property.path}"
+                                        data-propertyname="${property.wrapper.propertyName}"
+                                        data-language="${model.pageLanguage}"
+                                        data-os="${property.wrapper.originalCopy}"
+                                        data-ot="${property.wrapper.translatedCopy}"
+                                        data-ns="${property.wrapper.newOriginalCopy}"
+                                        data-nt="${property.wrapper.newTranslatedCopy}"
+                                        data-as="${property.wrapper.acceptedSource}"
+                                        data-at="${property.wrapper.acceptedTranslation}"
+                                        data-sd="${property.diffsHTML}"
+                                        data-e="${property.wrapper.currentValue}"
+                                        data-id="${pageComponentList.index}-${propertyList.index}"
+                                        data-isrich="${property.wrapper.isRichText}">
+                                        <td is="coral-table-cell" class="previoussrc diffscolor">
+                                            <sly data-sly-test="${hasData}">
+                                                <sly data-sly-call="${maybeHTML @ text=property.diffsSrcInsertionsMarked, richtext=true}"></sly>
+                                            </sly>
+                                        </td>
+                                        <td is="coral-table-cell" class="newsrc diffscolor">
+                                            <sly data-sly-test="${!hasData}">
+                                                <sly data-sly-call="${maybeHTML @ text=property.wrapper.originalCopy, richtext=isRichText}"></sly>
+                                            </sly>
+                                            <sly data-sly-test="${hasData}">
+                                                <sly data-sly-call="${maybeHTML @ text=property.diffsDstInsertionsMarked, richtext=true}"></sly>
+                                            </sly>
+                                        </td>
+                                        <td is="coral-table-cell" class="srcdiffs diffscolor">
+                                            <sly data-sly-test="${!hasData}">
+                                                <sly data-sly-call="${maybeHTML @ text=property.wrapper.originalCopy, richtext=isRichText}"></sly>
+                                            </sly>
+                                            <sly data-sly-test="${hasData}">
+                                                <sly data-sly-call="${maybeHTML @ text=property.diffsHTML, richtext=true}"></sly>
+                                            </sly>
+                                        </td>
+                                        <td is="coral-table-cell" class="translation">
+                                            <div class="translation-text">
+                                                <sly data-sly-test="${hasData}">
+                                                    <sly data-sly-test="${!cancelled}">
+                                                        <sly data-sly-call="${maybeHTML @ text=property.wrapper.acceptedTranslation, richtext=true}"></sly>
+                                                    </sly>
+                                                    <sly data-sly-test="${cancelled}">
+                                                        <sly data-sly-call="${maybeHTML @ text=property.wrapper.newTranslatedCopy, richtext=true}"></sly>
+                                                    </sly>
+                                                </sly>
+                                            </div>
+                                        </td>
+                                        <td is="coral-table-cell" class="editor">
                                             <sly data-sly-test="${cancelled}">
-                                                <button is="coral-button" variant="primary" class="save-editor">
-                                                    Save and Finish
+                                                <div class="rte-container"
+                                                     data-sly-test.isrichtext="${property.wrapper.isRichText}">
+                                                    <div class="rte-toolbar">
+                                                        <button class="rte-btn" is="coral-button" variant="minimal"
+                                                                title="Bold" icon="textBold"
+                                                                data-command="bold"></button>
+                                                        <!-- <coral-tooltip placement="bottom" target="_prev">
+                                                            <span slot="content">Make the text bold.</span>
+                                                        </coral-tooltip> -->
+                                                        <button is="coral-button" variant="minimal" title="Italic"
+                                                                icon="textItalic"
+                                                                data-command="italic"></button>
+                                                        <!-- <coral-tooltip placement="bottom" target="_prev">
+                                                            <span slot="content">Make the text italic.</span>
+                                                        </coral-tooltip> -->
+                                                        <button is="coral-button" variant="minimal" title="Underline"
+                                                                icon="textUnderline"
+                                                                data-command="underline"></button>
+                                                        <!-- <coral-tooltip placement="bottom" target="_prev">
+                                                            <span slot="content">Underline the text.</span>
+                                                        </coral-tooltip> -->
+                                                        <button is="coral-button" variant="minimal" title="Edit Link"
+                                                                icon="link" class="edit-link-btn"></button>
+                                                        <button is="coral-button" variant="minimal" title="Remove Link"
+                                                                icon="unlink" class="remove-link-btn"></button>
+                                                        <button is="coral-button" variant="minimal" title="Bullet List"
+                                                                icon="textBulleted"
+                                                                data-command="insertUnorderedList"></button>
+                                                        <!-- <coral-tooltip placement="bottom"
+                                                                       target="_prev">
+                                                            <span slot="content">Create a bullet list.</span>
+                                                        </coral-tooltip> -->
+                                                        <button is="coral-button" variant="minimal"
+                                                                title="Numbered List"
+                                                                icon="textNumbered"
+                                                                data-command="insertOrderedList"></button>
+                                                        <!-- <coral-tooltip placement="bottom"
+                                                                       target="_prev">
+                                                            <span slot="content">Create a numbered list.</span>
+                                                        </coral-tooltip> -->
+                                                    </div>
+                                                    <div class="rte-editor" contenteditable="true">
+                                                        ${property.wrapper.currentValue @ context='html'}
+                                                    </div>
+                                                </div>
+                                                <div class="text-container" data-sly-test="${!isrichtext}">
+                                                <textarea class="text-editor" rows="3"
+                                                          data-sly-text="${property.wrapper.currentValue}"></textarea>
+                                                </div>
+                                            </sly>
+                                            <sly data-sly-test="${!cancelled}">
+                                                <sly data-sly-call="${maybeHTML @ text=property.wrapper.currentValue, richtext=isRichText}"></sly>
+                                            </sly>
+                                        </td>
+                                        <td is="coral-table-cell" class="currenttext">
+                                            <div class="current-text" data-sly-test="${cancelled}">
+                                                <sly data-sly-call="${maybeHTML @ text=property.wrapper.currentValue, richtext=isRichText}"></sly>
+                                            </div>
+                                        </td>
+                                    </tr>
+
+                                    <!--/* Action buttons */-->
+
+                                    <tr is="coral-table-row"
+                                        class="property-row actionrow ${property.cancelledClass} ${property.processingNeededClass}"
+                                        data-componentpath="${pageComponent.componentPath}"
+                                        data-cancelpropertyname="${pageComponent.cancelPropertyName}"
+                                        id="actionrow-${pageComponentList.index}-${propertyList.index}">
+                                        <td is="coral-table-cell" class="previoussrc diffscolor">
+                                        </td>
+                                        <td is="coral-table-cell" class="newsrc diffscolor">
+                                        </td>
+                                        <td is="coral-table-cell" class="srcdiffs diffscolor"></td>
+                                        <td is="coral-table-cell" class="newtrans">
+                                            <div class="row-actions" data-sly-test="${cancelled && hasNewCopy}">
+                                                <button is="coral-button" variant="secondary"
+                                                        class="intelligent-merge onlycancelled">AI Merge
                                                     <coral-wait size="S" class="spinner"></coral-wait>
                                                 </button>
                                                 <coral-tooltip placement="right" target="_prev">
-                                                    <span slot="content">Save the changes made in the editor and marks this text as merged - that is it will not be shown again in this tool until there are further changes to the source text rolled out.</span>
+                                                    <span slot="content">
+                                                        This takes the current text, inspects the differences between the previously translated source text and the new source text and incorporates the corresponding changes from the new text translation. Thus this tries to keep manual changes that have been done to the current text of the component as much as possible.</span>
                                                 </coral-tooltip>
-                                                <button is="coral-button" variant="secondary" class="reset-editor">
-                                                    Reset
-                                                </button>
-                                                <coral-tooltip placement="right" target="_prev">
-                                                    <span slot="content">Resets the editor to the current text on the page.</span>
-                                                </coral-tooltip>
-                                            </sly>
-                                            <sly data-sly-test="${!cancelled}">
                                                 <button is="coral-button" variant="secondary"
-                                                        class="accept-translation">
-                                                    Accept translation
+                                                        class="copy-to-editor">Copy to Editor
                                                 </button>
                                                 <coral-tooltip placement="right" target="_prev">
-                                                    <span slot="content">Saves that the translation was accepted as it is. Alternative: cancel component and then edit.</span>
+                                                    <span slot="content">Copy the new translation as it is to the editor, replacing the editor content.</span>
                                                 </coral-tooltip>
-                                            </sly>
-                                        </div>
-                                    </td>
-                                    <td is="coral-table-cell" class="currenttext">
-                                    </td>
-                                </tr>
+                                                <!-- <button is="coral-button" variant="secondary"
+                                                        class="append-to-editor">Append to Editor
+                                                </button> -->
+                                            </div>
+                                        </td>
+                                        <td is="coral-table-cell" class="editor">
+                                            <div class="editor-actions">
+                                                <sly data-sly-test="${cancelled}">
+                                                    <button is="coral-button" variant="primary" class="save-editor">
+                                                        Save and Finish
+                                                        <coral-wait size="S" class="spinner"></coral-wait>
+                                                    </button>
+                                                    <coral-tooltip placement="right" target="_prev">
+                                                        <span slot="content">Save the changes made in the editor and marks this text as merged - that is it will not be shown again in this tool until there are further changes to the source text rolled out.</span>
+                                                    </coral-tooltip>
+                                                    <button is="coral-button" variant="secondary" class="reset-editor">
+                                                        Reset
+                                                    </button>
+                                                    <coral-tooltip placement="right" target="_prev">
+                                                        <span slot="content">Resets the editor to the current text on the page.</span>
+                                                    </coral-tooltip>
+                                                </sly>
+                                                <sly data-sly-test="${!cancelled}">
+                                                    <button is="coral-button" variant="secondary"
+                                                            class="accept-translation">
+                                                        Accept translation
+                                                    </button>
+                                                    <coral-tooltip placement="right" target="_prev">
+                                                        <span slot="content">Saves that the translation was accepted as it is. Alternative: cancel component and then edit.</span>
+                                                    </coral-tooltip>
+                                                </sly>
+                                            </div>
+                                        </td>
+                                        <td is="coral-table-cell" class="currenttext">
+                                        </td>
+                                    </tr>
 
-                                <!--/* Property end, component end */-->
+                                    <!--/* Property end, component end */-->
 
+                                </sly>
                             </sly>
                             </tbody>
                         </table>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -30,7 +30,7 @@
                     <section class="coral-Form-fieldset propertytable">
                         <table is="coral-table">
                             <colgroup>
-                              <col is="coral-table-column" fixedwidth>
+                                <col is="coral-table-column" fixedwidth>
                             </colgroup>
                             <thead is="coral-table-head" sticky>
                             <tr is="coral-table-row" class="tablehead">
@@ -66,7 +66,17 @@
                             <tr is="coral-table-row" class="component-head" id="component-${pageComponentList.index}">
                                 <td class="coral-table-cell" class="cancelcol"
                                     rowspan="${pageComponent.calculatedComponentRowspan}">
-                                    <!-- Column for cancel button --></td>
+                                    <button class="cancelinheritance" is="coral-button" variant="minimal" size="M"
+                                            title="Cancel Inheritance" icon="link"></button>
+                                    <coral-tooltip placement="right" target=".cancelinheritance">
+                                        <span slot="content">Cancels the inheritance for the whole component.</span>
+                                    </coral-tooltip>
+                                    <button class="reenableinheritance" is="coral-button" variant="minimal"
+                                            title="Re-enable Inheritance" icon="linkOff"></button>
+                                    <coral-tooltip placement="right" target=".reenableinheritance">
+                                        <span slot="content">Re-enables the inheritance for the whole component.</span>
+                                    </coral-tooltip>
+                                </td>
                                 <td is="coral-table-cell" colspan="6">Component header</td>
                             </tr>
                             <sly data-sly-list.property="${pageComponent.checkableProperties}">

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -39,8 +39,13 @@
                         <h2 class="coral-Form-fieldset-legend">Translation Review for page
                             <a target="_blank" href="/editor.html${model.pagePath}.html">${model.pagePath}</a>
                         </h2>
-                        <!--/* <span class="coral-Form-field foundation-layout-util-breakword">
-                            </span> */-->
+                        <span class="coral-Form-field foundation-layout-util-breakword">
+                            This allows you to review the translated texts and either accept them (so that they won't shown here again until changed) or cancel inheritance for the component and edit the text manually. Inheritance can be changed
+                            usually only for the whole component at once with
+                            <coral-icon icon="link" size="XS"></coral-icon> and
+                            <coral-icon icon="linkOff" size="XS"></coral-icon>.
+                            Hover with the mouse over a buttons or headers to get more information.
+                        </span>
                     </section>
 
                     <section class="coral-Form-fieldset propertytable">
@@ -71,8 +76,7 @@
                                     data-cancelpropertyname="${pageComponent.cancelPropertyName}">
                                     <td class="cancelcol" rowspan="${pageComponent.calculatedComponentRowspan}">
                                         <button class="cancelinheritance onlyenabled" is="coral-button"
-                                                variant="secondary"
-                                                size="M" icon="link"></button>
+                                                variant="secondary" size="M" icon="link"></button>
                                         <coral-tooltip placement="right" target="_prev">
                                             <span slot="content">Cancels the inheritance for the whole component.</span>
                                         </coral-tooltip>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -56,8 +56,8 @@
                                 </coral-tooltip>
                             </tr>
                             </thead>
-                            <tbody is="coral-table-body" class="propertiestable">
-                            <sly data-sly-list.property="${model.properties}">
+                            <tbody is="coral-table-body" class="propertiestable" data-sly-list.pageComponent="${model.pageComponents}">
+                            <sly data-sly-list.property="${pageComponent.checkableProperties}">
                                 <tr is="coral-table-row" class="row-separator" id="row-${propertyList.index}">
                                     <td is="coral-table-cell" class="row-separator"
                                         colspan="6">

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -35,15 +35,18 @@
                             </colgroup>
                             <tbody is="coral-table-body" class="propertiestable"
                                    data-sly-list.pageComponent="${model.pageComponents}">
-                            <tr is="coral-table-row" class="component-head ${pageComponent.cancelledClass}" id="component-${pageComponentList.index}">
+                            <tr is="coral-table-row" class="component-head ${pageComponent.cancelledClass}"
+                                id="component-${pageComponentList.index}">
                                 <td class="cancelcol"
                                     rowspan="${pageComponent.calculatedComponentRowspan}">
-                                    <button class="cancelinheritance onlycancelled" is="coral-button" variant="minimal" size="M"
+                                    <button class="cancelinheritance onlycancelled" is="coral-button" variant="minimal"
+                                            size="M"
                                             title="Cancel Inheritance" icon="linkOff"></button>
                                     <coral-tooltip placement="right" target=".cancelinheritance">
                                         <span slot="content">Cancels the inheritance for the whole component.</span>
                                     </coral-tooltip>
-                                    <button class="reenableinheritance onlyuncancelled" is="coral-button" variant="minimal"
+                                    <button class="reenableinheritance onlyuncancelled" is="coral-button"
+                                            variant="minimal"
                                             title="Re-enable Inheritance" icon="link"></button>
                                     <coral-tooltip placement="right" target=".reenableinheritance">
                                         <span slot="content">Re-enables the inheritance for the whole component.</span>
@@ -52,15 +55,24 @@
                                 <td is="coral-table-cell" colspan="6">
                                     <span class="componentName" data-sly-text="${pageComponent.componentName}"/>
                                     <sly data-sly-test="${pageComponent.componentPathInPage}">
-                                        | <span class="componentPath" data-sly-text="${pageComponent.componentPathInPage}"/>
+                                        | <span class="componentPath"
+                                                data-sly-text="${pageComponent.componentPathInPage}"/>
                                     </sly>
                                     <sly data-sly-test="${pageComponent.componentTitle}">
                                         | ${pageComponent.componentTitle}
                                     </sly>
+                                    <span class="linktocomponent right-aligned">
+                                        <a href="${pageComponent.linkToComponent}" target="_blank" rel="noopener noreferrer">
+                                            <coral-icon icon="linkOut" size="XS" class="linktocomponent"></coral-icon></a>
+                                        <coral-tooltip placement="left" target=".linktocomponent">
+                                            <span slot="content">Opens the page in the editor and scrolls to this component.</span>
+                                        </coral-tooltip>
+                                    </span>
                                 </td>
                             </tr>
                             <sly data-sly-list.property="${pageComponent.checkableProperties}">
-                                <tr is="coral-table-row" class="row-separator ${property.cancelledClass}" id="row-${propertyList.index}">
+                                <tr is="coral-table-row" class="row-separator ${property.cancelledClass}"
+                                    id="row-${propertyList.index}">
                                     <th is="coral-table-headercell" class="previoussrc">
                                         <span class="propertyname">${property.wrapper.propertyName}</span>
                                         Previously Translated Text

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -39,7 +39,7 @@
                             <tbody is="coral-table-body" class="propertiestable"
                                    data-sly-list.pageComponent="${model.pageComponents}">
 
-                            <!-- Component start  -->
+                            <!--/* Component start */-->
 
                             <tr is="coral-table-row" class="component-head ${pageComponent.cancelledClass}"
                                 id="component-${pageComponentList.index}"
@@ -83,7 +83,7 @@
                             <sly data-sly-list.property="${pageComponent.checkableProperties}">
                                 <sly data-sly-test.cancelled="${pageComponent.cancelled}"></sly>
 
-                                <!-- Property start - title row  -->
+                                <!--/* Property start - title row */-->
 
                                 <tr is="coral-table-row"
                                     class="row-separator ${property.cancelledClass} ${property.processingNeededClass}"
@@ -155,7 +155,7 @@
                                     </sly>
                                 </tr>
 
-                                <!-- Property data row  -->
+                                <!--/* Property data row */-->
 
                                 <tr is="coral-table-row"
                                     class="property-row datarow ${property.cancelledClass} ${property.processingNeededClass}"
@@ -279,7 +279,7 @@
                                     </td>
                                 </tr>
 
-                                <!-- Action buttons  -->
+                                <!--/* Action buttons */-->
 
                                 <tr is="coral-table-row"
                                     class="property-row actionrow ${property.cancelledClass} ${property.processingNeededClass}"
@@ -344,7 +344,7 @@
                                     </td>
                                 </tr>
 
-                                <!-- Property end, component end  -->
+                                <!--/* Property end, component end */-->
 
                             </sly>
                             </tbody>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -41,6 +41,8 @@
 
                             <!--/* Component start */-->
 
+                            <tr is="coral-table-row" class="component-spacer"></tr>
+
                             <tr is="coral-table-row" class="component-head ${pageComponent.cancelledClass}"
                                 id="component-${pageComponentList.index}"
                                 data-componentpath="${pageComponent.componentPath}"
@@ -55,9 +57,10 @@
                                     </coral-tooltip>
                                     <button class="reenableinheritance onlycancelled" is="coral-button"
                                             variant="minimal"
-                                            title="Re-enable Inheritance" icon="linkOff"></button>
+                                            title="Re-enable Inheritance and synchronize" icon="linkOff"></button>
                                     <coral-tooltip placement="right" target="_prev">
-                                        <span slot="content">Re-enables the inheritance for the whole component.</span>
+                                        <span slot="content">Re-enables the inheritance for the whole component. If
+                                        there was a new translation, this is written into the page.</span>
                                     </coral-tooltip>
                                 </td>
                                 <td is="coral-table-cell" colspan="6">
@@ -92,7 +95,7 @@
                                     id="row-${pageComponentList.index}-${propertyList.index}">
                                     <sly data-sly-test="${cancelled}">
                                         <th is="coral-table-headercell" class="previoussrc">
-                                            <span class="propertyname">${property.wrapper.propertyName}</span>
+                                            <span class="propertyname">${property.propertyPathInComponent}</span>
                                             <sly data-sly-test.hasNewCopy="${property.wrapper.newTranslatedCopy}"></sly>
                                             <sly data-sly-test="${hasNewCopy}">
                                                 <span>Previously Translated Text</span>
@@ -108,7 +111,7 @@
                                             </coral-tooltip>
                                         </th>
                                         <th is="coral-table-headercell" class="srcdiffs">
-                                            <span class="propertyname">${property.wrapper.propertyName}</span>
+                                            <span class="propertyname">${property.propertyPathInComponent}</span>
                                             <sly data-sly-test="${hasNewCopy}">
                                                 <span>Original Diffs</span>
                                                 <coral-tooltip placement="bottom" target="_prev">

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -50,13 +50,13 @@
                                             variant="minimal"
                                             size="M"
                                             title="Cancel Inheritance" icon="link"></button>
-                                    <coral-tooltip placement="right" target=".cancelinheritance">
+                                    <coral-tooltip placement="right" target="_prev">
                                         <span slot="content">Cancels the inheritance for the whole component.</span>
                                     </coral-tooltip>
                                     <button class="reenableinheritance onlycancelled" is="coral-button"
                                             variant="minimal"
                                             title="Re-enable Inheritance" icon="linkOff"></button>
-                                    <coral-tooltip placement="right" target=".reenableinheritance">
+                                    <coral-tooltip placement="right" target="_prev">
                                         <span slot="content">Re-enables the inheritance for the whole component.</span>
                                     </coral-tooltip>
                                 </td>
@@ -74,7 +74,7 @@
                                            rel="noopener noreferrer">
                                             <coral-icon icon="linkOut" size="XS"
                                                         class="linktocomponent"></coral-icon></a>
-                                        <coral-tooltip placement="left" target=".linktocomponent">
+                                        <coral-tooltip placement="left" target="_prev">
                                             <span slot="content">Opens the page in the editor and scrolls to this component.</span>
                                         </coral-tooltip>
                                     </span>
@@ -93,63 +93,76 @@
                                     <sly data-sly-test="${cancelled}">
                                         <th is="coral-table-headercell" class="previoussrc">
                                             <span class="propertyname">${property.wrapper.propertyName}</span>
-                                            Previously Translated Text
+                                            <span>Previously Translated Text</span>
+                                            <coral-tooltip placement="top" target="_prev">
+                                                <span slot="content">The source text on which the translation currently shown in the current page was based.</span>
+                                            </coral-tooltip>
                                         </th>
-                                        <coral-tooltip placement="top" target=".previoussrc" hidden>
-                                            <span slot="content">The source text on which the translation currently shown in the current page was based.</span>
-                                        </coral-tooltip>
-                                        <th is="coral-table-headercell" class="newsrc">New Source Text</th>
-                                        <coral-tooltip placement="top" target=".newsrc" hidden>
-                                            <span slot="content">The new source text as it was during the last rollout.</span>
-                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="newsrc"><span>New Source Text</span>
+                                            <coral-tooltip placement="top" target="_prev">
+                                                <span slot="content">The new source text as it was during the last rollout.</span>
+                                            </coral-tooltip>
+                                        </th>
                                         <th is="coral-table-headercell" class="srcdiffs">
                                             <span class="propertyname">${property.wrapper.propertyName}</span>
-                                            Original Diffs
+                                            <span>Original Diffs</span>
+                                            <coral-tooltip placement="top" target="_prev">
+                                                <span slot="content">This shows the differences between the source text on which the translation currently shown in the current page was based and the new source text as it was during the last rollout.</span>
+                                            </coral-tooltip>
                                         </th>
-                                        <coral-tooltip placement="top" target=".srcdiffs" hidden>
-                                            <span slot="content">This shows the differences between the source text on which the translation currently shown in the current page was based and the new source text as it was during the last rollout.</span>
-                                        </coral-tooltip>
-                                        <th is="coral-table-headercell" class="newtrans">New Text Translation</th>
-                                        <coral-tooltip placement="top" target=".newtrans" hidden>
-                                            <span slot="content">The AI translation of the new source text.</span>
-                                        </coral-tooltip>
-                                        <th is="coral-table-headercell" class="editor">Editor for Current Text</th>
-                                        <coral-tooltip placement="top" target=".editor" hidden>
-                                            <span slot="content">Edit the current text on the page and save it when done.</span>
-                                        </coral-tooltip>
-                                        <th is="coral-table-headercell" class="currenttext">Current Text on Page</th>
-                                        <coral-tooltip placement="top" target=".currenttext" hidden>
-                                            <span slot="content">The current text displayed on the page, for comparison purposes.</span>
-                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="newtrans">
+                                            <span>New Text Translation</span>
+                                            <coral-tooltip placement="top" target="_prev">
+                                                <span slot="content">The AI translation of the new source text.</span>
+                                            </coral-tooltip>
+                                        </th>
+                                        <th is="coral-table-headercell" class="editor">
+                                            <span>Editor for Current Text</span>
+                                            <coral-tooltip placement="top" target="_prev">
+                                                <span slot="content">Edit the current text on the page and save it when done.</span>
+                                            </coral-tooltip>
+                                        </th>
+                                        <th is="coral-table-headercell" class="currenttext">
+                                            <span>Current Text on Page</span>
+                                            <coral-tooltip placement="top" target="_prev">
+                                                <span slot="content">The current text displayed on the page, for comparison purposes.</span>
+                                            </coral-tooltip>
+                                        </th>
                                     </sly>
                                     <sly data-sly-test="${!cancelled}">
                                         <th is="coral-table-headercell" class="previoussrc">
                                             <span class="propertyname">${property.wrapper.propertyName}</span>
-                                            Last accepted original text
+                                            <span>Last accepted original text</span>
+                                            <coral-tooltip placement="top" target="_prev">
+                                                <span slot="content">The original when the translation was accepted last time</span>
+                                            </coral-tooltip>
                                         </th>
-                                        <coral-tooltip placement="top" target=".previoussrc" hidden>
-                                            <span slot="content">The original when the translation was accepted last time</span>
-                                        </coral-tooltip>
-                                        <th is="coral-table-headercell" class="newsrc">Current original</th>
-                                        <coral-tooltip placement="top" target=".newsrc" hidden>
-                                            <span slot="content">The current original text.</span>
-                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="newsrc">
+                                            <span>Current original</span>
+                                            <coral-tooltip placement="top" target="_prev">
+                                                <span slot="content">The current original text.</span>
+                                            </coral-tooltip>
+                                        </th>
                                         <th is="coral-table-headercell" class="srcdiffs">
                                             <span class="propertyname">${property.wrapper.propertyName}</span>
-                                            Diffs from last accepted original
+                                            <span>Diffs from last accepted original</span>
+                                            <coral-tooltip placement="top" target="_prev">
+                                                <span slot="content">This shows the differences between the source text where the translation was last accepted
+                                                    and the current source text.</span>
+                                            </coral-tooltip>
                                         </th>
-                                        <coral-tooltip placement="top" target=".srcdiffs" hidden>
-                                            <span slot="content">This shows the differences between the source text where the translation was last accepted
-                                                and the current source text.</span>
-                                        </coral-tooltip>
-                                        <th is="coral-table-headercell" class="newtrans">Last accepted translation</th>
-                                        <coral-tooltip placement="top" target=".newtrans" hidden>
-                                            <span slot="content">The AI translation of the original where the translation was last accepted.</span>
-                                        </coral-tooltip>
-                                        <th is="coral-table-headercell" class="editor">The current text</th>
-                                        <coral-tooltip placement="top" target=".editor" hidden>
-                                            <span slot="content">The current text on the page - AI translation of the current original.</span>
-                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="newtrans">
+                                            <span>Last accepted translation</span>
+                                            <coral-tooltip placement="top" target="_prev">
+                                                <span slot="content">The AI translation of the original where the translation was last accepted.</span>
+                                            </coral-tooltip>
+                                        </th>
+                                        <th is="coral-table-headercell" class="editor">
+                                            <span>The current text</span>
+                                            <coral-tooltip placement="top" target="_prev">
+                                                <span slot="content">The current text on the page - AI translation of the current original.</span>
+                                            </coral-tooltip>
+                                        </th>
                                         <th is="coral-table-headercell" class="currenttext">
                                             <!-- Deliberately empty - no meaning here. --></th>
                                     </sly>
@@ -218,19 +231,19 @@
                                                     <button class="rte-btn" is="coral-button" variant="minimal"
                                                             title="Bold" icon="textBold"
                                                             data-command="bold"></button>
-                                                    <!-- <coral-tooltip placement="top" target=".rte-btn[title='Bold']">
+                                                    <!-- <coral-tooltip placement="top" target="_prev">
                                                         <span slot="content">Make the text bold.</span>
                                                     </coral-tooltip> -->
                                                     <button is="coral-button" variant="minimal" title="Italic"
                                                             icon="textItalic"
                                                             data-command="italic"></button>
-                                                    <!-- <coral-tooltip placement="top" target=".rte-btn[title='Italic']">
+                                                    <!-- <coral-tooltip placement="top" target="_prev">
                                                         <span slot="content">Make the text italic.</span>
                                                     </coral-tooltip> -->
                                                     <button is="coral-button" variant="minimal" title="Underline"
                                                             icon="textUnderline"
                                                             data-command="underline"></button>
-                                                    <!-- <coral-tooltip placement="top" target=".rte-btn[title='Underline']">
+                                                    <!-- <coral-tooltip placement="top" target="_prev">
                                                         <span slot="content">Underline the text.</span>
                                                     </coral-tooltip> -->
                                                     <button is="coral-button" variant="minimal" title="Edit Link"
@@ -241,14 +254,14 @@
                                                             icon="textBulleted"
                                                             data-command="insertUnorderedList"></button>
                                                     <!-- <coral-tooltip placement="top"
-                                                                   target=".rte-btn[title='Bullet List']">
+                                                                   target="_prev">
                                                         <span slot="content">Create a bullet list.</span>
                                                     </coral-tooltip> -->
                                                     <button is="coral-button" variant="minimal" title="Numbered List"
                                                             icon="textNumbered"
                                                             data-command="insertOrderedList"></button>
                                                     <!-- <coral-tooltip placement="top"
-                                                                   target=".rte-btn[title='Numbered List']">
+                                                                   target="_prev">
                                                         <span slot="content">Create a numbered list.</span>
                                                     </coral-tooltip> -->
                                                 </div>
@@ -297,14 +310,14 @@
                                                     class="intelligent-merge onlycancelled">AI Merge
                                                 <coral-wait size="S" class="spinner"></coral-wait>
                                             </button>
-                                            <coral-tooltip placement="right" target=".intelligent-merge">
+                                            <coral-tooltip placement="right" target="_prev">
                                                     <span slot="content">
                                                         This takes the current text, inspects the differences between the previously translated source text and the new source text and incorporates the corresponding changes from the new text translation. Thus this tries to keep manual changes that have been done to the current text of the component as much as possible.</span>
                                             </coral-tooltip>
                                             <button is="coral-button" variant="secondary"
                                                     class="copy-to-editor">Copy to Editor
                                             </button>
-                                            <coral-tooltip placement="right" target=".copy-to-editor">
+                                            <coral-tooltip placement="right" target="_prev">
                                                 <span slot="content">Copy the new translation as it is to the editor, replacing the editor content.</span>
                                             </coral-tooltip>
                                             <!-- <button is="coral-button" variant="secondary"
@@ -319,13 +332,13 @@
                                                     Save and Finish
                                                     <coral-wait size="S" class="spinner"></coral-wait>
                                                 </button>
-                                                <coral-tooltip placement="right" target=".save-editor">
+                                                <coral-tooltip placement="right" target="_prev">
                                                     <span slot="content">Save the changes made in the editor and marks this text as merged - that is it will not be shown again in this tool until there are further changes to the source text rolled out.</span>
                                                 </coral-tooltip>
                                                 <button is="coral-button" variant="secondary" class="reset-editor">
                                                     Reset
                                                 </button>
-                                                <coral-tooltip placement="right" target=".reset-editor">
+                                                <coral-tooltip placement="right" target="_prev">
                                                     <span slot="content">Resets the editor to the current text on the page.</span>
                                                 </coral-tooltip>
                                             </sly>
@@ -334,7 +347,7 @@
                                                         class="accept-translation">
                                                     Accept translation
                                                 </button>
-                                                <coral-tooltip placement="right" target=".accept-translation">
+                                                <coral-tooltip placement="right" target="_prev">
                                                     <span slot="content">Saves that the translation was accepted as it is. Alternative: cancel component and then edit.</span>
                                                 </coral-tooltip>
                                             </sly>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -42,7 +42,9 @@
                             <!-- Component start  -->
 
                             <tr is="coral-table-row" class="component-head ${pageComponent.cancelledClass}"
-                                id="component-${pageComponentList.index}">
+                                id="component-${pageComponentList.index}"
+                                data-componentpath="${pageComponent.componentPath}"
+                                data-propertyname="${pageComponent.cancelPropertyName}">
                                 <td class="cancelcol"
                                     rowspan="${pageComponent.calculatedComponentRowspan}">
                                     <button class="cancelinheritance onlycancelled" is="coral-button" variant="minimal"
@@ -85,6 +87,7 @@
 
                                 <tr is="coral-table-row"
                                     class="row-separator ${property.cancelledClass} ${property.processingNeededClass}"
+                                    data-componentpath="${pageComponent.componentPath}"
                                     id="row-${pageComponentList.index}-${propertyList.index}">
                                     <sly data-sly-test="${cancelled}">
                                         <th is="coral-table-headercell" class="previoussrc">
@@ -154,6 +157,7 @@
 
                                 <tr is="coral-table-row"
                                     class="property-row datarow ${property.cancelledClass} ${property.processingNeededClass}"
+                                    data-componentpath="${pageComponent.componentPath}"
                                     id="datarow-${pageComponentList.index}-${propertyList.index}"
                                     data-path="${property.path}"
                                     data-propertyname="${property.wrapper.propertyName}"
@@ -276,6 +280,7 @@
 
                                 <tr is="coral-table-row"
                                     class="property-row actionrow ${property.cancelledClass} ${property.processingNeededClass}"
+                                    data-componentpath="${pageComponent.componentPath}"
                                     id="actionrow-${pageComponentList.index}-${propertyList.index}">
                                     <td is="coral-table-cell" class="previoussrc diffscolor">
                                     </td>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -11,6 +11,9 @@
 <body class="coral--light coral-Body foundation-layout-util-maximized-alt show-diffs hide-currenttext"
       data-page-path="${model.pagePath}">
 
+<sly data-sly-call="${clientLib.js @ categories='coralui3,granite.ui.foundation.content'}"></sly>
+<script src="${resource.path @ context='uri'}/list.js"></script>
+
 <div class="foundation-layout-panel">
     <div class="foundation-layout-panel-bodywrapper spectrum-ready">
         <div class="foundation-layout-panel-body">
@@ -278,6 +281,21 @@
                                 <span slot="content">Toggle the visibility of the current text column, to compare the current status of the page.</span>
                             </coral-tooltip>
                         </a>
+                        <select id="propertyfilter" class="_coral-FieldButton _coral-ActionButton">
+                            <option value="allstati">All Properties</option>
+                            <option value="cancelled">Inheritance Cancelled</option>
+                            <option value="uncancelled">Inheritance Uncancelled</option>
+                        </select>
+                        <coral-tooltip placement="top" target="#propertyfilter">
+                            <span slot="content">Filter the properties by inheritance status.</span>
+                        </coral-tooltip>
+                        <select id="scope" class="_coral-FieldButton _coral-ActionButton">
+                            <option value="unfinished">Unfinished Properties</option>
+                            <option value="allprops">All Properties</option>
+                        </select>
+                        <coral-tooltip placement="top" target="#scope">
+                            <span slot="content">Filter the properties by their status in the translation process.</span>
+                        </coral-tooltip>
                         <a href="/editor.html${model.pagePath}.html" target="_blank">
                             <button is="coral-button" variant="secondary" class="open-in-editor">
                                 Open in Editor
@@ -347,8 +365,5 @@
 
 <div id="path-chooser-content">
 </div>
-
-<sly data-sly-call="${clientLib.js @ categories='coralui3,granite.ui.foundation.content,cq.authoring.editor.core'}"></sly>
-<script src="${resource.path @ context='uri'}/list.js"></script>
 
 </body>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -39,7 +39,7 @@
                             <tbody is="coral-table-body" class="propertiestable"
                                    data-sly-list.pageComponent="${model.pageComponents}">
 
-<!-- Component start  -->
+                            <!-- Component start  -->
 
                             <tr is="coral-table-row" class="component-head ${pageComponent.cancelledClass}"
                                 id="component-${pageComponentList.index}">
@@ -68,8 +68,10 @@
                                         | ${pageComponent.componentTitle}
                                     </sly>
                                     <span class="linktocomponent right-aligned">
-                                        <a href="${pageComponent.linkToComponent}" target="_blank" rel="noopener noreferrer">
-                                            <coral-icon icon="linkOut" size="XS" class="linktocomponent"></coral-icon></a>
+                                        <a href="${pageComponent.linkToComponent}" target="_blank"
+                                           rel="noopener noreferrer">
+                                            <coral-icon icon="linkOut" size="XS"
+                                                        class="linktocomponent"></coral-icon></a>
                                         <coral-tooltip placement="left" target=".linktocomponent">
                                             <span slot="content">Opens the page in the editor and scrolls to this component.</span>
                                         </coral-tooltip>
@@ -77,46 +79,81 @@
                                 </td>
                             </tr>
                             <sly data-sly-list.property="${pageComponent.checkableProperties}">
+                                <sly data-sly-test.cancelled="${pageComponent.cancelled}"></sly>
 
-<!-- Property start - title row  -->
+                                <!-- Property start - title row  -->
 
-                                <tr is="coral-table-row" class="row-separator ${property.cancelledClass} ${property.processingNeededClass}"
+                                <tr is="coral-table-row"
+                                    class="row-separator ${property.cancelledClass} ${property.processingNeededClass}"
                                     id="row-${pageComponentList.index}-${propertyList.index}">
-                                    <th is="coral-table-headercell" class="previoussrc">
-                                        <span class="propertyname">${property.wrapper.propertyName}</span>
-                                        Previously Translated Text
-                                    </th>
-                                    <coral-tooltip placement="top" target=".previoussrc" hidden>
-                                        <span slot="content">The source text on which the translation currently shown in the current page was based.</span>
-                                    </coral-tooltip>
-                                    <th is="coral-table-headercell" class="newsrc">New Source Text</th>
-                                    <coral-tooltip placement="top" target=".newsrc" hidden>
-                                        <span slot="content">The new source text as it was during the last rollout.</span>
-                                    </coral-tooltip>
-                                    <th is="coral-table-headercell" class="srcdiffs">
-                                        <span class="propertyname">${property.wrapper.propertyName}</span>
-                                        Original Diffs
-                                    </th>
-                                    <coral-tooltip placement="top" target=".srcdiffs" hidden>
-                                        <span slot="content">This shows the differences between the source text on which the translation currently shown in the current page was based and the new source text as it was during the last rollout.</span>
-                                    </coral-tooltip>
-                                    <th is="coral-table-headercell" class="newtrans">New Text Translation</th>
-                                    <coral-tooltip placement="top" target=".newtrans" hidden>
-                                        <span slot="content">The AI translation of the new source text.</span>
-                                    </coral-tooltip>
-                                    <th is="coral-table-headercell" class="editor">Editor for Current Text</th>
-                                    <coral-tooltip placement="top" target=".editor" hidden>
-                                        <span slot="content">Edit the current text on the page and save it when done.</span>
-                                    </coral-tooltip>
-                                    <th is="coral-table-headercell" class="currenttext">Current Text on Page</th>
-                                    <coral-tooltip placement="top" target=".currenttext" hidden>
-                                        <span slot="content">The current text displayed on the page, for comparison purposes.</span>
-                                    </coral-tooltip>
+                                    <sly data-sly-test="${cancelled}">
+                                        <th is="coral-table-headercell" class="previoussrc">
+                                            <span class="propertyname">${property.wrapper.propertyName}</span>
+                                            Previously Translated Text
+                                        </th>
+                                        <coral-tooltip placement="top" target=".previoussrc" hidden>
+                                            <span slot="content">The source text on which the translation currently shown in the current page was based.</span>
+                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="newsrc">New Source Text</th>
+                                        <coral-tooltip placement="top" target=".newsrc" hidden>
+                                            <span slot="content">The new source text as it was during the last rollout.</span>
+                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="srcdiffs">
+                                            <span class="propertyname">${property.wrapper.propertyName}</span>
+                                            Original Diffs
+                                        </th>
+                                        <coral-tooltip placement="top" target=".srcdiffs" hidden>
+                                            <span slot="content">This shows the differences between the source text on which the translation currently shown in the current page was based and the new source text as it was during the last rollout.</span>
+                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="newtrans">New Text Translation</th>
+                                        <coral-tooltip placement="top" target=".newtrans" hidden>
+                                            <span slot="content">The AI translation of the new source text.</span>
+                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="editor">Editor for Current Text</th>
+                                        <coral-tooltip placement="top" target=".editor" hidden>
+                                            <span slot="content">Edit the current text on the page and save it when done.</span>
+                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="currenttext">Current Text on Page</th>
+                                        <coral-tooltip placement="top" target=".currenttext" hidden>
+                                            <span slot="content">The current text displayed on the page, for comparison purposes.</span>
+                                        </coral-tooltip>
+                                    </sly>
+                                    <sly data-sly-test="${!cancelled}">
+                                        <th is="coral-table-headercell" class="previoussrc">
+                                            <span class="propertyname">${property.wrapper.propertyName}</span>
+                                            Last accepted original text
+                                        </th>
+                                        <coral-tooltip placement="top" target=".previoussrc" hidden>
+                                            <span slot="content">The original when the translation was accepted last time</span>
+                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="newsrc">Current original</th>
+                                        <coral-tooltip placement="top" target=".newsrc" hidden>
+                                            <span slot="content">The current original text.</span>
+                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="srcdiffs">
+                                            <span class="propertyname">${property.wrapper.propertyName}</span>
+                                            Diffs from last accepted original
+                                        </th>
+                                        <coral-tooltip placement="top" target=".srcdiffs" hidden>
+                                            <span slot="content">This shows the differences between the source text where the translation was last accepted
+                                                and the current source text.</span>
+                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="newtrans">Last accepted translation</th>
+                                        <coral-tooltip placement="top" target=".newtrans" hidden>
+                                            <span slot="content">The AI translation of the original where the translation was last accepted.</span>
+                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="editor">The current text</th>
+                                        <coral-tooltip placement="top" target=".editor" hidden>
+                                            <span slot="content">The current text on the page - AI translation of the current original.</span>
+                                        </coral-tooltip>
+                                        <th is="coral-table-headercell" class="currenttext"><!-- Deliberately empty - no meaning here. --></th>
+                                    </sly>
                                 </tr>
 
-<!-- Property data row  -->
+                                <!-- Property data row  -->
 
-                                <tr is="coral-table-row" class="property-row datarow ${property.cancelledClass} ${property.processingNeededClass}"
+                                <tr is="coral-table-row"
+                                    class="property-row datarow ${property.cancelledClass} ${property.processingNeededClass}"
                                     id="datarow-${pageComponentList.index}-${propertyList.index}"
                                     data-path="${property.path}"
                                     data-propertyname="${property.wrapper.propertyName}"
@@ -125,87 +162,109 @@
                                     data-ot="${property.wrapper.translatedCopy}"
                                     data-ns="${property.wrapper.newOriginalCopy}"
                                     data-nt="${property.wrapper.newTranslatedCopy}"
-                                    data-sd="${property.originalCopyDiffsHTML}"
+                                    data-as="${property.wrapper.acceptedSource}"
+                                    data-at="${property.wrapper.acceptedTranslation}"
+                                    data-sd="${property.diffsHTML}"
                                     data-e="${property.wrapper.currentValue}"
                                     data-id="${pageComponentList.index}-${propertyList.index}"
                                     data-isrich="${property.wrapper.isRichText}">
                                     <td is="coral-table-cell" class="previoussrc diffscolor">
                                         <p data-sly-unwrap="${property.wrapper.isRichText}">
-                                            ${property.originalCopyInsertionsMarked @ context='html'}
+                                            ${property.diffsSrcInsertionsMarked @ context='html'}
                                         </p>
                                     </td>
                                     <td is="coral-table-cell" class="newsrc diffscolor">
                                         <p data-sly-unwrap="${property.wrapper.isRichText}">
-                                            ${property.newOriginalCopyInsertionsMarked @ context='html'}
+                                            ${property.diffsDstInsertionsMarked @ context='html'}
                                         </p>
                                     </td>
                                     <td is="coral-table-cell"
                                         class="srcdiffs diffscolor">
                                         <p data-sly-unwrap="${property.wrapper.isRichText}">
-                                        ${property.originalCopyDiffsHTML @ context='html'}</td>
+                                        ${property.diffsHTML @ context='html'}</td>
                                     <td is="coral-table-cell"
-                                        class="newtrans">
-                                        <div class="newtrans-text">
-                                            <sly data-sly-test.isrichtext="${property.wrapper.isRichText}">
-                                                ${property.wrapper.newTranslatedCopy @ context='html'}
+                                        class="translation">
+                                        <div class="translation-text">
+                                            <sly data-sly-test="${cancelled}">
+                                                <sly data-sly-test.isrichtext="${property.wrapper.isRichText}">
+                                                    ${property.wrapper.newTranslatedCopy @ context='html'}
+                                                </sly>
+                                                <sly data-sly-test="${!isrichtext}">
+                                                    <p>${property.wrapper.newTranslatedCopy}</p>
+                                                </sly>
                                             </sly>
-                                            <sly data-sly-test="${!isrichtext}">
-                                                <p>${property.wrapper.newTranslatedCopy}</p>
+                                            <sly data-sly-test="${!cancelled}">
+                                                <sly data-sly-test.isrichtext="${property.wrapper.isRichText}">
+                                                    ${property.wrapper.acceptedTranslation @ context='html'}
+                                                </sly>
+                                                <sly data-sly-test="${!isrichtext}">
+                                                    <p>${property.wrapper.acceptedTranslation}</p>
+                                                </sly>
                                             </sly>
                                         </div>
                                     </td>
                                     <td is="coral-table-cell" class="editor">
-                                        <div class="rte-container"
-                                             data-sly-test.isrichtext="${property.wrapper.isRichText}">
-                                            <div class="rte-toolbar">
-                                                <button class="rte-btn" is="coral-button" variant="minimal"
-                                                        title="Bold" icon="textBold"
-                                                        data-command="bold"></button>
-                                                <!-- <coral-tooltip placement="top" target=".rte-btn[title='Bold']">
-                                                    <span slot="content">Make the text bold.</span>
-                                                </coral-tooltip> -->
-                                                <button is="coral-button" variant="minimal" title="Italic"
-                                                        icon="textItalic"
-                                                        data-command="italic"></button>
-                                                <!-- <coral-tooltip placement="top" target=".rte-btn[title='Italic']">
-                                                    <span slot="content">Make the text italic.</span>
-                                                </coral-tooltip> -->
-                                                <button is="coral-button" variant="minimal" title="Underline"
-                                                        icon="textUnderline"
-                                                        data-command="underline"></button>
-                                                <!-- <coral-tooltip placement="top" target=".rte-btn[title='Underline']">
-                                                    <span slot="content">Underline the text.</span>
-                                                </coral-tooltip> -->
-                                                <button is="coral-button" variant="minimal" title="Edit Link"
-                                                        icon="link" class="edit-link-btn"></button>
-                                                <button is="coral-button" variant="minimal" title="Remove Link"
-                                                        icon="unlink" class="remove-link-btn"></button>
-                                                <button is="coral-button" variant="minimal" title="Bullet List"
-                                                        icon="textBulleted"
-                                                        data-command="insertUnorderedList"></button>
-                                                <!-- <coral-tooltip placement="top"
-                                                               target=".rte-btn[title='Bullet List']">
-                                                    <span slot="content">Create a bullet list.</span>
-                                                </coral-tooltip> -->
-                                                <button is="coral-button" variant="minimal" title="Numbered List"
-                                                        icon="textNumbered"
-                                                        data-command="insertOrderedList"></button>
-                                                <!-- <coral-tooltip placement="top"
-                                                               target=".rte-btn[title='Numbered List']">
-                                                    <span slot="content">Create a numbered list.</span>
-                                                </coral-tooltip> -->
+                                        <sly data-sly-test="${cancelled}">
+                                            <div class="rte-container"
+                                                 data-sly-test.isrichtext="${property.wrapper.isRichText}">
+                                                <div class="rte-toolbar">
+                                                    <button class="rte-btn" is="coral-button" variant="minimal"
+                                                            title="Bold" icon="textBold"
+                                                            data-command="bold"></button>
+                                                    <!-- <coral-tooltip placement="top" target=".rte-btn[title='Bold']">
+                                                        <span slot="content">Make the text bold.</span>
+                                                    </coral-tooltip> -->
+                                                    <button is="coral-button" variant="minimal" title="Italic"
+                                                            icon="textItalic"
+                                                            data-command="italic"></button>
+                                                    <!-- <coral-tooltip placement="top" target=".rte-btn[title='Italic']">
+                                                        <span slot="content">Make the text italic.</span>
+                                                    </coral-tooltip> -->
+                                                    <button is="coral-button" variant="minimal" title="Underline"
+                                                            icon="textUnderline"
+                                                            data-command="underline"></button>
+                                                    <!-- <coral-tooltip placement="top" target=".rte-btn[title='Underline']">
+                                                        <span slot="content">Underline the text.</span>
+                                                    </coral-tooltip> -->
+                                                    <button is="coral-button" variant="minimal" title="Edit Link"
+                                                            icon="link" class="edit-link-btn"></button>
+                                                    <button is="coral-button" variant="minimal" title="Remove Link"
+                                                            icon="unlink" class="remove-link-btn"></button>
+                                                    <button is="coral-button" variant="minimal" title="Bullet List"
+                                                            icon="textBulleted"
+                                                            data-command="insertUnorderedList"></button>
+                                                    <!-- <coral-tooltip placement="top"
+                                                                   target=".rte-btn[title='Bullet List']">
+                                                        <span slot="content">Create a bullet list.</span>
+                                                    </coral-tooltip> -->
+                                                    <button is="coral-button" variant="minimal" title="Numbered List"
+                                                            icon="textNumbered"
+                                                            data-command="insertOrderedList"></button>
+                                                    <!-- <coral-tooltip placement="top"
+                                                                   target=".rte-btn[title='Numbered List']">
+                                                        <span slot="content">Create a numbered list.</span>
+                                                    </coral-tooltip> -->
+                                                </div>
+                                                <div class="rte-editor" contenteditable="true">
+                                                    ${property.wrapper.currentValue @ context='html'}
+                                                </div>
                                             </div>
-                                            <div class="rte-editor" contenteditable="true">
-                                                ${property.wrapper.currentValue @ context='html'}
-                                            </div>
-                                        </div>
-                                        <div class="text-container" data-sly-test="${!isrichtext}">
+                                            <div class="text-container" data-sly-test="${!isrichtext}">
                                                 <textarea class="text-editor" rows="3"
                                                           data-sly-text="${property.wrapper.currentValue}"></textarea>
-                                        </div>
+                                            </div>
+                                        </sly>
+                                        <sly data-sly-test="${!cancelled}">
+                                            <sly data-sly-test.isrichtext="${property.wrapper.isRichText}">
+                                                ${property.wrapper.currentValue @ context='html'}
+                                            </sly>
+                                            <sly data-sly-test="${!isrichtext}">
+                                                <p>${property.wrapper.currentValue}</p>
+                                            </sly>
+                                        </sly>
                                     </td>
                                     <td is="coral-table-cell" class="currenttext">
-                                        <div class="current-text">
+                                        <div class="current-text" data-sly-test="${cancelled}">
                                             <p data-sly-unwrap="${property.wrapper.isRichText}">
                                                 ${property.wrapper.currentValue @ context='html'}
                                             </p>
@@ -213,9 +272,10 @@
                                     </td>
                                 </tr>
 
-<!-- Action buttons  -->
+                                <!-- Action buttons  -->
 
-                                <tr is="coral-table-row" class="property-row actionrow ${property.cancelledClass} ${property.processingNeededClass}"
+                                <tr is="coral-table-row"
+                                    class="property-row actionrow ${property.cancelledClass} ${property.processingNeededClass}"
                                     id="actionrow-${pageComponentList.index}-${propertyList.index}">
                                     <td is="coral-table-cell" class="previoussrc diffscolor">
                                     </td>
@@ -223,7 +283,7 @@
                                     </td>
                                     <td is="coral-table-cell" class="srcdiffs diffscolor"></td>
                                     <td is="coral-table-cell" class="newtrans">
-                                        <div class="row-actions">
+                                        <div class="row-actions" data-sly-test="${cancelled}">
                                             <button is="coral-button" variant="secondary"
                                                     class="intelligent-merge onlycancelled">AI Merge
                                                 <coral-wait size="S" class="spinner"></coral-wait>
@@ -245,33 +305,45 @@
                                     </td>
                                     <td is="coral-table-cell" class="editor">
                                         <div class="editor-actions">
-                                            <button is="coral-button" variant="primary" class="save-editor">
-                                                Save and Finish
-                                                <coral-wait size="S" class="spinner"></coral-wait>
-                                            </button>
-                                            <coral-tooltip placement="right" target=".save-editor">
-                                                <span slot="content">Save the changes made in the editor and marks this text as merged - that is it will not be shown again in this tool until there are further changes to the source text rolled out.</span>
-                                            </coral-tooltip>
-                                            <button is="coral-button" variant="secondary" class="reset-editor">
-                                                Reset
-                                            </button>
-                                            <coral-tooltip placement="right" target=".reset-editor">
-                                                <span slot="content">Resets the editor to the current text on the page.</span>
-                                            </coral-tooltip>
+                                            <sly data-sly-test="${cancelled}">
+                                                <button is="coral-button" variant="primary" class="save-editor">
+                                                    Save and Finish
+                                                    <coral-wait size="S" class="spinner"></coral-wait>
+                                                </button>
+                                                <coral-tooltip placement="right" target=".save-editor">
+                                                    <span slot="content">Save the changes made in the editor and marks this text as merged - that is it will not be shown again in this tool until there are further changes to the source text rolled out.</span>
+                                                </coral-tooltip>
+                                                <button is="coral-button" variant="secondary" class="reset-editor">
+                                                    Reset
+                                                </button>
+                                                <coral-tooltip placement="right" target=".reset-editor">
+                                                    <span slot="content">Resets the editor to the current text on the page.</span>
+                                                </coral-tooltip>
+                                            </sly>
+                                            <sly data-sly-test="${!cancelled}">
+                                                <button is="coral-button" variant="secondary"
+                                                        class="accept-translation">
+                                                    Accept translation
+                                                </button>
+                                                <coral-tooltip placement="right" target=".accept-translation">
+                                                    <span slot="content">Saves that the translation was accepted as it is. Alternative: cancel component and then edit.</span>
+                                                </coral-tooltip>
+                                            </sly>
                                         </div>
                                     </td>
                                     <td is="coral-table-cell" class="currenttext">
                                     </td>
                                 </tr>
 
-<!-- Property end, component end  -->
+                                <!-- Property end, component end  -->
 
                             </sly>
                             </tbody>
                         </table>
                     </section>
 
-                    <sly data-sly-use.bottombar="${'bottombar-template.html'}" data-sly-call="${bottombar.bottombarTemplate @ model=model}"></sly>
+                    <sly data-sly-use.bottombar="${'bottombar-template.html'}"
+                         data-sly-call="${bottombar.bottombarTemplate @ model=model}"></sly>
                 </div>
             </div>
         </div>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -64,7 +64,7 @@
                             <tbody is="coral-table-body" class="propertiestable"
                                    data-sly-list.pageComponent="${model.pageComponents}">
                             <tr is="coral-table-row" class="component-head" id="component-${pageComponentList.index}">
-                                <td class="coral-table-cell" class="cancelcol"
+                                <td class="cancelcol"
                                     rowspan="${pageComponent.calculatedComponentRowspan}">
                                     <button class="cancelinheritance" is="coral-button" variant="minimal" size="M"
                                             title="Cancel Inheritance" icon="link"></button>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -27,52 +27,24 @@
                                 - until they are saved and marked as merged.
                             </span>
                     </section>
+
                     <section class="coral-Form-fieldset propertytable">
                         <table is="coral-table">
                             <colgroup>
                                 <col is="coral-table-column" fixedwidth>
                             </colgroup>
-                            <thead is="coral-table-head" sticky>
-                            <tr is="coral-table-row" class="tablehead">
-                                <th is="coral-table-headercell" class="cancelcol"><!-- Column for cancel button --></th>
-                                <th is="coral-table-headercell" class="previoussrc">Previously Translated Text</th>
-                                <coral-tooltip placement="top" target=".previoussrc">
-                                    <span slot="content">The source text on which the translation currently shown in the current page was based.</span>
-                                </coral-tooltip>
-                                <th is="coral-table-headercell" class="newsrc">New Source Text</th>
-                                <coral-tooltip placement="top" target=".newsrc">
-                                    <span slot="content">The new source text as it was during the last rollout.</span>
-                                </coral-tooltip>
-                                <th is="coral-table-headercell" class="srcdiffs">Original Diffs</th>
-                                <coral-tooltip placement="top" target=".srcdiffs">
-                                    <span slot="content">This shows the differences between the source text on which the translation currently shown in the current page was based and the new source text as it was during the last rollout.</span>
-                                </coral-tooltip>
-                                <th is="coral-table-headercell" class="newtrans">New Text Translation</th>
-                                <coral-tooltip placement="top" target=".newtrans">
-                                    <span slot="content">The AI translation of the new source text.</span>
-                                </coral-tooltip>
-                                <th is="coral-table-headercell" class="editor">Editor for Current Text</th>
-                                <coral-tooltip placement="top" target=".editor">
-                                    <span slot="content">Edit the current text on the page and save it when done.</span>
-                                </coral-tooltip>
-                                <th is="coral-table-headercell" class="currenttext">Current Text on Page</th>
-                                <coral-tooltip placement="top" target=".currenttext">
-                                    <span slot="content">The current text displayed on the page, for comparison purposes.</span>
-                                </coral-tooltip>
-                            </tr>
-                            </thead>
                             <tbody is="coral-table-body" class="propertiestable"
                                    data-sly-list.pageComponent="${model.pageComponents}">
-                            <tr is="coral-table-row" class="component-head" id="component-${pageComponentList.index}">
+                            <tr is="coral-table-row" class="component-head ${pageComponent.cancelledClass}" id="component-${pageComponentList.index}">
                                 <td class="cancelcol"
                                     rowspan="${pageComponent.calculatedComponentRowspan}">
-                                    <button class="cancelinheritance" is="coral-button" variant="minimal" size="M"
-                                            title="Cancel Inheritance" icon="link"></button>
+                                    <button class="cancelinheritance onlycancelled" is="coral-button" variant="minimal" size="M"
+                                            title="Cancel Inheritance" icon="linkOff"></button>
                                     <coral-tooltip placement="right" target=".cancelinheritance">
                                         <span slot="content">Cancels the inheritance for the whole component.</span>
                                     </coral-tooltip>
-                                    <button class="reenableinheritance" is="coral-button" variant="minimal"
-                                            title="Re-enable Inheritance" icon="linkOff"></button>
+                                    <button class="reenableinheritance onlyuncancelled" is="coral-button" variant="minimal"
+                                            title="Re-enable Inheritance" icon="link"></button>
                                     <coral-tooltip placement="right" target=".reenableinheritance">
                                         <span slot="content">Re-enables the inheritance for the whole component.</span>
                                     </coral-tooltip>
@@ -88,24 +60,34 @@
                                 </td>
                             </tr>
                             <sly data-sly-list.property="${pageComponent.checkableProperties}">
-                                <tr is="coral-table-row" class="row-separator" id="row-${propertyList.index}">
-                                    <td is="coral-table-cell" class="row-separator"
-                                        colspan="6">
-                                        <!-- <a href="#" data-backwardid="${propertyList.index}"
-                                           data-sly-test="${!propertyList.first}">
-                                            <button is="coral-button" size="S" variant="minimal" icon="arrowUp"
-                                                    class="move-up" title="Up"></button>
-                                        </a>
-                                        <a href="#" data-forwardid="${propertyList.index}"
-                                           data-sly-test="${!propertyList.last}">
-                                            <button is="coral-button" size="S" variant="minimal"
-                                                    icon="arrowDown" class="move-down" title="Down"></button>
-                                        </a> -->
-                                        ${property.wrapper.propertyName}
-                                    </td>
+                                <tr is="coral-table-row" class="row-separator ${property.cancelledClass}" id="row-${propertyList.index}">
+                                    <th is="coral-table-headercell" class="previoussrc">Previously Translated Text</th>
+                                    <coral-tooltip placement="top" target=".previoussrc" hidden>
+                                        <span slot="content">The source text on which the translation currently shown in the current page was based.</span>
+                                    </coral-tooltip>
+                                    <th is="coral-table-headercell" class="newsrc">New Source Text</th>
+                                    <coral-tooltip placement="top" target=".newsrc" hidden>
+                                        <span slot="content">The new source text as it was during the last rollout.</span>
+                                    </coral-tooltip>
+                                    <th is="coral-table-headercell" class="srcdiffs">Original Diffs</th>
+                                    <coral-tooltip placement="top" target=".srcdiffs" hidden>
+                                        <span slot="content">This shows the differences between the source text on which the translation currently shown in the current page was based and the new source text as it was during the last rollout.</span>
+                                    </coral-tooltip>
+                                    <th is="coral-table-headercell" class="newtrans">New Text Translation</th>
+                                    <coral-tooltip placement="top" target=".newtrans" hidden>
+                                        <span slot="content">The AI translation of the new source text.</span>
+                                    </coral-tooltip>
+                                    <th is="coral-table-headercell" class="editor">Editor for Current Text</th>
+                                    <coral-tooltip placement="top" target=".editor" hidden>
+                                        <span slot="content">Edit the current text on the page and save it when done.</span>
+                                    </coral-tooltip>
+                                    <th is="coral-table-headercell" class="currenttext">Current Text on Page</th>
+                                    <coral-tooltip placement="top" target=".currenttext" hidden>
+                                        <span slot="content">The current text displayed on the page, for comparison purposes.</span>
+                                    </coral-tooltip>
                                 </tr>
                                 <!-- Data row -->
-                                <tr is="coral-table-row" class="property-row datarow"
+                                <tr is="coral-table-row" class="property-row datarow ${property.cancelledClass}"
                                     id="datarow-${propertyList.index}"
                                     data-path="${property.path}"
                                     data-propertyname="${property.wrapper.propertyName}"
@@ -203,7 +185,7 @@
                                     </td>
                                 </tr>
                                 <!-- Action buttons TR -->
-                                <tr is="coral-table-row" class="property-row actionrow"
+                                <tr is="coral-table-row" class="property-row actionrow ${property.cancelledClass}"
                                     id="actionrow-${propertyList.index}">
                                     <td is="coral-table-cell" class="previoussrc diffscolor">
                                     </td>
@@ -213,7 +195,7 @@
                                     <td is="coral-table-cell" class="newtrans">
                                         <div class="row-actions">
                                             <button is="coral-button" variant="secondary"
-                                                    class="intelligent-merge">AI Merge
+                                                    class="intelligent-merge onlycancelled">AI Merge
                                                 <coral-wait size="S" class="spinner"></coral-wait>
                                             </button>
                                             <coral-tooltip placement="right" target=".intelligent-merge">
@@ -255,6 +237,7 @@
                             </tbody>
                         </table>
                     </section>
+
                     <section class="coral-Form-fieldset bottombar coral--light">
                         <p class="errormessage" hidden>
                             <coral-alert variant="error">
@@ -308,8 +291,7 @@
         </div>
     </div>
 </div>
-<sly data-sly-call="${clientLib.js @ categories='coralui3,granite.ui.foundation.content,cq.authoring.editor.core'}"></sly>
-<script src="${resource.path @ context='uri'}/list.js"></script>
+
 <div id="edit-link-modal" class="modal-backdrop hidden">
     <div class="modal-content wide">
         <h3>Edit Link</h3>
@@ -347,5 +329,8 @@
 
 <div id="path-chooser-content">
 </div>
+
+<sly data-sly-call="${clientLib.js @ categories='coralui3,granite.ui.foundation.content,cq.authoring.editor.core'}"></sly>
+<script src="${resource.path @ context='uri'}/list.js"></script>
 
 </body>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -21,6 +21,14 @@
     </span>
     &nbsp;&nbsp;
 </sly>
+<sly data-sly-template.maybeHTML="${@ text, richtext}">
+    <sly data-sly-test="${richtext}">
+        ${text @ context='html'}
+    </sly>
+    <sly data-sly-test="${!richtext}">
+        <p>${text}</p>
+    </sly>
+</sly>
 
 <div class="foundation-layout-panel">
     <div class="foundation-layout-panel-bodywrapper spectrum-ready">
@@ -93,6 +101,10 @@
                             </tr>
                             <sly data-sly-list.property="${pageComponent.checkableProperties}">
                                 <sly data-sly-test.cancelled="${pageComponent.cancelled}"></sly>
+                                <sly data-sly-test.isRichText="${property.wrapper.isRichText}"></sly>
+                                <sly data-sly-test.hasNewCopy="${property.wrapper.newTranslatedCopy}"></sly>
+                                <sly data-sly-test.hasAccepted="${property.wrapper.acceptedTranslation}"></sly>
+                                <sly data-sly-test.hasData="${cancelled && hasNewCopy || !cancelled && hasAccepted}"></sly>
 
                                 <!--/* Property start - title row */-->
 
@@ -107,7 +119,6 @@
                                                 <sly data-sly-call="${todoIcon}"></sly>
                                                 ${property.propertyPathInComponent}
                                             </span>
-                                            <sly data-sly-test.hasNewCopy="${property.wrapper.newTranslatedCopy}"></sly>
                                             <sly data-sly-test="${hasNewCopy}">
                                                 <span>Previously Translated Text</span>
                                                 <coral-tooltip placement="bottom" target="_prev">
@@ -226,58 +237,34 @@
                                     data-id="${pageComponentList.index}-${propertyList.index}"
                                     data-isrich="${property.wrapper.isRichText}">
                                     <td is="coral-table-cell" class="previoussrc diffscolor">
-                                        <p data-sly-unwrap="${property.wrapper.isRichText}">
-                                            <sly data-sly-test="${hasNewCopy}">
-                                                ${property.diffsSrcInsertionsMarked @ context='html'}
-                                            </sly>
-                                        </p>
+                                        <sly data-sly-test="${hasData}">
+                                            <sly data-sly-call="${maybeHTML @ text=property.diffsSrcInsertionsMarked, richtext=true}"></sly>
+                                        </sly>
                                     </td>
                                     <td is="coral-table-cell" class="newsrc diffscolor">
-                                        <p data-sly-unwrap="${property.wrapper.isRichText}">
-                                            <sly data-sly-test="${hasNewCopy}">
-                                                ${property.diffsDstInsertionsMarked @ context='html'}
-                                            </sly>
-                                            <sly data-sly-test="${!hasNewCopy}">
-                                                <sly data-sly-test.isrichtext="${property.wrapper.isRichText}">
-                                                    ${property.wrapper.originalCopy @ context='html'}
-                                                </sly>
-                                                <sly data-sly-test="${!isrichtext}">
-                                                    ${property.wrapper.originalCopy}
-                                                </sly>
-                                            </sly>
-                                        </p>
+                                        <sly data-sly-test="${!hasData}">
+                                            <sly data-sly-call="${maybeHTML @ text=property.wrapper.originalCopy, richtext=isRichText}"></sly>
+                                        </sly>
+                                        <sly data-sly-test="${hasData}">
+                                            <sly data-sly-call="${maybeHTML @ text=property.diffsDstInsertionsMarked, richtext=true}"></sly>
+                                        </sly>
                                     </td>
-                                    <td is="coral-table-cell"
-                                        class="srcdiffs diffscolor">
-                                        <p data-sly-unwrap="${property.wrapper.isRichText}">
-                                            <sly data-sly-test="${hasNewCopy}">
-                                                ${property.diffsHTML @ context='html'}
-                                            </sly>
-                                            <sly data-sly-test.isrichtext="${property.wrapper.isRichText}">
-                                                ${property.wrapper.originalCopy @ context='html'}
-                                            </sly>
-                                            <sly data-sly-test="${!isrichtext}">
-                                                <p>${property.wrapper.originalCopy}</p>
-                                            </sly>
-                                        </p>
+                                    <td is="coral-table-cell" class="srcdiffs diffscolor">
+                                        <sly data-sly-test="${!hasData}">
+                                            <sly data-sly-call="${maybeHTML @ text=property.wrapper.originalCopy, richtext=isRichText}"></sly>
+                                        </sly>
+                                        <sly data-sly-test="${hasData}">
+                                            <sly data-sly-call="${maybeHTML @ text=property.diffsHTML, richtext=true}"></sly>
+                                        </sly>
                                     </td>
-                                    <td is="coral-table-cell"
-                                        class="translation">
+                                    <td is="coral-table-cell" class="translation">
                                         <div class="translation-text">
-                                            <sly data-sly-test="${cancelled}">
-                                                <sly data-sly-test.isrichtext="${property.wrapper.isRichText}">
-                                                    ${property.wrapper.newTranslatedCopy @ context='html'}
+                                            <sly data-sly-test="${hasData}">
+                                                <sly data-sly-test="${!cancelled}">
+                                                    <sly data-sly-call="${maybeHTML @ text=property.wrapper.acceptedTranslation, richtext=true}"></sly>
                                                 </sly>
-                                                <sly data-sly-test="${!isrichtext}">
-                                                    <p>${property.wrapper.newTranslatedCopy}</p>
-                                                </sly>
-                                            </sly>
-                                            <sly data-sly-test="${!cancelled}">
-                                                <sly data-sly-test.isrichtext="${property.wrapper.isRichText}">
-                                                    ${property.wrapper.acceptedTranslation @ context='html'}
-                                                </sly>
-                                                <sly data-sly-test="${!isrichtext}">
-                                                    <p>${property.wrapper.acceptedTranslation}</p>
+                                                <sly data-sly-test="${cancelled}">
+                                                    <sly data-sly-call="${maybeHTML @ text=property.wrapper.newTranslatedCopy, richtext=true}"></sly>
                                                 </sly>
                                             </sly>
                                         </div>
@@ -334,19 +321,12 @@
                                             </div>
                                         </sly>
                                         <sly data-sly-test="${!cancelled}">
-                                            <sly data-sly-test.isrichtext="${property.wrapper.isRichText}">
-                                                ${property.wrapper.currentValue @ context='html'}
-                                            </sly>
-                                            <sly data-sly-test="${!isrichtext}">
-                                                <p>${property.wrapper.currentValue}</p>
-                                            </sly>
+                                            <sly data-sly-call="${maybeHTML @ text=property.wrapper.currentValue, richtext=isRichText}"></sly>
                                         </sly>
                                     </td>
                                     <td is="coral-table-cell" class="currenttext">
                                         <div class="current-text" data-sly-test="${cancelled}">
-                                            <p data-sly-unwrap="${property.wrapper.isRichText}">
-                                                ${property.wrapper.currentValue @ context='html'}
-                                            </p>
+                                            <sly data-sly-call="${maybeHTML @ text=property.wrapper.currentValue, richtext=isRichText}"></sly>
                                         </div>
                                     </td>
                                 </tr>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -58,14 +58,12 @@
                                 <td class="cancelcol" rowspan="${pageComponent.calculatedComponentRowspan}">
                                     <button class="cancelinheritance onlyenabled" is="coral-button"
                                             variant="minimal"
-                                            size="M"
-                                            title="Cancel Inheritance" icon="link"></button>
+                                            size="M" icon="link"></button>
                                     <coral-tooltip placement="right" target="_prev">
                                         <span slot="content">Cancels the inheritance for the whole component.</span>
                                     </coral-tooltip>
                                     <button class="reenableinheritance onlycancelled" is="coral-button"
-                                            variant="minimal"
-                                            title="Re-enable Inheritance and synchronize" icon="linkOff"></button>
+                                            variant="minimal" icon="linkOff"></button>
                                     <coral-tooltip placement="right" target="_prev">
                                         <span slot="content">Re-enables the inheritance for the whole component. If
                                         there was a new translation, this is written into the page.</span>
@@ -238,9 +236,13 @@
                                                 ${property.diffsDstInsertionsMarked @ context='html'}
                                             </sly>
                                             <sly data-sly-test="${!hasNewCopy}">
-                                                ${property.wrapper.originalCopy}
+                                                <sly data-sly-test.isrichtext="${property.wrapper.isRichText}">
+                                                    ${property.wrapper.originalCopy @ context='html'}
+                                                </sly>
+                                                <sly data-sly-test="${!isrichtext}">
+                                                    ${property.wrapper.originalCopy}
+                                                </sly>
                                             </sly>
-
                                         </p>
                                     </td>
                                     <td is="coral-table-cell"
@@ -249,8 +251,11 @@
                                             <sly data-sly-test="${hasNewCopy}">
                                                 ${property.diffsHTML @ context='html'}
                                             </sly>
-                                            <sly data-sly-test="${!hasNewCopy}">
-                                                ${property.wrapper.originalCopy}
+                                            <sly data-sly-test.isrichtext="${property.wrapper.isRichText}">
+                                                ${property.wrapper.originalCopy @ context='html'}
+                                            </sly>
+                                            <sly data-sly-test="${!isrichtext}">
+                                                <p>${property.wrapper.originalCopy}</p>
                                             </sly>
                                         </p>
                                     </td>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -45,17 +45,16 @@
                                 id="component-${pageComponentList.index}"
                                 data-componentpath="${pageComponent.componentPath}"
                                 data-propertyname="${pageComponent.cancelPropertyName}">
-                                <td class="cancelcol"
-                                    rowspan="${pageComponent.calculatedComponentRowspan}">
-                                    <button class="cancelinheritance onlycancelled" is="coral-button" variant="minimal"
+                                <td class="cancelcol" rowspan="${pageComponent.calculatedComponentRowspan}">
+                                    <button class="cancelinheritance onlyuncancelled" is="coral-button" variant="minimal"
                                             size="M"
-                                            title="Cancel Inheritance" icon="linkOff"></button>
+                                            title="Cancel Inheritance" icon="link"></button>
                                     <coral-tooltip placement="right" target=".cancelinheritance">
                                         <span slot="content">Cancels the inheritance for the whole component.</span>
                                     </coral-tooltip>
-                                    <button class="reenableinheritance onlyuncancelled" is="coral-button"
+                                    <button class="reenableinheritance onlycancelled" is="coral-button"
                                             variant="minimal"
-                                            title="Re-enable Inheritance" icon="link"></button>
+                                            title="Re-enable Inheritance" icon="linkOff"></button>
                                     <coral-tooltip placement="right" target=".reenableinheritance">
                                         <span slot="content">Re-enables the inheritance for the whole component.</span>
                                     </coral-tooltip>
@@ -63,8 +62,7 @@
                                 <td is="coral-table-cell" colspan="6">
                                     <span class="componentName" data-sly-text="${pageComponent.componentName}"></span>
                                     <sly data-sly-test="${pageComponent.componentPathInPage}">
-                                        | <span class="componentPath"
-                                                data-sly-text="${pageComponent.componentPathInPage}"/>
+                                        | <span class="componentPath" data-sly-text="${pageComponent.componentPathInPage}"/>
                                     </sly>
                                     <sly data-sly-test="${pageComponent.componentTitle}">
                                         | ${pageComponent.componentTitle}

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -271,69 +271,7 @@
                         </table>
                     </section>
 
-                    <section class="coral-Form-fieldset bottombar coral--light">
-                        <p class="errormessage" hidden>
-                            <coral-alert variant="error">
-                                <coral-alert-content class="alertcontent"></coral-alert-content>
-                            </coral-alert>
-                        </p>
-                        <a>
-                            <button is="coral-button" variant="secondary" class="toggle-diffs">
-                                Toggle Diffs Column
-                            </button>
-                            <coral-tooltip placement="top" target=".toggle-diffs">
-                                <span slot="content">Toggle the visibility of the diffs column versus showing the old and new version of the source text separately.</span>
-                            </coral-tooltip>
-                        </a>
-                        <a>
-                            <button is="coral-button" variant="secondary" class="toggle-current">
-                                Toggle Current Text Column
-                            </button>
-                            <coral-tooltip placement="top" target=".toggle-current">
-                                <span slot="content">Toggle the visibility of the current text column, to compare the current status of the page.</span>
-                            </coral-tooltip>
-                        </a>
-                        <select id="propertyfilter" class="_coral-FieldButton _coral-ActionButton">
-                            <option value="allstati">All Properties</option>
-                            <option value="cancelled">Inheritance Cancelled</option>
-                            <option value="uncancelled">Inheritance Uncancelled</option>
-                        </select>
-                        <coral-tooltip placement="top" target="#propertyfilter">
-                            <span slot="content">Filter the properties by inheritance status.</span>
-                        </coral-tooltip>
-                        <select id="scope" class="_coral-FieldButton _coral-ActionButton">
-                            <option value="unfinished">Unfinished Properties</option>
-                            <option value="allprops">All Properties</option>
-                        </select>
-                        <coral-tooltip placement="top" target="#scope">
-                            <span slot="content">Filter the properties by their status in the translation process.</span>
-                        </coral-tooltip>
-                        <a href="/editor.html${model.pagePath}.html" target="_blank">
-                            <button is="coral-button" variant="secondary" class="open-in-editor">
-                                Open in Editor
-                            </button>
-                            <coral-tooltip placement="top" target=".open-in-editor">
-                                <span slot="content">Opens the page in the editor.</span>
-                            </coral-tooltip>
-                        </a>
-                        <a href="${model.pagePath}.html?wcmmode=preview" target="_blank">
-                            <button is="coral-button" variant="secondary" class="open-as-preview">
-                                Open as Preview
-                            </button>
-                            <coral-tooltip placement="top" target=".open-as-preview">
-                                <span slot="content">Opens the page in preview mode.</span>
-                            </coral-tooltip>
-                        </a>
-                        <a href="/apps/composum-ai/components/tool/comparetool.html${model.pagePath}"
-                           target="_blank">
-                            <button is="coral-button" variant="secondary" class="open-in-compare">
-                                Open in Compare Blueprint Tool
-                            </button>
-                            <coral-tooltip placement="top" target=".open-in-compare">
-                                <span slot="content">Opens a tool to compare the blueprint and this page side by side.</span>
-                            </coral-tooltip>
-                        </a>
-                    </section>
+                    <sly data-sly-use.bottombar="${'bottombar-template.html'}" data-sly-call="${bottombar.bottombarTemplate @ model=model}"></sly>
                 </div>
             </div>
         </div>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -10,6 +10,7 @@
 </head>
 <body class="coral--light coral-Body foundation-layout-util-maximized-alt show-diffs hide-currenttext"
       data-page-path="${model.pagePath}">
+
 <div class="foundation-layout-panel">
     <div class="foundation-layout-panel-bodywrapper spectrum-ready">
         <div class="foundation-layout-panel-body">
@@ -28,8 +29,12 @@
                     </section>
                     <section class="coral-Form-fieldset propertytable">
                         <table is="coral-table">
+                            <colgroup>
+                              <col is="coral-table-column" fixedwidth>
+                            </colgroup>
                             <thead is="coral-table-head" sticky>
-                            <tr is="coral-table-row">
+                            <tr is="coral-table-row" class="tablehead">
+                                <th is="coral-table-headercell" class="cancelcol"><!-- Column for cancel button --></th>
                                 <th is="coral-table-headercell" class="previoussrc">Previously Translated Text</th>
                                 <coral-tooltip placement="top" target=".previoussrc">
                                     <span slot="content">The source text on which the translation currently shown in the current page was based.</span>
@@ -56,7 +61,14 @@
                                 </coral-tooltip>
                             </tr>
                             </thead>
-                            <tbody is="coral-table-body" class="propertiestable" data-sly-list.pageComponent="${model.pageComponents}">
+                            <tbody is="coral-table-body" class="propertiestable"
+                                   data-sly-list.pageComponent="${model.pageComponents}">
+                            <tr is="coral-table-row" class="component-head" id="component-${pageComponentList.index}">
+                                <td class="coral-table-cell" class="cancelcol"
+                                    rowspan="${pageComponent.calculatedComponentRowspan}">
+                                    <!-- Column for cancel button --></td>
+                                <td is="coral-table-cell" colspan="6">Component header</td>
+                            </tr>
                             <sly data-sly-list.property="${pageComponent.checkableProperties}">
                                 <tr is="coral-table-row" class="row-separator" id="row-${propertyList.index}">
                                     <td is="coral-table-cell" class="row-separator"
@@ -105,7 +117,7 @@
                                     <td is="coral-table-cell"
                                         class="srcdiffs diffscolor">
                                         <p data-sly-unwrap="${property.wrapper.isRichText}">
-                                            ${property.originalCopyDiffsHTML @ context='html'}</td>
+                                        ${property.originalCopyDiffsHTML @ context='html'}</td>
                                     </p>
                                     <td is="coral-table-cell"
                                         class="newtrans">

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -93,28 +93,42 @@
                                     <sly data-sly-test="${cancelled}">
                                         <th is="coral-table-headercell" class="previoussrc">
                                             <span class="propertyname">${property.wrapper.propertyName}</span>
-                                            <span>Previously Translated Text</span>
-                                            <coral-tooltip placement="bottom" target="_prev">
-                                                <span slot="content">The source text on which the translation currently shown in the current page was based.</span>
-                                            </coral-tooltip>
+                                            <sly data-sly-test.hasNewCopy="${property.wrapper.newTranslatedCopy}"></sly>
+                                            <sly data-sly-test="${hasNewCopy}">
+                                                <span>Previously Translated Text</span>
+                                                <coral-tooltip placement="bottom" target="_prev">
+                                                    <span slot="content">The source text on which the translation currently shown in the current page was based.</span>
+                                                </coral-tooltip>
+                                            </sly>
                                         </th>
-                                        <th is="coral-table-headercell" class="newsrc"><span>New Source Text</span>
+                                        <th is="coral-table-headercell" class="newsrc">
+                                            <span>New Source Text</span>
                                             <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">The new source text as it was during the last rollout.</span>
                                             </coral-tooltip>
                                         </th>
                                         <th is="coral-table-headercell" class="srcdiffs">
                                             <span class="propertyname">${property.wrapper.propertyName}</span>
-                                            <span>Original Diffs</span>
-                                            <coral-tooltip placement="bottom" target="_prev">
-                                                <span slot="content">This shows the differences between the source text on which the translation currently shown in the current page was based and the new source text as it was during the last rollout.</span>
-                                            </coral-tooltip>
+                                            <sly data-sly-test="${hasNewCopy}">
+                                                <span>Original Diffs</span>
+                                                <coral-tooltip placement="bottom" target="_prev">
+                                                    <span slot="content">This shows the differences between the source text on which the translation currently shown in the current page was based and the new source text as it was during the last rollout.</span>
+                                                </coral-tooltip>
+                                            </sly>
+                                            <sly data-sly-test="${!hasNewCopy}">
+                                                <span>New Source Text</span>
+                                                <coral-tooltip placement="bottom" target="_prev">
+                                                    <span slot="content">The new source text as it was during the last rollout.</span>
+                                                </coral-tooltip>
+                                            </sly>
                                         </th>
                                         <th is="coral-table-headercell" class="newtrans">
-                                            <span>New Text Translation</span>
-                                            <coral-tooltip placement="bottom" target="_prev">
-                                                <span slot="content">The AI translation of the new source text.</span>
-                                            </coral-tooltip>
+                                            <sly data-sly-test="${hasNewCopy}">
+                                                <span>New Text Translation</span>
+                                                <coral-tooltip placement="bottom" target="_prev">
+                                                    <span slot="content">The AI translation of the new source text.</span>
+                                                </coral-tooltip>
+                                            </sly>
                                         </th>
                                         <th is="coral-table-headercell" class="editor">
                                             <span>Editor for Current Text</span>
@@ -190,18 +204,33 @@
                                     data-isrich="${property.wrapper.isRichText}">
                                     <td is="coral-table-cell" class="previoussrc diffscolor">
                                         <p data-sly-unwrap="${property.wrapper.isRichText}">
-                                            ${property.diffsSrcInsertionsMarked @ context='html'}
+                                            <sly data-sly-test="${hasNewCopy}">
+                                                ${property.diffsSrcInsertionsMarked @ context='html'}
+                                            </sly>
                                         </p>
                                     </td>
                                     <td is="coral-table-cell" class="newsrc diffscolor">
                                         <p data-sly-unwrap="${property.wrapper.isRichText}">
-                                            ${property.diffsDstInsertionsMarked @ context='html'}
+                                            <sly data-sly-test="${hasNewCopy}">
+                                                ${property.diffsDstInsertionsMarked @ context='html'}
+                                            </sly>
+                                            <sly data-sly-test="${!hasNewCopy}">
+                                                ${property.wrapper.originalCopy}
+                                            </sly>
+
                                         </p>
                                     </td>
                                     <td is="coral-table-cell"
                                         class="srcdiffs diffscolor">
                                         <p data-sly-unwrap="${property.wrapper.isRichText}">
-                                        ${property.diffsHTML @ context='html'}</td>
+                                            <sly data-sly-test="${hasNewCopy}">
+                                                ${property.diffsHTML @ context='html'}
+                                            </sly>
+                                            <sly data-sly-test="${!hasNewCopy}">
+                                                ${property.wrapper.originalCopy}
+                                            </sly>
+                                        </p>
+                                    </td>
                                     <td is="coral-table-cell"
                                         class="translation">
                                         <div class="translation-text">
@@ -305,7 +334,7 @@
                                     </td>
                                     <td is="coral-table-cell" class="srcdiffs diffscolor"></td>
                                     <td is="coral-table-cell" class="newtrans">
-                                        <div class="row-actions" data-sly-test="${cancelled}">
+                                        <div class="row-actions" data-sly-test="${cancelled && hasNewCopy}">
                                             <button is="coral-button" variant="secondary"
                                                     class="intelligent-merge onlycancelled">AI Merge
                                                 <coral-wait size="S" class="spinner"></coral-wait>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -94,37 +94,37 @@
                                         <th is="coral-table-headercell" class="previoussrc">
                                             <span class="propertyname">${property.wrapper.propertyName}</span>
                                             <span>Previously Translated Text</span>
-                                            <coral-tooltip placement="top" target="_prev">
+                                            <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">The source text on which the translation currently shown in the current page was based.</span>
                                             </coral-tooltip>
                                         </th>
                                         <th is="coral-table-headercell" class="newsrc"><span>New Source Text</span>
-                                            <coral-tooltip placement="top" target="_prev">
+                                            <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">The new source text as it was during the last rollout.</span>
                                             </coral-tooltip>
                                         </th>
                                         <th is="coral-table-headercell" class="srcdiffs">
                                             <span class="propertyname">${property.wrapper.propertyName}</span>
                                             <span>Original Diffs</span>
-                                            <coral-tooltip placement="top" target="_prev">
+                                            <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">This shows the differences between the source text on which the translation currently shown in the current page was based and the new source text as it was during the last rollout.</span>
                                             </coral-tooltip>
                                         </th>
                                         <th is="coral-table-headercell" class="newtrans">
                                             <span>New Text Translation</span>
-                                            <coral-tooltip placement="top" target="_prev">
+                                            <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">The AI translation of the new source text.</span>
                                             </coral-tooltip>
                                         </th>
                                         <th is="coral-table-headercell" class="editor">
                                             <span>Editor for Current Text</span>
-                                            <coral-tooltip placement="top" target="_prev">
+                                            <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">Edit the current text on the page and save it when done.</span>
                                             </coral-tooltip>
                                         </th>
                                         <th is="coral-table-headercell" class="currenttext">
                                             <span>Current Text on Page</span>
-                                            <coral-tooltip placement="top" target="_prev">
+                                            <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">The current text displayed on the page, for comparison purposes.</span>
                                             </coral-tooltip>
                                         </th>
@@ -133,33 +133,33 @@
                                         <th is="coral-table-headercell" class="previoussrc">
                                             <span class="propertyname">${property.wrapper.propertyName}</span>
                                             <span>Last accepted original text</span>
-                                            <coral-tooltip placement="top" target="_prev">
+                                            <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">The original when the translation was accepted last time</span>
                                             </coral-tooltip>
                                         </th>
                                         <th is="coral-table-headercell" class="newsrc">
                                             <span>Current original</span>
-                                            <coral-tooltip placement="top" target="_prev">
+                                            <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">The current original text.</span>
                                             </coral-tooltip>
                                         </th>
                                         <th is="coral-table-headercell" class="srcdiffs">
                                             <span class="propertyname">${property.wrapper.propertyName}</span>
                                             <span>Diffs from last accepted original</span>
-                                            <coral-tooltip placement="top" target="_prev">
+                                            <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">This shows the differences between the source text where the translation was last accepted
                                                     and the current source text.</span>
                                             </coral-tooltip>
                                         </th>
                                         <th is="coral-table-headercell" class="newtrans">
                                             <span>Last accepted translation</span>
-                                            <coral-tooltip placement="top" target="_prev">
+                                            <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">The AI translation of the original where the translation was last accepted.</span>
                                             </coral-tooltip>
                                         </th>
                                         <th is="coral-table-headercell" class="editor">
                                             <span>The current text</span>
-                                            <coral-tooltip placement="top" target="_prev">
+                                            <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">The current text on the page - AI translation of the current original.</span>
                                             </coral-tooltip>
                                         </th>
@@ -231,19 +231,19 @@
                                                     <button class="rte-btn" is="coral-button" variant="minimal"
                                                             title="Bold" icon="textBold"
                                                             data-command="bold"></button>
-                                                    <!-- <coral-tooltip placement="top" target="_prev">
+                                                    <!-- <coral-tooltip placement="bottom" target="_prev">
                                                         <span slot="content">Make the text bold.</span>
                                                     </coral-tooltip> -->
                                                     <button is="coral-button" variant="minimal" title="Italic"
                                                             icon="textItalic"
                                                             data-command="italic"></button>
-                                                    <!-- <coral-tooltip placement="top" target="_prev">
+                                                    <!-- <coral-tooltip placement="bottom" target="_prev">
                                                         <span slot="content">Make the text italic.</span>
                                                     </coral-tooltip> -->
                                                     <button is="coral-button" variant="minimal" title="Underline"
                                                             icon="textUnderline"
                                                             data-command="underline"></button>
-                                                    <!-- <coral-tooltip placement="top" target="_prev">
+                                                    <!-- <coral-tooltip placement="bottom" target="_prev">
                                                         <span slot="content">Underline the text.</span>
                                                     </coral-tooltip> -->
                                                     <button is="coral-button" variant="minimal" title="Edit Link"
@@ -253,14 +253,14 @@
                                                     <button is="coral-button" variant="minimal" title="Bullet List"
                                                             icon="textBulleted"
                                                             data-command="insertUnorderedList"></button>
-                                                    <!-- <coral-tooltip placement="top"
+                                                    <!-- <coral-tooltip placement="bottom"
                                                                    target="_prev">
                                                         <span slot="content">Create a bullet list.</span>
                                                     </coral-tooltip> -->
                                                     <button is="coral-button" variant="minimal" title="Numbered List"
                                                             icon="textNumbered"
                                                             data-command="insertOrderedList"></button>
-                                                    <!-- <coral-tooltip placement="top"
+                                                    <!-- <coral-tooltip placement="bottom"
                                                                    target="_prev">
                                                         <span slot="content">Create a numbered list.</span>
                                                     </coral-tooltip> -->

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -44,9 +44,10 @@
                             <tr is="coral-table-row" class="component-head ${pageComponent.cancelledClass}"
                                 id="component-${pageComponentList.index}"
                                 data-componentpath="${pageComponent.componentPath}"
-                                data-propertyname="${pageComponent.cancelPropertyName}">
+                                data-cancelpropertyname="${pageComponent.cancelPropertyName}">
                                 <td class="cancelcol" rowspan="${pageComponent.calculatedComponentRowspan}">
-                                    <button class="cancelinheritance onlyuncancelled" is="coral-button" variant="minimal"
+                                    <button class="cancelinheritance onlyuncancelled" is="coral-button"
+                                            variant="minimal"
                                             size="M"
                                             title="Cancel Inheritance" icon="link"></button>
                                     <coral-tooltip placement="right" target=".cancelinheritance">
@@ -62,7 +63,8 @@
                                 <td is="coral-table-cell" colspan="6">
                                     <span class="componentName" data-sly-text="${pageComponent.componentName}"></span>
                                     <sly data-sly-test="${pageComponent.componentPathInPage}">
-                                        | <span class="componentPath" data-sly-text="${pageComponent.componentPathInPage}"/>
+                                        | <span class="componentPath"
+                                                data-sly-text="${pageComponent.componentPathInPage}"/>
                                     </sly>
                                     <sly data-sly-test="${pageComponent.componentTitle}">
                                         | ${pageComponent.componentTitle}
@@ -86,6 +88,7 @@
                                 <tr is="coral-table-row"
                                     class="row-separator ${property.cancelledClass} ${property.processingNeededClass}"
                                     data-componentpath="${pageComponent.componentPath}"
+                                    data-cancelpropertyname="${pageComponent.cancelPropertyName}"
                                     id="row-${pageComponentList.index}-${propertyList.index}">
                                     <sly data-sly-test="${cancelled}">
                                         <th is="coral-table-headercell" class="previoussrc">
@@ -147,7 +150,8 @@
                                         <coral-tooltip placement="top" target=".editor" hidden>
                                             <span slot="content">The current text on the page - AI translation of the current original.</span>
                                         </coral-tooltip>
-                                        <th is="coral-table-headercell" class="currenttext"><!-- Deliberately empty - no meaning here. --></th>
+                                        <th is="coral-table-headercell" class="currenttext">
+                                            <!-- Deliberately empty - no meaning here. --></th>
                                     </sly>
                                 </tr>
 
@@ -156,6 +160,7 @@
                                 <tr is="coral-table-row"
                                     class="property-row datarow ${property.cancelledClass} ${property.processingNeededClass}"
                                     data-componentpath="${pageComponent.componentPath}"
+                                    data-cancelpropertyname="${pageComponent.cancelPropertyName}"
                                     id="datarow-${pageComponentList.index}-${propertyList.index}"
                                     data-path="${property.path}"
                                     data-propertyname="${property.wrapper.propertyName}"
@@ -279,6 +284,7 @@
                                 <tr is="coral-table-row"
                                     class="property-row actionrow ${property.cancelledClass} ${property.processingNeededClass}"
                                     data-componentpath="${pageComponent.componentPath}"
+                                    data-cancelpropertyname="${pageComponent.cancelPropertyName}"
                                     id="actionrow-${pageComponentList.index}-${propertyList.index}">
                                     <td is="coral-table-cell" class="previoussrc diffscolor">
                                     </td>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -75,7 +75,7 @@
                             </tr>
                             <sly data-sly-list.property="${pageComponent.checkableProperties}">
                                 <tr is="coral-table-row" class="row-separator ${property.cancelledClass} ${property.processingNeededClass}"
-                                    id="row-${propertyList.index}">
+                                    id="row-${pageComponentList.index}-${propertyList.index}">
                                     <th is="coral-table-headercell" class="previoussrc">
                                         <span class="propertyname">${property.wrapper.propertyName}</span>
                                         Previously Translated Text
@@ -109,7 +109,7 @@
                                 </tr>
                                 <!-- Data row -->
                                 <tr is="coral-table-row" class="property-row datarow ${property.cancelledClass} ${property.processingNeededClass}"
-                                    id="datarow-${propertyList.index}"
+                                    id="datarow-${pageComponentList.index}-${propertyList.index}"
                                     data-path="${property.path}"
                                     data-propertyname="${property.wrapper.propertyName}"
                                     data-language="${model.pageLanguage}"
@@ -119,7 +119,7 @@
                                     data-nt="${property.wrapper.newTranslatedCopy}"
                                     data-sd="${property.originalCopyDiffsHTML}"
                                     data-e="${property.wrapper.currentValue}"
-                                    data-id="${propertyList.index}"
+                                    data-id="${pageComponentList.index}-${propertyList.index}"
                                     data-isrich="${property.wrapper.isRichText}">
                                     <td is="coral-table-cell" class="previoussrc diffscolor">
                                         <p data-sly-unwrap="${property.wrapper.isRichText}">
@@ -206,7 +206,7 @@
                                 </tr>
                                 <!-- Action buttons TR -->
                                 <tr is="coral-table-row" class="property-row actionrow ${property.cancelledClass} ${property.processingNeededClass}"
-                                    id="actionrow-${propertyList.index}">
+                                    id="actionrow-${pageComponentList.index}-${propertyList.index}">
                                     <td is="coral-table-cell" class="previoussrc diffscolor">
                                     </td>
                                     <td is="coral-table-cell" class="newsrc diffscolor">

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -14,6 +14,14 @@
 <sly data-sly-call="${clientLib.js @ categories='coralui3,granite.ui.foundation.content'}"></sly>
 <script src="${resource.path @ context='uri'}/list.js"></script>
 
+<sly data-sly-template.todoIcon>
+    <span class="workflow-frame">
+        <coral-icon icon="checkCircle" size="S" class="workflow-icons done-icon"></coral-icon>
+        <coral-icon icon="alert" size="S" class="workflow-icons todo-icon"></coral-icon>
+    </span>
+    &nbsp;&nbsp;
+</sly>
+
 <div class="foundation-layout-panel">
     <div class="foundation-layout-panel-bodywrapper spectrum-ready">
         <div class="foundation-layout-panel-body">
@@ -95,7 +103,10 @@
                                     id="row-${pageComponentList.index}-${propertyList.index}">
                                     <sly data-sly-test="${cancelled}">
                                         <th is="coral-table-headercell" class="previoussrc">
-                                            <span class="propertyname">${property.propertyPathInComponent}</span>
+                                            <span class="propertyname">
+                                                <sly data-sly-call="${todoIcon}"></sly>
+                                                ${property.propertyPathInComponent}
+                                            </span>
                                             <sly data-sly-test.hasNewCopy="${property.wrapper.newTranslatedCopy}"></sly>
                                             <sly data-sly-test="${hasNewCopy}">
                                                 <span>Previously Translated Text</span>
@@ -111,7 +122,10 @@
                                             </coral-tooltip>
                                         </th>
                                         <th is="coral-table-headercell" class="srcdiffs">
-                                            <span class="propertyname">${property.propertyPathInComponent}</span>
+                                            <span class="propertyname">
+                                                <sly data-sly-call="${todoIcon}"></sly>
+                                                ${property.propertyPathInComponent}
+                                            </span>
                                             <sly data-sly-test="${hasNewCopy}">
                                                 <span>Original Diffs</span>
                                                 <coral-tooltip placement="bottom" target="_prev">
@@ -148,7 +162,10 @@
                                     </sly>
                                     <sly data-sly-test="${!cancelled}">
                                         <th is="coral-table-headercell" class="previoussrc">
-                                            <span class="propertyname">${property.wrapper.propertyName}</span>
+                                            <span class="propertyname">
+                                                <sly data-sly-call="${todoIcon}"></sly>
+                                                ${property.propertyPathInComponent}
+                                            </span>
                                             <span>Last accepted original text</span>
                                             <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">The original when the translation was accepted last time</span>
@@ -161,7 +178,10 @@
                                             </coral-tooltip>
                                         </th>
                                         <th is="coral-table-headercell" class="srcdiffs">
-                                            <span class="propertyname">${property.wrapper.propertyName}</span>
+                                            <span class="propertyname">
+                                                <sly data-sly-call="${todoIcon}"></sly>
+                                                ${property.propertyPathInComponent}
+                                            </span>
                                             <span>Diffs from last accepted original</span>
                                             <coral-tooltip placement="bottom" target="_prev">
                                                 <span slot="content">This shows the differences between the source text where the translation was last accepted

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -38,6 +38,9 @@
                             </colgroup>
                             <tbody is="coral-table-body" class="propertiestable"
                                    data-sly-list.pageComponent="${model.pageComponents}">
+
+<!-- Component start  -->
+
                             <tr is="coral-table-row" class="component-head ${pageComponent.cancelledClass}"
                                 id="component-${pageComponentList.index}">
                                 <td class="cancelcol"
@@ -74,6 +77,9 @@
                                 </td>
                             </tr>
                             <sly data-sly-list.property="${pageComponent.checkableProperties}">
+
+<!-- Property start - title row  -->
+
                                 <tr is="coral-table-row" class="row-separator ${property.cancelledClass} ${property.processingNeededClass}"
                                     id="row-${pageComponentList.index}-${propertyList.index}">
                                     <th is="coral-table-headercell" class="previoussrc">
@@ -107,7 +113,9 @@
                                         <span slot="content">The current text displayed on the page, for comparison purposes.</span>
                                     </coral-tooltip>
                                 </tr>
-                                <!-- Data row -->
+
+<!-- Property data row  -->
+
                                 <tr is="coral-table-row" class="property-row datarow ${property.cancelledClass} ${property.processingNeededClass}"
                                     id="datarow-${pageComponentList.index}-${propertyList.index}"
                                     data-path="${property.path}"
@@ -204,7 +212,9 @@
                                         </div>
                                     </td>
                                 </tr>
-                                <!-- Action buttons TR -->
+
+<!-- Action buttons  -->
+
                                 <tr is="coral-table-row" class="property-row actionrow ${property.cancelledClass} ${property.processingNeededClass}"
                                     id="actionrow-${pageComponentList.index}-${propertyList.index}">
                                     <td is="coral-table-cell" class="previoussrc diffscolor">
@@ -253,6 +263,9 @@
                                     <td is="coral-table-cell" class="currenttext">
                                     </td>
                                 </tr>
+
+<!-- Property end, component end  -->
+
                             </sly>
                             </tbody>
                         </table>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -340,40 +340,7 @@
     </div>
 </div>
 
-<div id="edit-link-modal" class="modal-backdrop hidden">
-    <div class="modal-content wide">
-        <h3>Edit Link</h3>
-        <label>Text</label>
-        <input type="text" id="edit-anchor-text" class="_coral-Textfield">
-
-        <label>Path / Link</label>
-        <div class="path-link-wrapper">
-            <input type="text" id="edit-anchor-href" class="_coral-Textfield">
-            <span class="coral-InputGroup-button">
-                <button is="coral-button" icon="FolderOpenOutline" iconsize="S" size="M" variant="default"
-                        id="choose-path-btn"></button>
-            </span>
-        </div>
-
-        <label>Alternative text</label>
-        <input type="text" id="edit-anchor-title" class="_coral-Textfield">
-
-        <select id="edit-anchor-target" class="_coral-FieldButton _coral-ActionButton">
-            <option value="">Target</option>
-            <option value="_self">Same tab</option>
-            <option value="_blank">New tab</option>
-            <option value="_parent">Parent frame</option>
-            <option value="_top">Top frame</option>
-        </select>
-
-        <input type="hidden" id="edit-anchor-rel">
-
-        <div class="modal-actions">
-            <button is="coral-button" variant="secondary" id="cancel-link-btn">Cancel</button>
-            <button is="coral-button" variant="primary" id="save-link-btn">Save</button>
-        </div>
-    </div>
-</div>
+<sly data-sly-include="link-modal.html"></sly>
 
 <div id="path-chooser-content">
 </div>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -46,7 +46,7 @@
                                 data-componentpath="${pageComponent.componentPath}"
                                 data-cancelpropertyname="${pageComponent.cancelPropertyName}">
                                 <td class="cancelcol" rowspan="${pageComponent.calculatedComponentRowspan}">
-                                    <button class="cancelinheritance onlyuncancelled" is="coral-button"
+                                    <button class="cancelinheritance onlyenabled" is="coral-button"
                                             variant="minimal"
                                             size="M"
                                             title="Cancel Inheritance" icon="link"></button>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -2,7 +2,7 @@
 <html lang="en" data-sly-use.model="com.composum.ai.aem.core.impl.autotranslate.AutoTranslateMergeModel">
 <head>
     <meta charset="UTF-8">
-    <title>Translation Merge UI</title>
+    <title>Translation Review UI</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <sly data-sly-use.clientLib="/libs/granite/sightly/templates/clientlib.html"></sly>
     <sly data-sly-call="${clientLib.css @ categories='cq.authoring.editor.core'}"></sly>
@@ -36,7 +36,7 @@
             <div class="foundation-layout-panel-content foundation-layout-form foundation-layout-form-mode-edit">
                 <div class="cq-dialog-content-page">
                     <section class="coral-Form-fieldset">
-                        <h2 class="coral-Form-fieldset-legend">Translation Merge Tool for page
+                        <h2 class="coral-Form-fieldset-legend">Translation Review for page
                             <a target="_blank" href="/editor.html${model.pagePath}.html">${model.pagePath}</a>
                         </h2>
                         <!--/* <span class="coral-Form-field foundation-layout-util-breakword">
@@ -96,7 +96,7 @@
                                         <span class="linktocomponent right-aligned">
                                         <a href="${pageComponent.linkToComponent}" target="_blank"
                                            rel="noopener noreferrer">
-                                            <coral-icon icon="linkOut" size="XS"
+                                            <coral-icon icon="linkOut" size="S"
                                                         class="linktocomponent"></coral-icon></a>
                                         <coral-tooltip placement="left" target="_prev">
                                             <span slot="content">Opens the page in the editor and scrolls to this component.</span>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -71,13 +71,13 @@
                                     data-cancelpropertyname="${pageComponent.cancelPropertyName}">
                                     <td class="cancelcol" rowspan="${pageComponent.calculatedComponentRowspan}">
                                         <button class="cancelinheritance onlyenabled" is="coral-button"
-                                                variant="minimal"
+                                                variant="secondary"
                                                 size="M" icon="link"></button>
                                         <coral-tooltip placement="right" target="_prev">
                                             <span slot="content">Cancels the inheritance for the whole component.</span>
                                         </coral-tooltip>
                                         <button class="reenableinheritance onlycancelled" is="coral-button"
-                                                variant="minimal" icon="linkOff"></button>
+                                                variant="secondary" icon="linkOff"></button>
                                         <coral-tooltip placement="right" target="_prev">
                                         <span slot="content">Re-enables the inheritance for the whole component. If
                                         there was a new translation, this is written into the page.</span>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -61,7 +61,10 @@
                             </tr>
                             <sly data-sly-list.property="${pageComponent.checkableProperties}">
                                 <tr is="coral-table-row" class="row-separator ${property.cancelledClass}" id="row-${propertyList.index}">
-                                    <th is="coral-table-headercell" class="previoussrc">Previously Translated Text</th>
+                                    <th is="coral-table-headercell" class="previoussrc">
+                                        <span class="propertyname">${property.wrapper.propertyName}</span>
+                                        Previously Translated Text
+                                    </th>
                                     <coral-tooltip placement="top" target=".previoussrc" hidden>
                                         <span slot="content">The source text on which the translation currently shown in the current page was based.</span>
                                     </coral-tooltip>
@@ -69,7 +72,10 @@
                                     <coral-tooltip placement="top" target=".newsrc" hidden>
                                         <span slot="content">The new source text as it was during the last rollout.</span>
                                     </coral-tooltip>
-                                    <th is="coral-table-headercell" class="srcdiffs">Original Diffs</th>
+                                    <th is="coral-table-headercell" class="srcdiffs">
+                                        <span class="propertyname">${property.wrapper.propertyName}</span>
+                                        Original Diffs
+                                    </th>
                                     <coral-tooltip placement="top" target=".srcdiffs" hidden>
                                         <span slot="content">This shows the differences between the source text on which the translation currently shown in the current page was based and the new source text as it was during the last rollout.</span>
                                     </coral-tooltip>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -1,5 +1,6 @@
 const URL_MERGE_SERVLET = '/bin/cpm/ai/aitranslationmerge';
 const PATH_CHOOSER_URL = '/mnt/overlay/cq/gui/content/linkpathfield/picker.html';
+const KEY_LOCALSTORAGE = 'composum.ai.autotranslatemerge';
 
 /** Handles the general script functionality for the Translation Merge Tool. */
 class AITranslateMergeTool {
@@ -8,6 +9,7 @@ class AITranslateMergeTool {
             this.tableBody = document.querySelector(".propertiestable");
             this.initFooterButtons();
             this.reinitialize();
+            this.readStateFromHistory();
         });
     }
 
@@ -76,11 +78,32 @@ class AITranslateMergeTool {
         this.scopeSelect.addEventListener('change', this.adaptFilters.bind(this));
     }
 
+    /** We save the state of the toggleDiffs and toggleCurrent to the local storage to be able to restore it. */
+    saveStateToHistory() {
+        const state = {
+            showDiffs: document.body.classList.contains('hide-diffs'),
+            showCurrent: document.body.classList.contains('show-currenttext')
+        }
+        localStorage.setItem(KEY_LOCALSTORAGE, JSON.stringify(state));
+    }
+
+    readStateFromHistory() {
+        const stateRep = localStorage.getItem(KEY_LOCALSTORAGE);
+        const state = stateRep ? JSON.parse(stateRep) : {};
+        if (state.showDiffs) {
+            this.toggleDiffs();
+        }
+        if (state.showCurrent) {
+            this.toggleCurrent();
+        }
+    }
+
     toggleDiffs() {
         console.log(">>toggleDiffs", document.body.classList);
         document.body.classList.toggle('show-diffs');
         document.body.classList.toggle('hide-diffs');
         console.log("<<toggleDiffs", document.body.classList);
+        this.saveStateToHistory();
     }
 
     toggleCurrent() {
@@ -88,6 +111,7 @@ class AITranslateMergeTool {
         document.body.classList.toggle('show-currenttext');
         document.body.classList.toggle('hide-currenttext');
         console.log("<<toggleCurrent", document.body.classList);
+        this.saveStateToHistory();
     }
 
     /** Implements the selects for propertyfilter and scope by reloading the page with the according query parameters. */
@@ -322,15 +346,15 @@ class AITranslateMergeRow {
                 this.row.classList.add("processed");
                 this.actionrow.classList.add("processed");
                 this.headerrow.classList.add("processed");
-                this.greenFlash(this.saveButton);
+                this.simulateButtonPress(this.saveButton);
             }
         });
     }
 
     /** Makes the button green for a second. */
-    greenFlash(button) {
-        button.style.backgroundColor = 'green';
-        setTimeout(() => button.style.backgroundColor = '', 1000);
+    simulateButtonPress(button) {
+        button.disabled = true;
+        setTimeout(() => button.disabled = false, 1000);
     }
 
     /** Calls the merge servlet with operation acceptTranslation and path and propertyName as POST parameters. */

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -193,7 +193,7 @@ class AITranslateMergeTool {
                     console.error("Error in " + operation, error);
                     this.showError(error.message);
                 }).finally(() => {
-                button.disabled = false;
+                setTimeout(() => button.disabled = false, 300); // delay for visibility
                 button.classList.remove('activespinner');
             });
         });
@@ -379,8 +379,8 @@ class AITranslateMergeRow {
 
     /** Makes the button green for a second. */
     simulateButtonPress(button) {
-        button.disabled = true;
-        setTimeout(() => button.disabled = false, 1000);
+        // button.disabled = true;
+        // setTimeout(() => button.disabled = false, 1000);
     }
 
     /** Calls the merge servlet with operation acceptTranslation and path and propertyName as POST parameters. */

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -232,7 +232,7 @@ class AIComponentRow {
 
 }
 
-/** Handles copy, append, save, and intelligent merge actions for each table row. */
+/** Handles copy, save, and intelligent merge actions for each table row. */
 class AITranslateMergeRow {
     constructor(row, actionrow, tool) {
         if (row.initialized) return;
@@ -244,7 +244,6 @@ class AITranslateMergeRow {
         this.editor = this.rteContainer?.querySelector(".rte-editor") || row.querySelector(".text-editor");
 
         this.copyButton = this.actionrow.querySelector(".copy-to-editor");
-        this.appendButton = this.actionrow.querySelector(".append-to-editor");
         this.mergeButton = this.actionrow.querySelector(".intelligent-merge");
         this.acceptButton = this.actionrow.querySelector(".accept-translation");
 
@@ -256,7 +255,6 @@ class AITranslateMergeRow {
         }
 
         if (this.copyButton) this.copyButton.addEventListener("click", this.copyToEditor.bind(this));
-        if (this.appendButton) this.appendButton.addEventListener("click", this.appendToEditor.bind(this));
         if (this.mergeButton) this.mergeButton.addEventListener("click", this.intelligentMerge.bind(this));
         if (this.acceptButton) this.acceptButton.addEventListener("click", this.acceptTranslation.bind(this));
 
@@ -264,16 +262,20 @@ class AITranslateMergeRow {
         if (this.saveButton) this.saveButton.addEventListener("click", this.saveEditor.bind(this));
     }
 
-    copyToEditor() {
-        this.editor.innerHTML = this.row.dataset.nt || '';
+    setEditorValue(value) {
+        if (this.editor.tagName === 'TEXTAREA') {
+            this.editor.value = value;
+        } else {
+            this.editor.innerHTML = value;
+        }
     }
 
-    appendToEditor() {
-        this.editor.innerHTML += this.row.dataset.nt || '';
+    copyToEditor() {
+        this.setEditorValue(this.row.dataset.nt || '');
     }
 
     resetEditor() {
-        this.editor.innerHTML = this.row.dataset.e || '';
+        this.setEditorValue(this.row.dataset.e || '');
     }
 
     intelligentMerge() {
@@ -287,7 +289,7 @@ class AITranslateMergeRow {
             language: this.row.dataset.language
         };
         this.tool.callOperation(this.mergeButton, 'merge', data, mergedText => {
-            this.editor.innerHTML = mergedText;
+            this.setEditorValue(mergedText);
             console.log("Merge successful");
         });
     }

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -205,7 +205,7 @@ class AITranslateMergeRow {
                     if (!result.saved) {
                         throw new Error(); // no error message to speak of
                     } else {
-                        row.classList.add("merged");
+                        row.classList.add("processed");
                     }
                 })
                 .catch(error => {

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -322,8 +322,15 @@ class AITranslateMergeRow {
                 this.row.classList.add("processed");
                 this.actionrow.classList.add("processed");
                 this.headerrow.classList.add("processed");
+                this.greenFlash(this.saveButton);
             }
         });
+    }
+
+    /** Makes the button green for a second. */
+    greenFlash(button) {
+        button.style.backgroundColor = 'green';
+        setTimeout(() => button.style.backgroundColor = '', 1000);
     }
 
     /** Calls the merge servlet with operation acceptTranslation and path and propertyName as POST parameters. */

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -4,21 +4,32 @@ const PATH_CHOOSER_URL = '/mnt/overlay/cq/gui/content/linkpathfield/picker.html'
 /** Handles the general script functionality for the Translation Merge Tool. */
 class AITranslateMergeTool {
     constructor() {
-        document.addEventListener("DOMContentLoaded", () => this.init());
+        document.addEventListener("DOMContentLoaded", () => {
+            this.initFooterButtons();
+            this.reinitialize();
+        });
     }
 
-    init() {
+    reinitialize() {
+        console.log("init");
         this.initTableEventListeners();
         this.initNavButtons();
-        this.initFooterButtons();
         document.querySelectorAll('coral-tooltip').forEach(tooltip => tooltip.delay = 1000);
     }
 
     /** Initializes table event listeners for handling row-specific actions. */
     initTableEventListeners() {
         const tableBody = document.querySelector(".propertiestable");
-        document.querySelectorAll("tbody tr.datarow").forEach(row => this.initDatarow(row));
-        document.querySelectorAll("tbody tr.component-head").forEach(row => this.initComponentHead(row));
+        tableBody.querySelectorAll("tr.datarow").forEach(row => {
+            if (row.initialized) return;
+            this.initDatarow(row);
+            row.initialized = true;
+        });
+        tableBody.querySelectorAll("tr.component-head").forEach(row => {
+            if (row.initialized) return;
+            this.initComponentHead(row)
+            row.initialized = true;
+        });
         this.linkModal = new AITranslateLinkEditModal();
     }
 
@@ -56,13 +67,17 @@ class AITranslateMergeTool {
     }
 
     toggleDiffs() {
+        console.log(">>toggleDiffs", document.body.classList);
         document.body.classList.toggle('show-diffs');
         document.body.classList.toggle('hide-diffs');
+        console.log("<<toggleDiffs", document.body.classList);
     }
 
     toggleCurrent() {
+        console.log(">>toggleCurrent", document.body.classList);
         document.body.classList.toggle('show-currenttext');
         document.body.classList.toggle('hide-currenttext');
+        console.log("<<toggleCurrent", document.body.classList);
     }
 
     /** Implements the selects for propertyfilter and scope by reloading the page with the according query parameters. */
@@ -163,7 +178,7 @@ class AITranslateMergeTool {
                     tableBody.insertBefore(tr, firsttr);
                 });
                 trs.forEach(tr => tr.remove());
-                this.init();
+                this.reinitialize();
             })
             .catch(error => {
                 console.error("Error in reloadComponent", error);

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -108,15 +108,15 @@ class AITranslateMergeRow {
     }
 
     copyToEditor() {
-        this.editor.innerHTML = this.row.dataset.nt;
+        this.editor.innerHTML = this.row.dataset.nt || '';
     }
 
     appendToEditor() {
-        this.editor.innerHTML += this.row.dataset.nt;
+        this.editor.innerHTML += this.row.dataset.nt || '';
     }
 
     resetEditor() {
-        this.editor.innerHTML = this.row.dataset.e;
+        this.editor.innerHTML = this.row.dataset.e || '';
     }
 
     intelligentMerge() {

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -5,6 +5,7 @@ const PATH_CHOOSER_URL = '/mnt/overlay/cq/gui/content/linkpathfield/picker.html'
 class AITranslateMergeTool {
     constructor() {
         document.addEventListener("DOMContentLoaded", () => {
+            this.tableBody = document.querySelector(".propertiestable");
             this.initFooterButtons();
             this.reinitialize();
         });
@@ -15,17 +16,17 @@ class AITranslateMergeTool {
         this.initTableEventListeners();
         this.initNavButtons();
         document.querySelectorAll('coral-tooltip').forEach(tooltip => tooltip.delay = 1000);
+        this.resizeTextAreas();
     }
 
     /** Initializes table event listeners for handling row-specific actions. */
     initTableEventListeners() {
-        const tableBody = document.querySelector(".propertiestable");
-        tableBody.querySelectorAll("tr.datarow").forEach(row => {
+        this.tableBody.querySelectorAll("tr.datarow").forEach(row => {
             if (row.initialized) return;
             this.initDatarow(row);
             row.initialized = true;
         });
-        tableBody.querySelectorAll("tr.component-head").forEach(row => {
+        this.tableBody.querySelectorAll("tr.component-head").forEach(row => {
             if (row.initialized) return;
             this.initComponentHead(row)
             row.initialized = true;
@@ -42,6 +43,14 @@ class AITranslateMergeTool {
     initComponentHead(row) {
         new AIComponentRow(this, row);
     };
+
+    /** Makes the textareas one line larger than the content. */
+    resizeTextAreas() {
+        this.tableBody.querySelectorAll('textarea').forEach(textarea => {
+            textarea.style.height = 'auto';
+            textarea.style.height = textarea.scrollHeight + 'px';
+        });
+    }
 
     /** For anchors with data-forwardid or data-backwardid set the href to #(id+1) / #(id-1). */
     initNavButtons() {

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -38,6 +38,12 @@ class AITranslateMergeTool {
     initFooterButtons() {
         document.querySelector('.toggle-diffs').addEventListener('click', this.toggleDiffs.bind(this));
         document.querySelector('.toggle-current').addEventListener('click', this.toggleCurrent.bind(this));
+        this.propertySelect = document.querySelector('#propertyfilter');
+        this.scopeSelect = document.querySelector('#scope');
+        this.propertySelect.value = new URLSearchParams(window.location.search).get('propertyfilter') || 'allstati';
+        this.scopeSelect.value = new URLSearchParams(window.location.search).get('scope') || 'unfinished';
+        this.propertySelect.addEventListener('change', this.adaptFilters.bind(this));
+        this.scopeSelect.addEventListener('change', this.adaptFilters.bind(this));
     }
 
     toggleDiffs() {
@@ -48,6 +54,16 @@ class AITranslateMergeTool {
     toggleCurrent() {
         document.body.classList.toggle('show-currenttext');
         document.body.classList.toggle('hide-currenttext');
+    }
+
+    /** Implements the selects for propertyfilter and scope by reloading the page with the according query parameters. */
+    adaptFilters() {
+        const propertyfilter = this.propertySelect.value;
+        const scope = this.scopeSelect.value;
+        const url = new URL(window.location.href);
+        url.searchParams.set('propertyfilter', propertyfilter);
+        url.searchParams.set('scope', scope);
+        window.location.href = url.href;
     }
 
     /** If the message is null, the error field is hidden. */
@@ -371,7 +387,8 @@ class AITranslateLinkEditModal {
         }
         if (newRel) {
             anchor.setAttribute('rel', newRel);
-        } if ('_blank' === newTarget) { // general guideline or new link
+        }
+        if ('_blank' === newTarget) { // general guideline or new link
             anchor.setAttribute('rel', 'noopener noreferrer');
         } else {
             anchor.removeAttribute('rel');

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -100,19 +100,15 @@ class AITranslateMergeTool {
     }
 
     toggleDiffs() {
-        console.log(">>toggleDiffs", document.body.classList);
         document.body.classList.toggle('show-diffs');
         document.body.classList.toggle('hide-diffs');
-        console.log("<<toggleDiffs", document.body.classList);
         this.saveStateToHistory();
         this.calculateWidths();
     }
 
     toggleCurrent() {
-        console.log(">>toggleCurrent", document.body.classList);
         document.body.classList.toggle('show-currenttext');
         document.body.classList.toggle('hide-currenttext');
-        console.log("<<toggleCurrent", document.body.classList);
         this.saveStateToHistory();
         this.calculateWidths();
     }

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -192,7 +192,8 @@ class AITranslateMergeRow {
             if (!result.saved) {
                 throw new Error(); // no error message to speak of
             } else {
-                row.classList.add("processed");
+                this.row.classList.add("processed");
+                this.actionrow.classList.add("processed");
             }
         });
     }
@@ -211,7 +212,8 @@ class AITranslateMergeRow {
             if (!result.accepted) {
                 throw new Error(); // no error message to speak of
             } else {
-                row.classList.add("processed");
+                this.row.classList.add("processed");
+                this.actionrow.classList.add("processed");
             }
         });
     }

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -37,7 +37,8 @@ class AITranslateMergeTool {
     initDatarow(row) {
         const id = row.dataset.id;
         const actionrow = document.getElementById("actionrow-" + id);
-        new AITranslateMergeRow(row, actionrow, this);
+        const headerrow = document.getElementById("row-" + id);
+        new AITranslateMergeRow(row, actionrow, headerrow, this);
     };
 
     initComponentHead(row) {
@@ -243,11 +244,12 @@ class AIComponentRow {
 
 /** Handles copy, save, and intelligent merge actions for each table row. */
 class AITranslateMergeRow {
-    constructor(row, actionrow, tool) {
+    constructor(row, actionrow, headerrow, tool) {
         if (row.initialized) return;
         row.initialized = true;
         this.row = row;
         this.actionrow = actionrow;
+        this.headerrow = headerrow;
         this.tool = tool;
         this.rteContainer = row.querySelector(".rte-container");
         this.editor = this.rteContainer?.querySelector(".rte-editor") || row.querySelector(".text-editor");
@@ -319,6 +321,7 @@ class AITranslateMergeRow {
             } else {
                 this.row.classList.add("processed");
                 this.actionrow.classList.add("processed");
+                this.headerrow.classList.add("processed");
             }
         });
     }
@@ -339,6 +342,7 @@ class AITranslateMergeRow {
             } else {
                 this.row.classList.add("processed");
                 this.actionrow.classList.add("processed");
+                this.headerrow.classList.add("processed");
             }
         });
     }

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -371,6 +371,8 @@ class AITranslateLinkEditModal {
         }
         if (newRel) {
             anchor.setAttribute('rel', newRel);
+        } if ('_blank' === newTarget) { // general guideline or new link
+            anchor.setAttribute('rel', 'noopener noreferrer');
         } else {
             anchor.removeAttribute('rel');
         }

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -136,7 +136,7 @@ class AIComponentRow {
     cancelInheritance() {
         const data = this.cancelData();
         this.tool.callOperation(this.cancelInheritanceButton, 'cancelInheritance', data, responseText => {
-            alert("CANCELLED"); // XXX implement me
+            alert("CANCELLED " + responseText); // XXX implement me
         });
     }
 
@@ -144,7 +144,7 @@ class AIComponentRow {
     reenableInheritance() {
         const data = this.cancelData();
         this.tool.callOperation(this.reenableInheritanceButton, 'reenableInheritance', data, responseText => {
-            alert("REENABLED"); // XXX implement me
+            alert("REENABLED " + responseText); // XXX implement me
         });
     }
 

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -99,12 +99,12 @@ class AITranslateMergeRow {
             new AITranslatorMergeRTE(this.rteContainer, tool);
         }
 
-        this.copyButton.addEventListener("click", this.copyToEditor.bind(this));
+        if (this.copyButton) this.copyButton.addEventListener("click", this.copyToEditor.bind(this));
         if (this.appendButton) this.appendButton.addEventListener("click", this.appendToEditor.bind(this));
-        this.mergeButton.addEventListener("click", this.intelligentMerge.bind(this));
+        if (this.mergeButton) this.mergeButton.addEventListener("click", this.intelligentMerge.bind(this));
 
-        this.resetButton.addEventListener("click", this.resetEditor.bind(this));
-        this.saveButton.addEventListener("click", this.saveEditor.bind(this));
+        if (this.resetButton) this.resetButton.addEventListener("click", this.resetEditor.bind(this));
+        if (this.saveButton) this.saveButton.addEventListener("click", this.saveEditor.bind(this));
     }
 
     copyToEditor() {

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -10,6 +10,7 @@ class AITranslateMergeTool {
             this.initFooterButtons();
             this.reinitialize();
             this.readStateFromHistory();
+            this.calculateWidths();
         });
     }
 
@@ -104,6 +105,7 @@ class AITranslateMergeTool {
         document.body.classList.toggle('hide-diffs');
         console.log("<<toggleDiffs", document.body.classList);
         this.saveStateToHistory();
+        this.calculateWidths();
     }
 
     toggleCurrent() {
@@ -112,6 +114,30 @@ class AITranslateMergeTool {
         document.body.classList.toggle('hide-currenttext');
         console.log("<<toggleCurrent", document.body.classList);
         this.saveStateToHistory();
+        this.calculateWidths();
+    }
+
+    /** Compute table layout since otherwise changes in the richtext editor change the table layout.
+     * For all colgroup elements: set the width of the first col element to 50px and divide the
+     * width of the colgroup evenly between the other col elements that are visible (that is, are not assigned a
+     * display: none by some CSS rule.  */
+    calculateWidths() {
+        document.querySelectorAll('colgroup').forEach(colgroup => {
+            const cols = colgroup.querySelectorAll('col');
+            if (cols.length) {
+                const table = colgroup.closest('table');
+                const numVisibleCols = Array.from(cols)
+                    .filter(col => window.getComputedStyle(col).display !== 'none').length;
+                const width = (table.clientWidth - cols[0].clientWidth) / (numVisibleCols - 1);
+                for (let i = 1; i < cols.length; i++) {
+                    if (window.getComputedStyle(cols[i]).display !== 'none') {
+                        cols[i].style.width = width + 'px';
+                    } else {
+                        cols[i].style.width = '';
+                    }
+                }
+            }
+        });
     }
 
     /** Implements the selects for propertyfilter and scope by reloading the page with the according query parameters. */

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -209,7 +209,8 @@ class AITranslateMergeTool {
      */
     reloadComponent(componentpath, propertyname) {
         const url = new URL(window.location.href);
-        url.searchParams.set('propertyfilter', 'allstati'); // make sure it's visible
+        url.searchParams.set('propertyfilter', 'allstati'); // make sure everything is visible.
+        url.searchParams.set('scope', 'allprops');
         url.searchParams.set('componentpath', componentpath);
         if (propertyname) url.searchParams.set('propertyname', propertyname);
         console.log('reloadComponent', url.href);

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -134,6 +134,7 @@ class AITranslateMergeTool {
      */
     reloadComponent(componentpath, propertyname) {
         const url = new URL(window.location.href);
+        url.searchParams.set('propertyfilter', 'allstati'); // make sure it's visible
         url.searchParams.set('componentpath', componentpath);
         if (propertyname) url.searchParams.set('propertyname', propertyname);
         console.log('reloadComponent', url.href);

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -4,12 +4,14 @@ const PATH_CHOOSER_URL = '/mnt/overlay/cq/gui/content/linkpathfield/picker.html'
 /** Handles the general script functionality for the Translation Merge Tool. */
 class AITranslateMergeTool {
     constructor() {
-        document.addEventListener("DOMContentLoaded", () => {
-            this.initTableEventListeners();
-            this.initNavButtons();
-            this.initFooterButtons();
-            document.querySelectorAll('coral-tooltip').forEach(tooltip => tooltip.delay = 1000);
-        });
+        document.addEventListener("DOMContentLoaded", () => this.init());
+    }
+
+    init() {
+        this.initTableEventListeners();
+        this.initNavButtons();
+        this.initFooterButtons();
+        document.querySelectorAll('coral-tooltip').forEach(tooltip => tooltip.delay = 1000);
     }
 
     /** Initializes table event listeners for handling row-specific actions. */
@@ -143,17 +145,24 @@ class AITranslateMergeTool {
             selector += ':not([data-cancelpropertyname]';
         }
         const trs = tableBody.querySelectorAll(selector);
+        if (!trs.length) {
+            debugger;
+        }
         fetch(url.href)
             .then(response => response.text())
             .then(html => {
                 const tempDiv = document.createElement('div');
                 tempDiv.innerHTML = html;
-                const replacementTableBody = tempDiv.querySelector(".propertytable tbody");
+                const replacements = tempDiv.querySelectorAll(".propertytable tbody tr");
                 const firsttr = trs[0];
-                replacementTableBody.childNodes.forEach(tr => {
+                if (!firsttr) {
+                    debugger;
+                }
+                replacements.forEach(tr => {
                     tableBody.insertBefore(tr, firsttr);
                 });
                 trs.forEach(tr => tr.remove());
+                this.init();
             })
             .catch(error => {
                 console.error("Error in reloadComponent", error);

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/prototype/templating/templating.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/prototype/templating/templating.html
@@ -69,11 +69,6 @@ AIGenPromptEnd(foobar) -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script>
         $(document).ready(function() {
-            // Load CSRF token
-            $.getJSON('/libs/granite/csrf/token.json', function(data) {
-                $('#cq_csrf_token').val(data.token);
-            });
-
             // Restore form data from localStorage
             var formData = JSON.parse(localStorage.getItem('composum-ai-prototype-templating')) || {};
             $('#resourcePath').val(formData.resourcePath || '');
@@ -88,23 +83,31 @@ AIGenPromptEnd(foobar) -->
                     resourcePath: $('#resourcePath').val(),
                     additionalPrompt: $('#additionalPrompt').val(),
                     additionalUrls: $('#additionalUrls').val(),
-                    backgroundInformation: $('#backgroundInformation').val(),
-                    ':cq_csrf_token': $('#cq_csrf_token').val()
+                    backgroundInformation: $('#backgroundInformation').val()
                 };
                 localStorage.setItem('composum-ai-prototype-templating', JSON.stringify(formData));
 
                 $('#replacePromptsBtn, #resetPromptsBtn').prop('disabled', true);
                 $('#resultDiv').text('Contacting the AI ...');
-                $.post('/bin/cpm/ai/experimental/templating.' + method + '.json', formData)
-                    .done(function(data) {
-                        $('#resultDiv').text(JSON.stringify(data, null, 2));
-                    })
-                    .fail(function(jqXHR, textStatus, errorThrown) {
-                        $('#resultDiv').text('Error: ' + errorThrown);
-                    })
-                    .always(function() {
-                        $('#replacePromptsBtn, #resetPromptsBtn').prop('disabled', false);
-                    });
+
+                // Fetch CSRF token before making the POST request
+                $.getJSON('/libs/granite/csrf/token.json', function(data) {
+                    formData[':cq_csrf_token'] = data.token;
+
+                    $.post('/bin/cpm/ai/experimental/templating.' + method + '.json', formData)
+                        .done(function(data) {
+                            $('#resultDiv').text(JSON.stringify(data, null, 2));
+                        })
+                        .fail(function(jqXHR, textStatus, errorThrown) {
+                            $('#resultDiv').text('Error: ' + errorThrown);
+                        })
+                        .always(function() {
+                            $('#replacePromptsBtn, #resetPromptsBtn').prop('disabled', false);
+                        });
+                }).fail(function() {
+                    $('#resultDiv').text('Error: Unable to fetch CSRF token.');
+                    $('#replacePromptsBtn, #resetPromptsBtn').prop('disabled', false);
+                });
             });
         });
     </script>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/prototype/templating/templating.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/prototype/templating/templating.html
@@ -34,8 +34,14 @@ AIGenPromptEnd(foobar) -->
 <body>
     <div class="container">
         <h1>Create a page from a template with AI</h1>
-        <p>This single page application allows you to generate a complete text for a page by replacing prompts with AI-generated content. The page structure contains various components with prompts marked by special placeholders, such as 'PROMPTFIELD: ' for individual prompts and 'PROMPTFIELD#ID: ' for referenced prompts. Additionally, URLs can be included using 'SOURCEURL(https://example.com/)'. The application interacts with the AITemplatingServlet to process the page template.</p>
-        
+        <p>This single page application allows you to generate a complete text for a page by replacing prompts with
+            AI-generated content. The page structure contains various components with prompts marked by special
+            placeholders, such as 'PROMPTFIELD: ' for individual prompts and 'PROMPTFIELD#ID: ' for referenced prompts.
+            Additionally, URLs can be included using 'SOURCEURL(https://example.com/)'.
+            'PAGEPROMPT: ' means the rest of the prompt field are general instructions for the whole page.
+            More detailed instructions are <a href="https://ai.composum.com/aiPageTemplating.html">here</a>.
+        </p>
+
         <form id="templatingForm">
             <input type="hidden" id="cq_csrf_token" name=":cq_csrf_token">
             <div class="form-group">
@@ -61,7 +67,7 @@ AIGenPromptEnd(foobar) -->
             <button type="submit" class="btn btn-primary" id="replacePromptsBtn">Replace Prompts</button>
             <button type="submit" class="btn btn-primary" id="resetPromptsBtn">Reset to Prompts</button>
         </form>
-        
+
         <div class="mt-4"><pre style="white-space: pre-wrap;" id="resultDiv"></pre></div>
     </div>
 

--- a/aem/ui.frontend/src/main/webpack/site/editorExtensions.js
+++ b/aem/ui.frontend/src/main/webpack/site/editorExtensions.js
@@ -10,36 +10,46 @@ var retries;
 // e.g. http://localhost:5502/editor.html/content/gfps/com/en/about-us/going-forward.html#scrolltocomponent-content/container_copy_52774894/item_1510732628
 function maybeScrollToComponent(event, args) {
     console.log('maybeScrollToComponent', event.type, event.target, args);
-    if (Granite?.author?.OverlayWrapper?.$el) {
-        Coral.commons.ready(Granite.author.OverlayWrapper.$el, function () {
-                if (waitingTimeout) {
-                    clearTimeout(waitingTimeout);
-                }
-                retries = 3;
-                waitingTimeout = setTimeout(scrollToComponent, 2000);
-            }
-        );
-    }
+    Coral.commons.ready(document, function () {
+        if (waitingTimeout) {
+            clearTimeout(waitingTimeout);
+        }
+        retries = 40;
+        waitingTimeout = setTimeout(scrollToComponent, 500);
+    });
 }
 
 function scrollToComponent() {
-    const urlParams = new URL(window.location.href);
-    const anchor = urlParams.hash;
+    const url = new URL(window.location.href);
+    const anchor = url.hash;
+    url.hash = '';
+    const newUrl = url.href;
 
     if (anchor.startsWith('#scrolltocomponent-')) {
+        console.log('scrollToComponent', anchor);
         const path = Granite.author.page.path + '/jcr:content/' +
             anchor.replace('#scrolltocomponent-', '');
-        const element = Granite.author.OverlayWrapper.$el.find(`div[data-path="${path}"]`);
-        debugger;
-        if (element.size()) {
-            element[0].scrollIntoView({behavior: 'smooth', block: 'start'});
+        const element = Granite?.author?.OverlayWrapper?.$el?.find(`div.cq-Overlay[data-path="${path}"]`);
+        console.log('scrollToComponent', path, element.size(), element);
+        if (element && element.size()) {
+            setTimeout(() =>
+                    Coral.commons.ready(Granite.author.OverlayWrapper.$el, () =>
+                        element[0].scrollIntoView({behavior: 'smooth', block: 'start'})),
+                500
+            );
+            setTimeout(() => // sometimes that doesn't work - retry :-(
+                    Coral.commons.ready(Granite.author.OverlayWrapper.$el, () =>
+                        element[0].scrollIntoView({behavior: 'smooth', block: 'start'})),
+                2500
+            );
             // Remove the anchor from the URL
-            history.pushState({}, '', window.location.href.split('#')[0]);
+            history.pushState({}, '', newUrl);
         } else if (retries > 0) {
+            console.log('scrollToComponent retry', retries);
             retries--;
-            waitingTimeout = setTimeout(scrollToComponent, 4000);
+            waitingTimeout = setTimeout(scrollToComponent, 500);
         } else { // give up.
-            history.pushState({}, '', window.location.href.split('#')[0]);
+            history.pushState({}, '', newUrl);
         }
     }
 }

--- a/aem/ui.frontend/src/main/webpack/site/editorExtensions.js
+++ b/aem/ui.frontend/src/main/webpack/site/editorExtensions.js
@@ -9,7 +9,6 @@ var retries;
  */
 // e.g. http://localhost:5502/editor.html/content/gfps/com/en/about-us/going-forward.html#scrolltocomponent-content/container_copy_52774894/item_1510732628
 function maybeScrollToComponent(event, args) {
-    console.log('maybeScrollToComponent', event.type, event.target, args);
     Coral.commons.ready(document, function () {
         if (waitingTimeout) {
             clearTimeout(waitingTimeout);

--- a/aem/ui.frontend/src/main/webpack/site/editorExtensions.js
+++ b/aem/ui.frontend/src/main/webpack/site/editorExtensions.js
@@ -1,12 +1,13 @@
 /** Extensions for editor */
 
 var waitingTimeout;
+var retries;
 
 /** Check whether the editor has an anchor #scrolltocomponent-path where path is an actual path like
  * /content/gfps/com/en/about-us/going-forward/jcr:content/content/heroautomaticdata
  * If it has, we remove that anchor from the URL and find the div with data-path with this path and scroll that into view.
  */
-// e.g. http://localhost:5502/editor.html/content/gfps/com/en/about-us/going-forward.html#scrolltocomponent-/content/gfps/com/en/about-us/going-forward/jcr:content/content/container_copy_52774894/item_1510732628
+// e.g. http://localhost:5502/editor.html/content/gfps/com/en/about-us/going-forward.html#scrolltocomponent-content/container_copy_52774894/item_1510732628
 function maybeScrollToComponent(event, args) {
     console.log('maybeScrollToComponent', event.type, event.target, args);
     if (Granite?.author?.OverlayWrapper?.$el) {
@@ -14,6 +15,7 @@ function maybeScrollToComponent(event, args) {
                 if (waitingTimeout) {
                     clearTimeout(waitingTimeout);
                 }
+                retries = 3;
                 waitingTimeout = setTimeout(scrollToComponent, 2000);
             }
         );
@@ -25,13 +27,19 @@ function scrollToComponent() {
     const anchor = urlParams.hash;
 
     if (anchor.startsWith('#scrolltocomponent-')) {
-        const path = anchor.replace('#scrolltocomponent-', '');
-        // Remove the anchor from the URL
-        // history.pushState({}, '', window.location.href.split('#')[0]);
+        const path = Granite.author.page.path + '/jcr:content/' +
+            anchor.replace('#scrolltocomponent-', '');
         const element = Granite.author.OverlayWrapper.$el.find(`div[data-path="${path}"]`);
         debugger;
         if (element.size()) {
-            element[0].scrollIntoView({block: 'center'});
+            element[0].scrollIntoView({behavior: 'smooth', block: 'start'});
+            // Remove the anchor from the URL
+            history.pushState({}, '', window.location.href.split('#')[0]);
+        } else if (retries > 0) {
+            retries--;
+            waitingTimeout = setTimeout(scrollToComponent, 4000);
+        } else { // give up.
+            history.pushState({}, '', window.location.href.split('#')[0]);
         }
     }
 }

--- a/aem/ui.frontend/src/main/webpack/site/editorExtensions.js
+++ b/aem/ui.frontend/src/main/webpack/site/editorExtensions.js
@@ -1,0 +1,40 @@
+/** Extensions for editor */
+
+var waitingTimeout;
+
+/** Check whether the editor has an anchor #scrolltocomponent-path where path is an actual path like
+ * /content/gfps/com/en/about-us/going-forward/jcr:content/content/heroautomaticdata
+ * If it has, we remove that anchor from the URL and find the div with data-path with this path and scroll that into view.
+ */
+// e.g. http://localhost:5502/editor.html/content/gfps/com/en/about-us/going-forward.html#scrolltocomponent-/content/gfps/com/en/about-us/going-forward/jcr:content/content/container_copy_52774894/item_1510732628
+function maybeScrollToComponent(event, args) {
+    console.log('maybeScrollToComponent', event.type, event.target, args);
+    if (Granite?.author?.OverlayWrapper?.$el) {
+        Coral.commons.ready(Granite.author.OverlayWrapper.$el, function () {
+                if (waitingTimeout) {
+                    clearTimeout(waitingTimeout);
+                }
+                waitingTimeout = setTimeout(scrollToComponent, 2000);
+            }
+        );
+    }
+}
+
+function scrollToComponent() {
+    const urlParams = new URL(window.location.href);
+    const anchor = urlParams.hash;
+
+    if (anchor.startsWith('#scrolltocomponent-')) {
+        const path = anchor.replace('#scrolltocomponent-', '');
+        // Remove the anchor from the URL
+        // history.pushState({}, '', window.location.href.split('#')[0]);
+        const element = Granite.author.OverlayWrapper.$el.find(`div[data-path="${path}"]`);
+        debugger;
+        if (element.size()) {
+            element[0].scrollIntoView({block: 'center'});
+        }
+    }
+}
+
+export {maybeScrollToComponent};
+

--- a/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
+++ b/aem/ui.frontend/src/main/webpack/site/registerdialogs.js
@@ -6,6 +6,7 @@
 import {ContentCreationDialog} from './ContentCreationDialog.js';
 import {SidePanelDialog} from './SidePanelDialog.js';
 import {AIConfig} from './AIConfig.js';
+import {maybeScrollToComponent} from './editorExtensions.js';
 
 try {
     /**
@@ -26,6 +27,8 @@ try {
         const SERVICE_SIDEPANEL = 'sidepanel';
         const aiconfig = new AIConfig();
         var debug = false;
+
+        channel.on('coral-overlay:open foundation-contentloaded', maybeScrollToComponent);
 
         channel.on('cq-sidepanel-loaded', (event) => Coral.commons.ready(event.target, loadSidebarPanelDialog));
         // for AEM 6.5.7 we, strangely, don't get the cq-sidepanel-loaded event. Try something else.

--- a/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/GPTTranslationServiceImplTest.java
+++ b/backend/base/src/test/java/com/composum/ai/backend/base/service/chat/impl/GPTTranslationServiceImplTest.java
@@ -161,7 +161,7 @@ public class GPTTranslationServiceImplTest extends TestCase {
         String text = "This is a test <a href=\"https://www.composum.com\">and some Code</a>";
         String faked = fakeTranslation(text);
         assertEquals(text.toLowerCase(), faked.toLowerCase());
-        assertTrue(!text.equals(faked)); // changes in case
+        assertTrue(faked,!text.equals(faked)); // changes in case
         assertTrue(faked, faked.contains("https://www.composum.com")); // this must not be changed.
     }
 

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/experimential/impl/AITemplatingServiceImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/experimential/impl/AITemplatingServiceImpl.java
@@ -177,11 +177,8 @@ public class AITemplatingServiceImpl implements AITemplatingService {
     }
 
 
-    protected static @NotNull String joinText(Map<String, String> prompts, String additionalPrompt) {
+    protected static @NotNull String joinText(Map<String, String> prompts) {
         StringBuilder prompt = new StringBuilder(PREFIX_PROMPT);
-        if (StringUtils.isNotBlank(additionalPrompt)) {
-            prompt.append("\n").append(additionalPrompt).append("\n");
-        }
         for (Map.Entry<String, String> entry : prompts.entrySet()) {
             prompt.append("%%%%%%%% ").append(entry.getKey()).append(" %%%%%%%%\n");
             prompt.append(entry.getValue().trim()).append("\n");
@@ -191,7 +188,7 @@ public class AITemplatingServiceImpl implements AITemplatingService {
 
     /**
      * Splits the response at the %%%%%%%% ID %%%%%%%% separators and puts the items into a map.
-     * Inverse of {@link #joinText(Map, String)}.
+     * Inverse of {@link #joinText(Map)}.
      */
     @Nonnull
     protected static Map<String, String> extractParts(String response) {
@@ -233,6 +230,9 @@ public class AITemplatingServiceImpl implements AITemplatingService {
         for (String pagePrompt : pagePrompts) {
             sysprompt.append("\n\n").append(pagePrompt);
         }
+        if (StringUtils.isNotBlank(additionalPrompt)) {
+            sysprompt.append("\n\n").append(additionalPrompt);
+        }
         request.addMessage(GPTMessageRole.SYSTEM, sysprompt.toString());
 
         for (String url : urls) {
@@ -245,7 +245,7 @@ public class AITemplatingServiceImpl implements AITemplatingService {
             request.addMessage(GPTMessageRole.USER, "Retrieve the background information for later prompts.");
             request.addMessage(GPTMessageRole.ASSISTANT, backgroundInformation.trim());
         }
-        request.addMessage(GPTMessageRole.USER, joinText(prompts, additionalPrompt));
+        request.addMessage(GPTMessageRole.USER, joinText(prompts));
         return request;
     }
 

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/experimential/impl/AITemplatingServiceImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/experimential/impl/AITemplatingServiceImpl.java
@@ -270,7 +270,7 @@ public class AITemplatingServiceImpl implements AITemplatingService {
             if (idmatch.find()) {
                 String name = idmatch.group("id");
                 id = name != null ? "PROMPT" + name : "PROMPT#" + String.valueOf(1000 + counter.incrementAndGet()).substring(1);
-                prompt = StringUtils.defaultString(idmatch.group("prefix")) + replacement.text.substring(idmatch.end());
+                prompt = /* StringUtils.defaultString(idmatch.group("prefix")) + */ replacement.text.substring(idmatch.end());
                 prompt = (isRichtext ? "As rich text HTML: " : "As plain text: ") + prompt;
                 if (ids.containsKey(id)) {
                     LOG.error("The resource contains a declaration for the key {} twice: one at {} and one at {}", id, ids.get(id), replacement);

--- a/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImpl.java
+++ b/backend/slingbase/src/main/java/com/composum/ai/backend/slingbase/impl/ApproximateMarkdownServiceImpl.java
@@ -81,7 +81,7 @@ public class ApproximateMarkdownServiceImpl implements ApproximateMarkdownServic
     /**
      * Pattern for several kinds of ignored keys.
      */
-    protected final static Pattern IGNORED_ATTRIBUTE_PATTERN = Pattern.compile("^((cq:|sling:|ai_|lc_).*|fileReference|link|linkURL)$");
+    protected final static Pattern IGNORED_ATTRIBUTE_PATTERN = Pattern.compile("^((cq:|sling:|ai_|lc_).*|fileReference|link|linkURL|imageMap)$");
 
     /**
      * We ignore nodes named i18n or renditions and nodes starting with rep:, dam:, cq:

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/experimential/impl/AITemplatingServiceImplTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/experimential/impl/AITemplatingServiceImplTest.java
@@ -49,7 +49,8 @@ public class AITemplatingServiceImplTest {
 
         ec.checkThat(texts.get("PROMPT#001"), is("As plain text: single sentence invitation to check out the product"));
         ec.checkThat(texts.get("PROMPT#ID1"), is("As plain text: name of the product"));
-        ec.checkThat(texts.get("PROMPT#002"), is("As rich text HTML: <p><strong>markdown list of key features</strong></p>"));
+        // we remove html tags at the start of the prompt as that seems ChatGPT to prevent recognizing these as prompts.
+        ec.checkThat(texts.get("PROMPT#002"), is("As rich text HTML: markdown list of key features</strong></p>"));
         ec.checkThat(texts.get("informationally#003"), is("Print unchanged the quoted text without the triple backtick quoting: ```Key Features```"));
 
         ec.checkThat(ids.size(), is(3));

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/experimential/impl/AITemplatingServiceImplTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/experimential/impl/AITemplatingServiceImplTest.java
@@ -102,7 +102,7 @@ public class AITemplatingServiceImplTest {
         Map<String, String> prompts = new LinkedHashMap<>();
         prompts.put("PROMPT#001", "something");
         prompts.put("informationally#002", "As rich text HTML: <p><strong>markdown list of key features</strong></p>");
-        String joined = AITemplatingServiceImpl.joinText(prompts, null);
+        String joined = AITemplatingServiceImpl.joinText(prompts);
         Map<String, String> result = AITemplatingServiceImpl.extractParts(joined);
         ec.checkThat(result, is(prompts));
     }

--- a/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/experimential/impl/AITemplatingServiceImplTest.java
+++ b/backend/slingbase/src/test/java/com/composum/ai/backend/slingbase/experimential/impl/AITemplatingServiceImplTest.java
@@ -47,10 +47,10 @@ public class AITemplatingServiceImplTest {
         ec.checkThat(texts.size(), is(4));
         ec.checkThat(texts.keySet(), allOf(hasItem("PROMPT#001"), hasItem("PROMPT#ID1"), hasItem("PROMPT#002"), hasItem("informationally#003")));
 
-        ec.checkThat(texts.get("PROMPT#001"), is("Print as plain text: single sentence invitation to check out the product"));
-        ec.checkThat(texts.get("PROMPT#ID1"), is("Print as plain text: name of the product"));
-        ec.checkThat(texts.get("PROMPT#002"), is("Print as rich text HTML: <p><strong>markdown list of key features</strong></p>"));
-        ec.checkThat(texts.get("informationally#003"), is("Print unchanged the quoted text without the quotes: ```Key Features```"));
+        ec.checkThat(texts.get("PROMPT#001"), is("As plain text: single sentence invitation to check out the product"));
+        ec.checkThat(texts.get("PROMPT#ID1"), is("As plain text: name of the product"));
+        ec.checkThat(texts.get("PROMPT#002"), is("As rich text HTML: <p><strong>markdown list of key features</strong></p>"));
+        ec.checkThat(texts.get("informationally#003"), is("Print unchanged the quoted text without the triple backtick quoting: ```Key Features```"));
 
         ec.checkThat(ids.size(), is(3));
         ec.checkThat(ids.get("PROMPT#001"), is(r1));
@@ -100,8 +100,8 @@ public class AITemplatingServiceImplTest {
     public void joinAndExtract() {
         Map<String, String> prompts = new LinkedHashMap<>();
         prompts.put("PROMPT#001", "something");
-        prompts.put("informationally#002", "Print as rich text HTML: <p><strong>markdown list of key features</strong></p>");
-        String joined = AITemplatingServiceImpl.joinText(prompts);
+        prompts.put("informationally#002", "As rich text HTML: <p><strong>markdown list of key features</strong></p>");
+        String joined = AITemplatingServiceImpl.joinText(prompts, null);
         Map<String, String> result = AITemplatingServiceImpl.extractParts(joined);
         ec.checkThat(result, is(prompts));
     }

--- a/featurespecs/8.2AutomaticTranslationMergeTool.md
+++ b/featurespecs/8.2AutomaticTranslationMergeTool.md
@@ -76,7 +76,7 @@ Since the inheritance can be cancelled and reenabled at any time without the tra
 to be prepared for that. The following actions influence the saved properties:
 
 1. If a rollout translation is done on a cancelled inheritance, only the ai_new_* properties are set / updated.
-2. If a rollout translation is done on uncancelled inheritance, the ai_new_* properties are removed and the ai_*
+2. If a rollout translation is done on enabled inheritance, the ai_new_* properties are removed and the ai_*
    properties are updated.
 3. If a merge is completed, we remove the ai_new_* properties but save the ai_new_original into ai_original and the
    current value into ai_translated to support future rollouts. (Possibly also set _manualChange properties.)

--- a/featurespecs/8.3AutomaticTranslationCheckTool.md
+++ b/featurespecs/8.3AutomaticTranslationCheckTool.md
@@ -219,3 +219,9 @@ if the editor does a page sync while at that, it'll be fine.)
 5. **Prüfung des Gesamttextes**: Es wurde betont, dass es wichtig ist, nicht nur die einzelnen Übersetzungen zu prüfen,
    sondern auch das Gesamtbild der Seiten im Auge zu behalten. Die Editoren sollten die Seiten nach der Bearbeitung noch
    einmal in ihrem Gesamtkontext überprüfen.
+
+## TODO / Unclear
+
+- when should the tool be shown in the menu? Only if there is something to do or always? (Likely always if it's a 
+  live copy.)
+- Cancel inheritance leads to a "no action needed" state since there is no new translation. Set a marker?

--- a/featurespecs/8.3AutomaticTranslationCheckTool.md
+++ b/featurespecs/8.3AutomaticTranslationCheckTool.md
@@ -1,0 +1,87 @@
+# Automatic Translation Checking
+
+## Preliminaries
+
+### Livecycle of properties
+
+The following meta-properties might be present for a property {propertyName}:
+
+- ai_original_{propertyName}: Stores the text in its original state before any AI-generated translation is applied.
+- ai_translated_{propertyName}: Holds the AI-generated translation for the corresponding property.
+- ai_new_original_{propertyName} is the value after the last rollout
+- ai_new_translated_{propertyName} is the translation of ai_new_original_{propertyName}
+
+### Current state diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> AutoTranslated
+    AutoTranslated: Automatically Translated\n\nai_original_P\nai_translated_P
+    InheritanceBroken: Inheritance Broken\n\nai_new_original_P\nai_new_translated_P
+    InheritanceBrokenWithPendingChanges: Inheritance Broken\nwith Pending Changes\n\n\n\nai_new_original_P\nai_new_translated_P\nai_new_original_P\nai_new_translated_P
+    AutoTranslated --> InheritanceBroken: cancel\ninheritance
+    AutoTranslated --> AutoTranslated: rollout
+    InheritanceBroken --> AutoTranslated: restore\ninheritance
+    InheritanceBroken --> InheritanceBrokenWithPendingChanges: rollout\nchanged\nsource
+    InheritanceBrokenWithPendingChanges --> AutoTranslated: cancel\ninheritance
+    InheritanceBrokenWithPendingChanges --> InheritanceBroken: merge\nchanges
+```
+
+<hr>
+
+### State diagram with check tool
+
+```mermaid
+stateDiagram-v2
+    [*] --> AutoTranslatedUnchecked
+    AutoTranslatedUnchecked: Automatically Translated\nUnchecked\n\nai_original_P\nai_translated_P\nai_unchecked_P
+    AutoTranslated: Automatically Translated\n\nai_original_P\nai_translated_P
+    InheritanceBroken: Inheritance Broken\n\nai_new_original_P\nai_new_translated_P
+    InheritanceBrokenWithPendingChanges: Inheritance Broken\nwith Pending Changes\n\nai_original_P\nai_translated_P\nai_new_original_P\nai_new_translated_P
+    AutoTranslatedUnchecked --> AutoTranslated: check\ntranslation
+    AutoTranslatedUnchecked --> InheritanceBroken: cancel\ninheritance
+    AutoTranslatedUnchecked --> AutoTranslatedUnchecked: rollout
+    AutoTranslated --> InheritanceBroken: cancel\ninheritance
+    AutoTranslated --> AutoTranslatedUnchecked: rollout
+    InheritanceBroken --> AutoTranslated: restore\ninheritance
+    InheritanceBroken --> InheritanceBrokenWithPendingChanges: rollout\nchanged\nsource
+    InheritanceBroken --> InheritanceBroken: rollout\nunchanged\nsource
+    InheritanceBrokenWithPendingChanges --> AutoTranslated: restore\ninheritance
+    InheritanceBrokenWithPendingChanges --> InheritanceBroken: merge\nchanges
+    InheritanceBrokenWithPendingChanges --> InheritanceBrokenWithPendingChanges: rollout
+```
+
+```mermaid
+stateDiagram-v2
+    [*] --> AutoTranslatedUnchecked
+    AutoTranslatedUnchecked --> AutoTranslated: approve\ntranslation
+    AutoTranslatedUnchecked --> InheritanceBroken: save\ntranslation
+    AutoTranslatedUnchecked --> InheritanceBroken: cancel\ninheritance
+    AutoTranslatedUnchecked --> AutoTranslatedUnchecked: rollout
+    AutoTranslated --> InheritanceBroken: cancel\ninheritance
+    AutoTranslated --> InheritanceBroken: change+finish\ntranslation
+    AutoTranslated --> AutoTranslatedUnchecked: rollout\nchanged\nsource
+    AutoTranslated --> AutoTranslated: rollout\nunchanged\nsource
+    InheritanceBroken --> AutoTranslated: restore\ninheritance
+    InheritanceBroken --> InheritanceBrokenWithPendingChanges: rollout\nchanged\nsource
+    InheritanceBroken --> InheritanceBroken: rollout\nunchanged\nsource
+    InheritanceBrokenWithPendingChanges --> AutoTranslated: restore\ninheritance
+    InheritanceBrokenWithPendingChanges --> InheritanceBroken: merge\nchanges
+    InheritanceBrokenWithPendingChanges --> InheritanceBrokenWithPendingChanges: rollout
+```
+<hr>
+
+AutoTranslateUnchecked:
+- property = auto translated value
+- ai_original_{propertyName} : source
+- ai_translated_{propertyName} : auto translated value, as displayed
+- ai_unchecked_{propertyName} : true, marker for checking
+
+
+Changes:
+- rollout splitten
+- Anzeige welche Stati
+- Diffs klären
+- ai_approved: eigentlich 2 Sprachen
+- 
+

--- a/featurespecs/8.3AutomaticTranslationCheckTool.md
+++ b/featurespecs/8.3AutomaticTranslationCheckTool.md
@@ -69,19 +69,108 @@ stateDiagram-v2
     InheritanceBrokenWithPendingChanges --> InheritanceBroken: merge\nchanges
     InheritanceBrokenWithPendingChanges --> InheritanceBrokenWithPendingChanges: rollout
 ```
+
 <hr>
 
 AutoTranslateUnchecked:
+
 - property = auto translated value
 - ai_original_{propertyName} : source
 - ai_translated_{propertyName} : auto translated value, as displayed
 - ai_unchecked_{propertyName} : true, marker for checking
 
+## Kinds of properties
 
-Changes:
+Important point: a switch between inheritance cancelled and inheritance not cancelled can be done any time "behind 
+the back" of the translation mechanism. An important difference is that in the case of inheritance cancelled the 
+current content of the page counts as approved by the editor and can be changed any time behind the mechanisms back, 
+while in the case of uncancelled inheritance the approval is given only by action in the merge dialog.
+
+### Inheritance not cancelled
+
+Action: 
+1. Accept automatical translation -> inheritance is not cancelled
+2. Either one of these:
+   a. Cancel inheritance, save and finish, or
+   b. Cancel inheritance and switch to "inheritance cancelled" view (editing was disabled)
+
+Case b): in the new "cancel inheritance" view we would have to see:
+1. the diffs between last accepted source and current source
+2. the last accepted translation
+3. the translation of the new source
+Columns are currently: "Original diffs", "New text translation" and "Editor for current text"
+
+Columns: Original diffs / previously translated text + new source text ,
+
+? translation of previous text and current translation
+
+- New property. Diff = empty vs. source value, editor and current text on page = autotranslated 
+  value
+- Property that was accepted: no display (?). Diff = source value vs. source value, editor and current text on page = 
+  accepted value
+- Property that was not yet accepted. Diff = old source value vs. new source value,  
+
+- property = initially the auto translated value. Can be different when inheritance cancelled, change and restore
+- ai_original_{propertyName}: source for the last auto translation
+- ai_translated_{propertyName}: result of the last auto translation
+- ai_new_original_{propertyName} ???
+- ai_new_translated_{propertyName} ???
+- ai_unchecked_{propertyName} : true, marker for checking
+
+?? where to store result of last "accept"?
+
+Vorgang: die Übersetzungen wurden manuell überschrieben und sollen kontrolliert werden auf Basis der letzten 
+akzeptierten Übersetzungen.
+
+### Inheritance cancelled
+
+Action: 
+- Save and Finish: deletes ai_new_* and saves the current value
+- "Restore inheritance": overwrites the current value with the last ai_new_translated, moves the ai_new_* to ai_*.
+
+Columns: Original diffs / previously translated text + new source text , new text translation, editor for current 
+text, current text on page
+
+- no new translation: no display (?). diff = same vs. same, editor and current text on page = 
+  current value
+- new translation: diff = last checked source vs. new source, editor and current text on page = 
+  new translation
+
+- property = initially the auto translated value. Can be different when inheritance cancelled, change and restore
+- ai_original_{propertyName}: source for the last auto translation or the last "save and finish"
+- ai_translated_{propertyName}: auto-translated result of the ai_original_{propertyName}
+- ai_new_original_{propertyName} unmerged source for last rollout
+- ai_new_translated_{propertyName} unmerged ai translation result for the last rollout
+
+## Changes:
+
 - rollout splitten
 - Anzeige welche Stati
 - Diffs klären
 - ai_approved: eigentlich 2 Sprachen
-- 
 
+! cancelling / restoring inheritance has to work organically - the display has to make sense
+
+## Aspects
+
+1. **Eindeutige Visualisierung von Zuständen**: Es wurde empfohlen, die unterschiedlichen Fälle (z.B. wenn die
+   Inheritance gecancelt ist vs. nicht gecancelt) optisch klar zu unterscheiden. Dies könnte durch unterschiedliche
+   Farben, Symbole oder Beschriftungen in den Überschriften der Spalten erreicht werden, um den Benutzern zu helfen, den
+   jeweiligen Status der Übersetzungen besser zu verstehen.
+
+2. **Einführung einer neuen Spalte für den alten, genehmigten Text**: Die Idee war, eine zusätzliche Spalte einzuführen,
+   die den bereits genehmigten Text anzeigt, damit Benutzer den Unterschied zwischen dem aktuellen und dem vorigen Text
+   leicht erkennen können. Dies hilft, Entscheidungshilfen zu geben, wenn die englische Version eines Textes
+   aktualisiert wurde.
+
+3. **Kombination von Funktionen**: Anstatt separate Tools für verschiedene Funktionen zu erstellen, wurde vorgeschlagen,
+   alle relevanten Funktionen in einer einzigen Benutzeroberfläche zusammenzufassen. Dies würde den Editoren helfen,
+   effizienter zu arbeiten, indem sie zwischen verschiedenen Ansichten und Aktionen leicht wechseln können.
+
+4. **Verbesserung der Benutzeroberfläche (UI)**: Eine klarere Struktur der Benutzeroberfläche wurde als wichtig
+   erachtet, um den Benutzern die Navigation und das Verständnis der Dialoge zu erleichtern. Dies könnte durch Tooltips,
+   Hilfetexte oder klare Anweisungen innerhalb der Anwendung geschehen.
+
+5. **Prüfung des Gesamttextes**: Es wurde betont, dass es wichtig ist, nicht nur die einzelnen Übersetzungen zu prüfen,
+   sondern auch das Gesamtbild der Seiten im Auge zu behalten. Die Editoren sollten die Seiten nach der Bearbeitung noch
+   einmal in ihrem Gesamtkontext überprüfen.

--- a/featurespecs/8.3AutomaticTranslationCheckTool.md
+++ b/featurespecs/8.3AutomaticTranslationCheckTool.md
@@ -80,34 +80,38 @@ AutoTranslateUnchecked:
 
 ## Kinds of properties
 
-Important point: a switch between inheritance cancelled and inheritance not cancelled can be done any time "behind 
-the back" of the translation mechanism. An important difference is that in the case of inheritance cancelled the 
-current content of the page counts as approved by the editor and can be changed any time behind the mechanisms back, 
+Important point: a switch between inheritance cancelled and inheritance not cancelled can be done any time "behind
+the back" of the translation mechanism. An important difference is that in the case of inheritance cancelled the
+current content of the page counts as approved by the editor and can be changed any time behind the mechanisms back,
 while in the case of uncancelled inheritance the approval is given only by action in the merge dialog.
 
 ### Inheritance not cancelled
 
-Action: 
+Action:
+
 1. Accept automatical translation -> inheritance is not cancelled
-2. Either one of these:
-   a. Cancel inheritance, save and finish, or
-   b. Cancel inheritance and switch to "inheritance cancelled" view (editing was disabled)
+2. Cancel inheritance and switch to "inheritance cancelled" view (editing was disabled)
 
 Case b): in the new "cancel inheritance" view we would have to see:
+
 1. the diffs between last accepted source and current source
 2. the last accepted translation
 3. the translation of the new source
-Columns are currently: "Original diffs", "New text translation" and "Editor for current text"
 
-Columns: Original diffs / previously translated text + new source text ,
+Columns:
 
-? translation of previous text and current translation
+1. last accepted source (deletions marked)
+2. current source (insertions marked)
+3. diffs between 1 and 2
+4. last accepted translation
+5. current value on page
+6. (current value on page -> duplicate!)
 
-- New property. Diff = empty vs. source value, editor and current text on page = autotranslated 
+- New property. Diff = empty vs. source value, editor and current text on page = autotranslated
   value
-- Property that was accepted: no display (?). Diff = source value vs. source value, editor and current text on page = 
+- Property that was accepted: no display (?). Diff = source value vs. source value, editor and current text on page =
   accepted value
-- Property that was not yet accepted. Diff = old source value vs. new source value,  
+- Property that was not yet accepted. Diff = old source value vs. new source value,
 
 - property = initially the auto translated value. Can be different when inheritance cancelled, change and restore
 - ai_original_{propertyName}: source for the last auto translation
@@ -120,21 +124,22 @@ Columns: Original diffs / previously translated text + new source text ,
 The ai_new_* and ai_accepted_* properties are alternatives - only one of them is stored, depending on the cancellation
 state of the property / component.
 
-Vorgang: die Übersetzungen wurden manuell überschrieben und sollen kontrolliert werden auf Basis der letzten 
+Vorgang: die Übersetzungen wurden manuell überschrieben und sollen kontrolliert werden auf Basis der letzten
 akzeptierten Übersetzungen.
 
 ### Inheritance cancelled
 
-Action: 
+Action:
+
 - Save and Finish: deletes ai_new_* and saves the current value
 - "Restore inheritance": overwrites the current value with the last ai_new_translated, moves the ai_new_* to ai_*.
 
-Columns: Original diffs / previously translated text + new source text , new text translation, editor for current 
+Columns: Original diffs / previously translated text + new source text , new text translation, editor for current
 text, current text on page
 
-- no new translation: no display (?). diff = same vs. same, editor and current text on page = 
+- no new translation: no display (?). diff = same vs. same, editor and current text on page =
   current value
-- new translation: diff = last checked source vs. new source, editor and current text on page = 
+- new translation: diff = last checked source vs. new source, editor and current text on page =
   new translation
 
 - property = initially the auto translated value. Can be different when inheritance cancelled, change and restore

--- a/featurespecs/8.3AutomaticTranslationCheckTool.md
+++ b/featurespecs/8.3AutomaticTranslationCheckTool.md
@@ -144,11 +144,31 @@ text, current text on page
 
 - property = initially the auto translated value. Can be different when inheritance cancelled, change and restore
 - ai_original_{propertyName}: source for the last auto translation or the last "save and finish"
-- ai_translated_{propertyName}: auto-translated result of the ai_original_{propertyName}. If the inheritance is not 
-  cancelled, this should always be the same as the current value on the page since that is used during rollout if 
+- ai_translated_{propertyName}: auto-translated result of the ai_original_{propertyName}. If the inheritance is not
+  cancelled, this should always be the same as the current value on the page since that is used during rollout if
   the source is as in ai_original_{propertyName}.
 - ai_new_original_{propertyName} unmerged source for last rollout
 - ai_new_translated_{propertyName} unmerged ai translation result for the last rollout
+
+## Summary of modi
+
+1. Inheritance is not cancelled, there is no accepted translation = 1. = hasData
+    - source text, empty, source text, empty, editor for current text, current text on page
+2. Inheritance is not cancelled, there is an accepted translation
+    - original diffs deletions, original diffs insert, original diffs, last accepted translation, editor for current
+      text, empty
+3. Inheritance is cancelled and there is no new data (that is, cancellation in UI after rollout)
+    - source text, empty, source text, empty, editor for current text, current text on page
+4. Inheritance is cancelled and there is new data
+    - original diffs deletions, original diffs insert, original diffs, new text translation, editor for current text,
+      current text on page
+
+| Inheritance   | New Data | 1 (Deletions)               | 2 (Insertions)   | 3 (Diffs)                         | 4 (Translation)           | 5 (Editor) | 6 (current) 
+|---------------|----------|-----------------------------|------------------|-----------------------------------|---------------------------|------------|-------------
+| not cancelled | no       | -                           | New Source Text  | New Source Text                   | -                         | current    | -           
+| not cancelled | yes      | Last Accepted Original Text | Current Original | Diffs from last accepted original | Last Accepted Translation | current    | -           
+| cancelled     | no       | -                           | New Source Text  | New Source Text                   | -                         | editor     | current     
+| cancelled     | yes      | Previously Translated Text  | New Source Text  | Original Diffs                    | New Translation           | editor     | current     
 
 ## Important considerations
 
@@ -163,17 +183,17 @@ AutoPageTranslateServiceImpl.translateLiveCopy).
 
 It probably doesn't hurt if we don't change the accepted values during cancel / reenable, though.
 
-If there is no new translation, the display for the editor doesn't make sense - it should probably just behave as if 
+If there is no new translation, the display for the editor doesn't make sense - it should probably just behave as if
 the new translation is exactly the same as the current translation.
 
 ### Reenabling inheritance
 
 Assume we have a new translation and are restoring inheritance after a rollout. *Since the new translation is newer than
-the currently set value, the new translation should overwrite the current value* - ai_original, ai_translated and 
-current value. (Done in com.composum.ai.aem.core.impl.autotranslate.AutoTranslateMergeServiceImpl.changeInheritance). 
+the currently set value, the new translation should overwrite the current value* - ai_original, ai_translated and
+current value. (Done in com.composum.ai.aem.core.impl.autotranslate.AutoTranslateMergeServiceImpl.changeInheritance).
 This means a cancel / reenable turnaround does change the current value - reenable is including sync.
 
-Trouble: if the cancel / reenable is done in the editor, nothing changes. (Can't do anything about that - however, 
+Trouble: if the cancel / reenable is done in the editor, nothing changes. (Can't do anything about that - however,
 if the editor does a page sync while at that, it'll be fine.)
 
 ## Aspects

--- a/featurespecs/8.3AutomaticTranslationCheckTool.md
+++ b/featurespecs/8.3AutomaticTranslationCheckTool.md
@@ -144,18 +144,37 @@ text, current text on page
 
 - property = initially the auto translated value. Can be different when inheritance cancelled, change and restore
 - ai_original_{propertyName}: source for the last auto translation or the last "save and finish"
-- ai_translated_{propertyName}: auto-translated result of the ai_original_{propertyName}
+- ai_translated_{propertyName}: auto-translated result of the ai_original_{propertyName}. If the inheritance is not 
+  cancelled, this should always be the same as the current value on the page since that is used during rollout if 
+  the source is as in ai_original_{propertyName}.
 - ai_new_original_{propertyName} unmerged source for last rollout
 - ai_new_translated_{propertyName} unmerged ai translation result for the last rollout
 
-## Changes:
+## Important considerations
 
-- rollout splitten
-- Anzeige welche Stati
-- Diffs klären
-- ai_approved: eigentlich 2 Sprachen
+Cancelling / restoring inheritance has to work organically - the display has to make sense.
 
-! cancelling / restoring inheritance has to work organically - the display has to make sense
+### Cancelling inheritance
+
+If we cancel the inheritance and there was a "new translation" from a previous cancel inheritance
+that'd be bad since that would be older than the automatically translated value -> *a rollout should remove new
+translation if inheritance is enabled at that moment.* (Done in com.composum.ai.aem.core.impl.autotranslate.
+AutoPageTranslateServiceImpl.translateLiveCopy).
+
+It probably doesn't hurt if we don't change the accepted values during cancel / reenable, though.
+
+If there is no new translation, the display for the editor doesn't make sense - it should probably just behave as if 
+the new translation is exactly the same as the current translation.
+
+### Reenabling inheritance
+
+Assume we have a new translation and are restoring inheritance after a rollout. *Since the new translation is newer than
+the currently set value, the new translation should overwrite the current value* - ai_original, ai_translated and 
+current value. (Done in com.composum.ai.aem.core.impl.autotranslate.AutoTranslateMergeServiceImpl.changeInheritance). 
+This means a cancel / reenable turnaround does change the current value - reenable is including sync.
+
+Trouble: if the cancel / reenable is done in the editor, nothing changes. (Can't do anything about that - however, 
+if the editor does a page sync while at that, it'll be fine.)
 
 ## Aspects
 

--- a/featurespecs/8.3AutomaticTranslationCheckTool.md
+++ b/featurespecs/8.3AutomaticTranslationCheckTool.md
@@ -83,7 +83,7 @@ AutoTranslateUnchecked:
 Important point: a switch between inheritance cancelled and inheritance not cancelled can be done any time "behind
 the back" of the translation mechanism. An important difference is that in the case of inheritance cancelled the
 current content of the page counts as approved by the editor and can be changed any time behind the mechanisms back,
-while in the case of uncancelled inheritance the approval is given only by action in the merge dialog.
+while in the case of enabled inheritance the approval is given only by action in the merge dialog.
 
 ### Inheritance not cancelled
 

--- a/featurespecs/8.3AutomaticTranslationCheckTool.md
+++ b/featurespecs/8.3AutomaticTranslationCheckTool.md
@@ -77,7 +77,6 @@ AutoTranslateUnchecked:
 - property = auto translated value
 - ai_original_{propertyName} : source
 - ai_translated_{propertyName} : auto translated value, as displayed
-- ai_unchecked_{propertyName} : true, marker for checking
 
 ## Kinds of properties
 
@@ -113,11 +112,13 @@ Columns: Original diffs / previously translated text + new source text ,
 - property = initially the auto translated value. Can be different when inheritance cancelled, change and restore
 - ai_original_{propertyName}: source for the last auto translation
 - ai_translated_{propertyName}: result of the last auto translation
-- ai_new_original_{propertyName} ???
-- ai_new_translated_{propertyName} ???
-- ai_unchecked_{propertyName} : true, marker for checking
+- ai_new_original_{propertyName} unmerged source for last rollout of inheritance cancelled property
+- ai_new_translated_{propertyName} unmerged auto translation of new_original
+- ai_accepted_source_{propertyName} source of property when user hit "accept" last time
+- ai_accepted_translation_{propertyName} property value (= auto translation) of property when user hit "accept"
 
-?? where to store result of last "accept"?
+The ai_new_* and ai_accepted_* properties are alternatives - only one of them is stored, depending on the cancellation
+state of the property / component.
 
 Vorgang: die Übersetzungen wurden manuell überschrieben und sollen kontrolliert werden auf Basis der letzten 
 akzeptierten Übersetzungen.


### PR DESCRIPTION
The translation review tool allows to easily inspect all translations that have been done by the AI for a page and change them if necessary. It is done in a workflow-like manner: only translations that need attention are displayed (or all translated properties, if that’s desired.) For each shown translation with enabled inheritance it’s possible to accept the translation, or to cancel the inheritance of the component and change the translation. For translations with cancelled inheritance where changes are pending it’s possible to merge in the pending changes and save the translation - or reset it to enabled inheritance.

This has been implemented by extending the existing Translation Merge Tool.