### PR TITLE
AI Translation Review Tool: show dedicated message for suspended pages

### DIFF
--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeModel.java
@@ -129,12 +129,30 @@ public class AutoTranslateMergeModel {
 
     public boolean isBlueprintBroken() {
         try {
-            LiveRelationship livecopy = liveRelationshipManager.getLiveRelationship(getPageResource(), true);
-            return livecopy == null || livecopy.getStatus() == null || !livecopy.getStatus().isSourceExisting();
+            LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(getPageResource(), true);
+            return relationship == null || relationship.getStatus() == null || !relationship.getStatus().isSourceExisting();
         } catch (WCMException e) {
             LOG.error("For " + getPageResource(), e);
         }
         return true;
+    }
+
+    /**
+     * If a whole page is suspended as a live copy then the jcr:content node has a cancelled relationship.
+     * Otherwise, the jcr:content node itself is never cancelled - only some of it's properties.
+     */
+    public boolean isPageSuspended() {
+        try {
+            LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(getPageResource(), true);
+            return relationship != null && relationship.getStatus() != null && relationship.getStatus().isCancelled();
+        } catch (WCMException e) {
+            LOG.error("For " + getPageResource(), e);
+        }
+        return true;
+    }
+
+    public String getLinkToPageProperties() {
+        return "/mnt/overlay/wcm/core/content/sites/properties.html?item=" + getPagePath();
     }
 
     public List<AutoTranslateComponent> getPageComponents() {
@@ -179,6 +197,9 @@ public class AutoTranslateMergeModel {
         return pageResource;
     }
 
+    /**
+     * The path to the cq:Page, without jcr:content.
+     */
     public String getPagePath() {
         return getPageResource() != null ? getPageResource().getParent().getPath() : null;
     }

--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -85,7 +86,9 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
             if (relationship == null) {
                 return false;
             }
-            return contentResource.getValueMap().get(AITranslatePropertyWrapper.PROPERTY_AI_TRANSLATED_DATE) != null;
+            Calendar lastAiTranslation = contentResource.getValueMap().get(AITranslatePropertyWrapper.PROPERTY_AI_TRANSLATED_DATE, Calendar.class);
+            LOG.debug("Last AI translation date: {}", lastAiTranslation != null ? lastAiTranslation.toInstant() : null);
+            return lastAiTranslation != null;
         } catch (WCMException e) {
             LOG.error("Could not determine relationships of " + resource.getPath(), e);
             return false;

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/bottombar-template.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/bottombar-template.html
@@ -1,18 +1,8 @@
 <template data-sly-template.bottombarTemplate="${@ model}">
     <section class="coral-Form-fieldset bottombar coral--light">
-        <p data-sly-test="${model.unfilteredPropertiesSize != 0 && model.properties.empty}">
-            <coral-alert variant="error">
-                <coral-alert-content class="alertcontent">No properties are matching the current filter settings.
-                </coral-alert-content>
-            </coral-alert>
-        </p>
-        <p data-sly-test="${model.blueprintBroken}">
-            <coral-alert variant="error">
-                <coral-alert-content class="alertcontent">Can't identify blueprint for this page.</coral-alert-content>
-            </coral-alert>
-        </p>
         <p class="errormessage" hidden>
             <coral-alert variant="error">
+                <coral-alert-header>An error has occurred.</coral-alert-header>
                 <coral-alert-content class="alertcontent"></coral-alert-content>
             </coral-alert>
         </p>

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -40,15 +40,33 @@
                             <a target="_blank" href="/editor.html${model.pagePath}.html">${model.pagePath}</a>
                         </h2>
                         <span class="coral-Form-field foundation-layout-util-breakword">
-                            This allows you to review the translated texts and either accept them (so that they won't shown here again until changed) or cancel inheritance for the component and edit the text manually. Inheritance can be changed
+                            This allows you to review the translated texts and either accept them (so that they won't
+                            be shown here again until changed) or cancel inheritance for the component and edit the text
+                            manually. Inheritance can be changed
                             usually only for the whole component at once with
                             <coral-icon icon="link" size="XS"></coral-icon> and
                             <coral-icon icon="linkOff" size="XS"></coral-icon>.
                             Hover with the mouse over a buttons or headers to get more information.
                         </span>
+                        <span class="coral-Form-field foundation-layout-util-breakword">
+                            This tool assumes that the page has been rolled out recently: the blueprint texts shown are
+                            the texts at the point of the last rollout.
+                        </span>
+
+                        <coral-alert variant="error" data-sly-test="${model.pageSuspended}">
+                            <coral-alert-content class="alertcontent">
+                                This page is suspended as a live copy and thus this tool is not available. You can
+                                resume this page as a live copy in the
+                                <a href="${model.linkToPageProperties}">page properties</a>
+                                in the "Live Copy" tab. After doing that you might want to re-open this tool to
+                                cancel the inheritance for any components where you don't want automatically overwritten
+                                or do that in the page editor, and then roll out the page so that everything is updated.
+                                After that the tool is fully available.
+                            </coral-alert-content>
+                        </coral-alert>
                     </section>
 
-                    <section class="coral-Form-fieldset propertytable">
+                    <section class="coral-Form-fieldset propertytable" data-sly-test="${!model.pageSuspended}">
                         <table is="coral-table">
 
                             <colgroup>
@@ -87,7 +105,8 @@
                                         there was a new translation, this is written into the page.</span>
                                         </coral-tooltip>
                                     </td>
-                                    <td is="coral-table-cell" colspan="6" id="componentlink-${pageComponent.componentPathInPage}+${pageComponent.cancelPropertyName}">
+                                    <td is="coral-table-cell" colspan="6"
+                                        id="componentlink-${pageComponent.componentPathInPage}+${pageComponent.cancelPropertyName}">
                                         <span class="componentName"
                                               data-sly-text="${pageComponent.componentName}"></span>
                                         <sly data-sly-test="${pageComponent.componentTitle}">

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/autotranslatemerge/list/list.html
@@ -39,7 +39,7 @@
                         <h2 class="coral-Form-fieldset-legend">Translation Review for page
                             <a target="_blank" href="/editor.html${model.pagePath}.html">${model.pagePath}</a>
                         </h2>
-                        <span class="coral-Form-field foundation-layout-util-breakword">
+                        <div class="coral-Form-field foundation-layout-util-breakword">
                             This allows you to review the translated texts and either accept them (so that they won't
                             be shown here again until changed) or cancel inheritance for the component and edit the text
                             manually. Inheritance can be changed
@@ -47,21 +47,35 @@
                             <coral-icon icon="link" size="XS"></coral-icon> and
                             <coral-icon icon="linkOff" size="XS"></coral-icon>.
                             Hover with the mouse over a buttons or headers to get more information.
-                        </span>
-                        <span class="coral-Form-field foundation-layout-util-breakword">
+                        </div>
+                        <div class="coral-Form-field foundation-layout-util-breakword">
                             This tool assumes that the page has been rolled out recently: the blueprint texts shown are
                             the texts at the point of the last rollout.
-                        </span>
+                        </div>
 
                         <coral-alert variant="error" data-sly-test="${model.pageSuspended}">
+                            <coral-alert-header>This page is suspended as a live copy and thus this tool is not available.</coral-alert-header>
                             <coral-alert-content class="alertcontent">
-                                This page is suspended as a live copy and thus this tool is not available. You can
-                                resume this page as a live copy in the
+                                You can resume this page as a live copy in the
                                 <a href="${model.linkToPageProperties}">page properties</a>
                                 in the "Live Copy" tab. After doing that you might want to re-open this tool to
                                 cancel the inheritance for any components where you don't want automatically overwritten
-                                or do that in the page editor, and then roll out the page so that everything is updated.
+                                or do that in the page editor, and then roll out the page so that everything is updated
+                                / synchronize the whole page.
                                 After that the tool is fully available.
+                            </coral-alert-content>
+                        </coral-alert>
+
+                        <coral-alert variant="info"
+                                     data-sly-test="${model.unfilteredPropertiesSize != 0 && model.properties.empty && !model.pageSuspended}">
+                            <coral-alert-content class="alertcontent">No properties are matching the current filter settings.
+                            </coral-alert-content>
+                        </coral-alert>
+
+                        <coral-alert variant="error"  data-sly-test="${model.blueprintBroken}">
+                            <coral-alert-header>Can't identify blueprint for this page.</coral-alert-header>
+                            <coral-alert-content class="alertcontent">
+                                This page is not a correct live copy since the blueprint cannot be determined.
                             </coral-alert-content>
                         </coral-alert>
                     </section>


### PR DESCRIPTION
This shows a dedicated message in the AI Translation Review Tool if the page is suspended as a live copy in the page properties "Live Copy" tab. Since it won't work properly in this setting we are not showing the properties in that case. (All properties would be shown as cancelled, and the tool relies on a recent rollout for showing the changed texts from the blueprint.)