### PR TITLE
Feature/fixes

### DIFF
--- a/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
+++ b/aem/core/src/main/java/com/composum/ai/aem/core/impl/autotranslate/AutoTranslateMergeServiceImpl.java
@@ -83,7 +83,7 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
                 }
             }
             LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(contentResource, true);
-            if (relationship == null) {
+            if (relationship == null || contentResource == null) {
                 return false;
             }
             Calendar lastAiTranslation = contentResource.getValueMap().get(AITranslatePropertyWrapper.PROPERTY_AI_TRANSLATED_DATE, Calendar.class);
@@ -103,7 +103,7 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
             ModifiableValueMap properties = res.adaptTo(ModifiableValueMap.class);
             try {
                 LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(res, true);
-                if (relationship != null) {
+                if (relationship != null && properties != null) {
                     String sourcePath = relationship.getSourcePath();
                     Resource sourceResource = res.getResourceResolver().getResource(sourcePath);
                     if (sourceResource != null) {
@@ -141,7 +141,7 @@ public class AutoTranslateMergeServiceImpl implements AutoTranslateMergeService 
     }
 
     @Override
-    public Map<String, String> saveTranslation(@Nonnull Resource resource, @Nonnull String propertyName, @Nonnull String content, @Nonnull boolean markAsMerged) throws WCMException {
+    public Map<String, String> saveTranslation(@Nonnull Resource resource, @Nonnull String propertyName, @Nonnull String content, boolean markAsMerged) throws WCMException {
         ModifiableValueMap properties = Objects.requireNonNull(resource.adaptTo(ModifiableValueMap.class));
         LiveRelationship relationship = liveRelationshipManager.getLiveRelationship(resource, true);
         if (relationship != null) {

--- a/aem/core/src/test/java/com/composum/ai/aem/core/impl/SelectorUtilsTest.java
+++ b/aem/core/src/test/java/com/composum/ai/aem/core/impl/SelectorUtilsTest.java
@@ -3,8 +3,6 @@ package com.composum.ai.aem.core.impl;
 import static com.composum.ai.aem.core.impl.SelectorUtils.getLanguageName;
 import static com.composum.ai.aem.core.impl.SelectorUtils.getLanguageSiblings;
 import static com.composum.ai.aem.core.impl.SelectorUtils.isLocaleName;
-import static org.mockito.Mockito.*;
-
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/aem/core/src/test/java/com/composum/ai/aem/core/impl/SelectorUtilsTest.java
+++ b/aem/core/src/test/java/com/composum/ai/aem/core/impl/SelectorUtilsTest.java
@@ -3,11 +3,13 @@ package com.composum.ai.aem.core.impl;
 import static com.composum.ai.aem.core.impl.SelectorUtils.getLanguageName;
 import static com.composum.ai.aem.core.impl.SelectorUtils.getLanguageSiblings;
 import static com.composum.ai.aem.core.impl.SelectorUtils.isLocaleName;
+import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.Locale;
 
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
 import org.junit.jupiter.api.Test;
 
 import io.wcm.testing.mock.aem.junit5.AemContext;
@@ -73,6 +75,24 @@ public class SelectorUtilsTest extends TestCase {
         result = getLanguageSiblings(context.resourceResolver().getResource("/content/ai/aem/core/es_ES/foo/bar"), "de_de");
         assertEquals(1, result.size());
         assertEquals("/content/ai/aem/core/de/foo/bar", result.get(0).getPath());
+    }
+
+    @Test
+    public void testFindLanguageMockito() {
+        Resource pageResource = mock(Resource.class);
+        Resource parentResource = mock(Resource.class);
+        ValueMap valueMap = mock(ValueMap.class);
+
+        when(pageResource.getPath()).thenReturn("/content/foo/ar/es-ar/bar");
+        when(pageResource.getValueMap()).thenReturn(valueMap);
+        when(pageResource.getParent()).thenReturn(parentResource);
+
+        when(parentResource.getValueMap()).thenReturn(valueMap);
+        // Ensure parent's parent is null to finish the loop
+        when(parentResource.getParent()).thenReturn(null);
+
+        String language = SelectorUtils.findLanguage(pageResource);
+        assertEquals("es-ar", language);
     }
 
 }


### PR DESCRIPTION
This fixes the problem that a path like /content/foo/ar/es-ar was treated as language Arabic instead of Spanish for Argentina and adds some unit tests of related code.