### PR TITLE
Improve Translation review

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ Copilot IntelliJ plugin, for speeding up development. Some outcomes of that:
 
 ## More project documentation
 
-[Architecture](./Architecture.md) contains a description of the chosen project architecture and records
-architectural decisions.
+[AEM Architecture](featurespecs/AemIntegrationArchitecture.md) and
+[Composum Architecture](featurespecs/ComposumIntegrationArchitecture.md) 
+contain a description of the chosen project architecture and records architectural decisions.
 
 [Project structure](./ProjectStructure.md) describes the module structure of the project.
 

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
@@ -237,7 +237,7 @@ public class AutoTranslateMergeModel {
 
         public static PropertyFilter fromValue(String value) {
             if (value == null) {
-                return INHERITANCE_CANCELLED;
+                return PropertyFilter.ALL_PROPERTIES;
             }
             for (PropertyFilter filter : values()) {
                 if (filter.value.equals(value)) {

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -200,6 +201,13 @@ public class AutoTranslateMergeModel {
 
         public String getComponentPath() {
             return componentPath;
+        }
+
+        /**
+         * An unique id to identify the component in the HTML.
+         */
+        public int getComponentId() {
+            return Math.abs(92821 * Objects.hash(componentPath) + Objects.hash(getCancelPropertyName()));
         }
 
         /**

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/bottombar-template.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/bottombar-template.html
@@ -1,5 +1,16 @@
 <template data-sly-template.bottombarTemplate="${@ model}">
     <section class="coral-Form-fieldset bottombar coral--light">
+        <p data-sly-test="${model.unfilteredPropertiesSize != 0 && model.properties.empty}">
+            <coral-alert variant="error">
+                <coral-alert-content class="alertcontent">No properties are matching the current filter settings.
+                </coral-alert-content>
+            </coral-alert>
+        </p>
+        <p data-sly-test="${model.blueprintBroken}">
+            <coral-alert variant="error">
+                <coral-alert-content class="alertcontent">Can't identify blueprint for this page.</coral-alert-content>
+            </coral-alert>
+        </p>
         <p class="errormessage" hidden>
             <coral-alert variant="error">
                 <coral-alert-content class="alertcontent"></coral-alert-content>
@@ -22,7 +33,7 @@
             </coral-tooltip>
         </a>
         <select id="propertyfilter" class="_coral-FieldButton _coral-ActionButton">
-            <option value="allstati">All Properties</option>
+            <option value="allstati">All Components</option>
             <option value="cancelled">Inheritance Cancelled</option>
             <option value="inheritanceenabled">Inheritance Enabled</option>
         </select>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.css
@@ -196,6 +196,10 @@ body.hide-currenttext .currenttext {
     border-radius: 4px;
 }
 
+.rte-container {
+    background-color: white;
+}
+
 .rte-editor {
     border: 1px solid #ccc;
     padding: 8px;

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -71,7 +71,7 @@
                                     data-cancelpropertyname="${pageComponent.cancelPropertyName}"></tr>
 
                                 <tr is="coral-table-row" class="component-head ${pageComponent.cancelledClass}"
-                                    id="component-${pageComponentList.index}"
+                                    id="component-${pageComponent.componentId}"
                                     data-componentpath="${pageComponent.componentPath}"
                                     data-cancelpropertyname="${pageComponent.cancelPropertyName}">
                                     <td class="cancelcol" rowspan="${pageComponent.calculatedComponentRowspan}">
@@ -121,7 +121,7 @@
                                         class="row-separator ${property.cancelledClass} ${property.processingNeededClass}"
                                         data-componentpath="${pageComponent.componentPath}"
                                         data-cancelpropertyname="${pageComponent.cancelPropertyName}"
-                                        id="row-${pageComponentList.index}-${propertyList.index}">
+                                        id="row-${pageComponent.componentId}-${propertyList.index}">
                                         <sly data-sly-test="${cancelled}">
                                             <th is="coral-table-headercell" class="previoussrc">
                                             <span class="propertyname">
@@ -231,7 +231,7 @@
                                         class="property-row datarow ${property.cancelledClass} ${property.processingNeededClass}"
                                         data-componentpath="${pageComponent.componentPath}"
                                         data-cancelpropertyname="${pageComponent.cancelPropertyName}"
-                                        id="datarow-${pageComponentList.index}-${propertyList.index}"
+                                        id="datarow-${pageComponent.componentId}-${propertyList.index}"
                                         data-path="${property.path}"
                                         data-propertyname="${property.wrapper.propertyName}"
                                         data-language="${model.pageLanguage}"
@@ -243,7 +243,7 @@
                                         data-at="${property.wrapper.acceptedTranslation}"
                                         data-sd="${property.diffsHTML}"
                                         data-e="${property.wrapper.currentValue}"
-                                        data-id="${pageComponentList.index}-${propertyList.index}"
+                                        data-id="${pageComponent.componentId}-${propertyList.index}"
                                         data-isrich="${property.wrapper.isRichText}">
                                         <td is="coral-table-cell" class="previoussrc diffscolor">
                                             <sly data-sly-test="${hasData}">
@@ -347,7 +347,7 @@
                                         class="property-row actionrow ${property.cancelledClass} ${property.processingNeededClass}"
                                         data-componentpath="${pageComponent.componentPath}"
                                         data-cancelpropertyname="${pageComponent.cancelPropertyName}"
-                                        id="actionrow-${pageComponentList.index}-${propertyList.index}">
+                                        id="actionrow-${pageComponent.componentId}-${propertyList.index}">
                                         <td is="coral-table-cell" class="previoussrc diffscolor">
                                         </td>
                                         <td is="coral-table-cell" class="newsrc diffscolor">
@@ -377,7 +377,7 @@
                                         <td is="coral-table-cell" class="editor">
                                             <div class="editor-actions">
                                                 <sly data-sly-test="${cancelled}">
-                                                    <button is="coral-button" variant="primary" class="save-editor">
+                                                    <button is="coral-button" variant="secondary" class="save-editor">
                                                         Save and Finish
                                                         <coral-wait size="S" class="spinner"></coral-wait>
                                                     </button>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -209,16 +209,17 @@ class AITranslateMergeTool {
         url.searchParams.set('scope', 'allprops');
         url.searchParams.set('componentpath', componentpath);
         if (propertyname) url.searchParams.set('propertyname', propertyname);
-        console.log('reloadComponent', url.href);
+        console.log('reloadComponent', url.href, this);
         const tableBody = document.querySelector(".propertytable tbody");
         var selector = `tr[data-componentpath="${componentpath}"]`;
         if (propertyname) {
             selector += `[data-cancelpropertyname="${propertyname}"]`;
         } else {
-            selector += ':not([data-cancelpropertyname]';
+            selector += ':not([data-cancelpropertyname])';
         }
         const trs = tableBody.querySelectorAll(selector);
         if (!trs.length) {
+            console.error('Could not find elements to replace', selector, this);
             debugger;
         }
         fetch(url.href)
@@ -228,9 +229,6 @@ class AITranslateMergeTool {
                 tempDiv.innerHTML = html;
                 const replacements = tempDiv.querySelectorAll(".propertytable tbody tr");
                 const firsttr = trs[0];
-                if (!firsttr) {
-                    debugger;
-                }
                 replacements.forEach(tr => {
                     tableBody.insertBefore(tr, firsttr);
                 });
@@ -309,7 +307,7 @@ class AITranslateMergeRow {
         this.saveButton = this.actionrow.querySelector(".save-editor");
 
         if (this.rteContainer) {
-            new AITranslatorMergeRTE(this.rteContainer, tool);
+            new AITranslatorMergeRTE(this.rteContainer, tool, () => this.markSaveButton(true));
         }
 
         if (this.copyButton) this.copyButton.addEventListener("click", this.copyToEditor.bind(this));
@@ -317,7 +315,17 @@ class AITranslateMergeRow {
         if (this.acceptButton) this.acceptButton.addEventListener("click", this.acceptTranslation.bind(this));
 
         if (this.resetButton) this.resetButton.addEventListener("click", this.resetEditor.bind(this));
-        if (this.saveButton) this.saveButton.addEventListener("click", this.saveEditor.bind(this));
+        if (this.saveButton) {
+            this.saveButton.addEventListener("click", this.saveEditor.bind(this));
+            this.editor.addEventListener("change", () => this.markSaveButton(true));
+            this.editor.addEventListener("keyup", () => this.markSaveButton(true));
+            this.rteContainer?.addEventListener("input", () => this.markSaveButton(true));
+        }
+    }
+
+    /** Creates a visual alert when the editor is changed. */
+    markSaveButton(changed) {
+        this.saveButton.variant = changed ? "primary" : "secondary";
     }
 
     setEditorValue(value) {
@@ -329,14 +337,18 @@ class AITranslateMergeRow {
     }
 
     copyToEditor() {
+        console.log('copyToEditor', this);
         this.setEditorValue(this.row.dataset.nt || '');
     }
 
     resetEditor() {
+        console.log('resetEditor', this);
         this.setEditorValue(this.row.dataset.e || '');
+        this.markSaveButton(false);
     }
 
     intelligentMerge() {
+        console.log('intelligentMerge', this);
         const data = {
             path: this.row.dataset.path,
             propertyName: this.row.dataset.propertyname,
@@ -349,10 +361,12 @@ class AITranslateMergeRow {
         this.tool.callOperation(this.mergeButton, 'merge', data, mergedText => {
             this.setEditorValue(mergedText);
             console.log("Merge successful");
+            this.markSaveButton(true);
         });
     }
 
     saveEditor() {
+        console.log('saveEditor', this);
         const data = {
             path: this.row.dataset.path,
             propertyName: this.row.dataset.propertyname,
@@ -369,19 +383,14 @@ class AITranslateMergeRow {
                 this.row.classList.add("processed");
                 this.actionrow.classList.add("processed");
                 this.headerrow.classList.add("processed");
-                this.simulateButtonPress(this.saveButton);
+                this.markSaveButton(false);
             }
         });
     }
 
-    /** Makes the button green for a second. */
-    simulateButtonPress(button) {
-        // button.disabled = true;
-        // setTimeout(() => button.disabled = false, 1000);
-    }
-
     /** Calls the merge servlet with operation acceptTranslation and path and propertyName as POST parameters. */
     acceptTranslation() {
+        console.log('acceptTranslation', this);
         const data = {
             path: this.row.dataset.path,
             propertyName: this.row.dataset.propertyname
@@ -405,12 +414,13 @@ class AITranslateMergeRow {
 
 /** Manages the rich text editor functionalities, including toolbar actions and link management. */
 class AITranslatorMergeRTE {
-    constructor(container, tool) {
+    constructor(container, tool, markAsChangedCallback) {
         if (container.initialized) return;
         container.initialized = true;
         this.tool = tool;
         this.editor = container.querySelector(".rte-editor") || container.querySelector(".text-editor");
         this.toolbar = container.querySelector(".rte-toolbar");
+        this.markAsChangedCallback = markAsChangedCallback;
 
         this.toolbar?.addEventListener("click", this.handleToolbarClick.bind(this));
 
@@ -418,10 +428,12 @@ class AITranslatorMergeRTE {
     }
 
     handleToolbarClick(event) {
+        console.log("handleToolbarClick", event, this);
         const command = event.target.dataset.command;
         if (command) {
             document.execCommand(command, false, null);
             this.editor.focus(); // Refocus the editor after the action
+            this.markAsChangedCallback();
         }
     }
 
@@ -459,6 +471,7 @@ class AITranslatorMergeRTE {
     }
 
     editLink(anchor) {
+        console.log("edit link", anchor, this);
         let selectedText = undefined;
         if (!anchor) {
             // if selection is within this.editor, save it
@@ -477,6 +490,7 @@ class AITranslatorMergeRTE {
     }
 
     saveLink(anchor, linkModal) {
+        console.log("saveLink", anchor, linkModal, this);
         if (!anchor) {
             if (this.savedRange) {
                 const range = this.savedRange;
@@ -497,15 +511,18 @@ class AITranslatorMergeRTE {
         } else {
             linkModal.updateAnchor(anchor);
         }
+        this.markAsChangedCallback();
     }
 
     removeLink(anchor) {
+        console.log("removeLink", anchor, this);
         const range = document.createRange();
         const sel = window.getSelection();
         range.selectNodeContents(anchor);
         anchor.replaceWith(...anchor.childNodes);
         sel.removeAllRanges();
         sel.addRange(range);
+        this.markAsChangedCallback();
     }
 }
 
@@ -530,6 +547,7 @@ class AITranslateLinkEditModal {
     }
 
     editLink(anchor, selectedText, saveCallback) {
+        console.log("edit link", anchor, selectedText, saveCallback, this);
         this.saveCallback = saveCallback;
         this.anchor = anchor;
         // Pre-fill inputs with current anchor values if the anchor exists.
@@ -587,15 +605,18 @@ class AITranslateLinkEditModal {
     }
 
     saveLink() {
+        console.log("saveLink", this);
         this.saveCallback(this.anchor, this);
         this.hideModal();
     }
 
     hideModal() {
+        console.log("hideModal", this);
         this.modal.classList.add("hidden");
     }
 
     showModal() {
+        console.log("showModal", this);
         this.modal.classList.remove("hidden");
     }
 
@@ -628,6 +649,7 @@ class AITranslationPathChooser {
 
     /** Loads the column corresponding to the last element of the path. */
     async loadPath(path) {
+        console.log("loadPath", path, this);
         const url = path && path.startsWith('/') ? PATH_CHOOSER_URL + path : PATH_CHOOSER_URL;
         this.pathChooserContent.innerHTML = '';
         try {
@@ -655,6 +677,7 @@ class AITranslationPathChooser {
     }
 
     onSelect() {
+        console.log("onSelect", this);
         const path = this.pathDialog.querySelector('coral-checkbox[checked]')?.parentNode?.dataset?.foundationCollectionItemId;
         if (path) {
             this.pathInput.value = path;
@@ -663,6 +686,7 @@ class AITranslationPathChooser {
     }
 
     async selectItem(event) {
+        console.log("selectItem", event, this);
         const path = event?.target?.dataset?.foundationCollectionItemId;
         if (path) {
             await this.loadPath(path);
@@ -716,6 +740,7 @@ class AITranslationPathChooser {
 
     /** Finds the coral-columnview-item by the data-foundation-collection-item-id and checks that and scrolls it into view. */
     selectPath(path) {
+        console.log("selectPath", path, this);
         if (path) {
             const item = this.pathDialog.querySelector(`coral-columnview-item[data-foundation-collection-item-id="${path}"]`);
             if (item) {

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.js
@@ -11,6 +11,7 @@ class AITranslateMergeTool {
             this.reinitialize();
             this.readStateFromHistory();
             this.calculateWidths();
+            this.linkModal = new AITranslateLinkEditModal();
         });
     }
 
@@ -34,7 +35,6 @@ class AITranslateMergeTool {
             this.initComponentHead(row)
             row.initialized = true;
         });
-        this.linkModal = new AITranslateLinkEditModal();
     }
 
     initDatarow(row) {


### PR DESCRIPTION
This fixes a couple of bugs in the translation review and makes some small improvements:

- The save button is optically emphasized on changes, but only then, and reset when the changes are saved.
- Bugfix: after reenabling / cancelling inheritance the action row buttons often did not work
- If the page is empty because of missing blueprint or filtered properties then that is shown.
- On first call the selectors were on "all properties" but actually only changed properties were shown until the filter was explicitly set.