### PR TITLE
Switch default model from gpt-4o or gpt-4o-mini to gpt-4.1

### DIFF
--- a/ChatGPTAPI.md
+++ b/ChatGPTAPI.md
@@ -1,7 +1,7 @@
 # Analysis of about the ChatGPT API wrt. our needs
 
 At least initially we will restrict ourselves to the [ChatGPT chat API](https://platform.openai.com/docs/guides/chat) 
-with gpt-4o-mini , since that model is likely appropriate and sufficient for our purposes, and rather 
+with gpt-4.1 , since that model is likely appropriate and sufficient for our purposes, and rather 
 [competitively priced](https://openai.com/pricing) at
 $0.15 / 1M tokens (= about 600000-700000 words), as of 8/2024.
 

--- a/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/tool/bulkreplace/bulkreplace.html
+++ b/aem/ui.apps/src/main/content/jcr_root/apps/composum-ai/components/tool/bulkreplace/bulkreplace.html
@@ -47,7 +47,7 @@
                 <div class="col-sm-10">
                     <input type="text" class="form-control" id="search-string" placeholder="Enter search string (case sensitive)"
                            required data-toggle="tooltip"
-                           title="Search for a literal text string. The case is important since that might influence the replacement - if needed you could use two searches with different cases. Whitespace at the beginning and/or the end require a word boundary there.">
+                           title="Search for a literal text string. The case is important since that might influence the replacement - if needed you could use two searches with different cases. Whitespace at the beginning and/or the end require a word boundary there: searching for 'book' (without the quotes) will match 'book', 'books', and 'handbook'; searching for ' book' will find 'book' and 'books' but not 'handbook'; searching for 'book ' will find 'book' and 'handbook' but not 'books'; searching for ' book ' will find only 'book' but not 'books' or 'handbook'.">
                 </div>
             </div>
             <div class="form-group row">

--- a/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/GPTChatCompletionServiceImpl.java
+++ b/backend/base/src/main/java/com/composum/ai/backend/base/service/chat/impl/GPTChatCompletionServiceImpl.java
@@ -118,10 +118,10 @@ public class GPTChatCompletionServiceImpl extends GPTInternalOpenAIHelper.GPTInt
 
     protected static final Pattern PATTERN_TRY_AGAIN = Pattern.compile("Please try again in (\\d+)s.");
 
-    public static final String DEFAULT_MODEL = "gpt-4o";
-    public static final String DEFAULT_IMAGE_MODEL = "gpt-4o";
+    public static final String DEFAULT_MODEL = "gpt-4.1";
+    public static final String DEFAULT_IMAGE_MODEL = "gpt-4.1";
     public static final String DEFAULT_EMBEDDINGS_MODEL = "text-embedding-3-small";
-    public static final String DEFAULT_HIGH_INTELLIGENCE_MODEL = "gpt-4o";
+    public static final String DEFAULT_HIGH_INTELLIGENCE_MODEL = "gpt-4.1";
 
     protected static final int DEFAULTVALUE_CONNECTIONTIMEOUT = 30;
     protected static final int DEFAULTVALUE_REQUESTTIMEOUT = 300;
@@ -887,7 +887,7 @@ public class GPTChatCompletionServiceImpl extends GPTInternalOpenAIHelper.GPTInt
         String highIntelligenceModel() default DEFAULT_HIGH_INTELLIGENCE_MODEL;
 
         @AttributeDefinition(name = "Vision model", required = false,
-                description = "Optional, a model that is used if an image is given as input, e.g. gpt-4o. If not given, image recognition is rejected.",
+                description = "Optional, a model that is used if an image is given as input, e.g. gpt-4.1. If not given, image recognition is rejected.",
                 defaultValue = DEFAULT_IMAGE_MODEL)
         String imageModel() default DEFAULT_IMAGE_MODEL;
 

--- a/composum/config/src/main/content/jcr_root/libs/composum/pages/install/com.composum.ai.backend.base.service.chat.impl.GPTChatCompletionServiceImpl.cfg.json
+++ b/composum/config/src/main/content/jcr_root/libs/composum/pages/install/com.composum.ai.backend.base.service.chat.impl.GPTChatCompletionServiceImpl.cfg.json
@@ -1,6 +1,6 @@
 {
-  "defaultModel": "gpt-4o-mini",
-  "imageModel": "gpt-4o-mini",
+  "defaultModel": "gpt-4.1",
+  "imageModel": "gpt-4.1",
   "disable": false,
   "openAiApiKey": "${openai.api.key}"
 }

--- a/src/site/markdown/aem-variant/automaticTranslation.md
+++ b/src/site/markdown/aem-variant/automaticTranslation.md
@@ -225,6 +225,10 @@ the blueprint was modified after cancelling inheritance or the last merging are 
 optionally creating page versions before replacement and automatic publishing. This omits internal properties that are
 used for the AI translation (see it's specifications) but also replaces the text in those for the target language.
 
+`/apps/composum-ai/components/autotranslatemodelcompare.html` is a mini application that can be used to compare
+the translations different LLM provide for the same text - mostly for a pre-evaluation of the support different
+language models provide for different languages.
+
 ## Notes about the implementation
 
 - To have a painless startup, the identification of properties that need translation is heuristic. Standard

--- a/src/site/markdown/aem-variant/configuration.md
+++ b/src/site/markdown/aem-variant/configuration.md
@@ -42,26 +42,26 @@ For the OpenAI key there is a fallback hierarchy:
 
 For the OSGI configuration there are the following configurations:
 
-| id | name | type | default value | description |
-|----|------|------|---------------|-------------|
-| disabled | Disable | Boolean | false | Disable the GPT Chat Completion Service |
-| chatCompletionUrl | URL of the chat completion service | String |  | Optional, if not OpenAI's default https://api.openai.com/v1/chat/completions |
-| openAiApiKey | OpenAI API key | String |  | OpenAI API key from https://platform.openai.com/. If not given, we check the key file, the environment Variable OPENAI_API_KEY, and the system property openai.api.key . |
-| openAiOrganizationId | OpenAI Organization ID | String |  | Optionally, OpenAI Organization ID from https://platform.openai.com/account/organization . |
-| openAiApiKeyFile | OpenAI API key file | String |  | Key File containing the API key, as an alternative to Open AKI Key configuration and the variants described there. |
-| defaultModel | Default model | String | gpt-4o-mini | Default model to use for the chat completion. The default if not set is gpt-4o-mini. Please consider the varying prices https://openai.com/pricing . |
-| highIntelligenceModel | High intelligence model | String | gpt-4o | The model that is used for requests that need more reasoning performance. The default if not set is gpt-4o. Please consider the varying prices https://openai.com/pricing . |
-| imageModel | Vision model | String | gpt-4o | Optional, a model that is used if an image is given as input, e.g. gpt-4o. If not given, image recognition is rejected. |
-| temperature | Temperature | String |  | Optional temperature setting that determines variability and creativity as a floating point between 0.0 and 1.0 |
-| maximumTokensPerRequest | Maximum Tokens per Request | Integer | 50000 | If > 0 limit to the maximum number of tokens per request. That's about a twice the word count. Caution: Compare with the pricing - on GPT-4 models a thousand tokens might cost $0.01 or more. |
-| maximumTokensPerResponse | Maximum output tokens per request | Integer | 4096 | Maximum number of tokens to return in the response. Must not exceed the capabilities of the model - as of 10/03/24 this is 4096 for most OpenAI models - which is the default, so no need to set that. |
-| connectionTimeout | Connection timeout in seconds | Integer | 20 | Default 20 |
-| requestTimeout | Request timeout in seconds | Integer | 120 | Default 120 |
-| requestsPerMinute | Maximum requests per minute | Integer | 100 | Maximum count of requests to ChatGPT per minute - from the second half there will be a slowdown to avoid hitting the limit. Default 100 |
-| requestsPerHour | Maximum requests per hour | Integer | 1000 | Maximum count of requests to ChatGPT per hour - from the second half there will be a slowdown to avoid hitting the limit. Default 1000 |
-| requestsPerDay | Maximum requests per day | Integer | 3000 | Maximum count of requests to ChatGPT per day - from the second half there will be a slowdown to avoid hitting the limit. Default 3000 |
-| embeddingsUrl | URL of the embeddings service | String |  | Optional, if not OpenAI's default https://api.openai.com/v1/embeddings |
-| embeddingsModel | Embeddings model | String | text-embedding-3-small | Optional model to use for the embeddings. The default is text-embedding-3-small. |
+| id | name | type | default value          | description                                                                                                                                                                                            |
+|----|------|------|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| disabled | Disable | Boolean | false                  | Disable the GPT Chat Completion Service                                                                                                                                                                |
+| chatCompletionUrl | URL of the chat completion service | String |                        | Optional, if not OpenAI's default https://api.openai.com/v1/chat/completions                                                                                                                           |
+| openAiApiKey | OpenAI API key | String |                        | OpenAI API key from https://platform.openai.com/. If not given, we check the key file, the environment Variable OPENAI_API_KEY, and the system property openai.api.key .                               |
+| openAiOrganizationId | OpenAI Organization ID | String |                        | Optionally, OpenAI Organization ID from https://platform.openai.com/account/organization .                                                                                                             |
+| openAiApiKeyFile | OpenAI API key file | String |                        | Key File containing the API key, as an alternative to Open AKI Key configuration and the variants described there.                                                                                     |
+| defaultModel | Default model | String | gpt-4.1                | Default model to use for the chat completion. The default if not set is gpt-4.1. Please consider the varying prices https://openai.com/pricing .                                                       |
+| highIntelligenceModel | High intelligence model | String | gpt-4o                 | The model that is used for requests that need more reasoning performance. The default if not set is gpt-4o. Please consider the varying prices https://openai.com/pricing .                            |
+| imageModel | Vision model | String | gpt-4o                 | Optional, a model that is used if an image is given as input, e.g. gpt-4o. If not given, image recognition is rejected.                                                                                |
+| temperature | Temperature | String |                        | Optional temperature setting that determines variability and creativity as a floating point between 0.0 and 1.0                                                                                        |
+| maximumTokensPerRequest | Maximum Tokens per Request | Integer | 50000                  | If > 0 limit to the maximum number of tokens per request. That's about a twice the word count. Caution: Compare with the pricing - on GPT-4 models a thousand tokens might cost $0.01 or more.         |
+| maximumTokensPerResponse | Maximum output tokens per request | Integer | 4096                   | Maximum number of tokens to return in the response. Must not exceed the capabilities of the model - as of 10/03/24 this is 4096 for most OpenAI models - which is the default, so no need to set that. |
+| connectionTimeout | Connection timeout in seconds | Integer | 20                     | Default 20                                                                                                                                                                                             |
+| requestTimeout | Request timeout in seconds | Integer | 120                    | Default 120                                                                                                                                                                                            |
+| requestsPerMinute | Maximum requests per minute | Integer | 100                    | Maximum count of requests to ChatGPT per minute - from the second half there will be a slowdown to avoid hitting the limit. Default 100                                                                |
+| requestsPerHour | Maximum requests per hour | Integer | 1000                   | Maximum count of requests to ChatGPT per hour - from the second half there will be a slowdown to avoid hitting the limit. Default 1000                                                                 |
+| requestsPerDay | Maximum requests per day | Integer | 3000                   | Maximum count of requests to ChatGPT per day - from the second half there will be a slowdown to avoid hitting the limit. Default 3000                                                                  |
+| embeddingsUrl | URL of the embeddings service | String |                        | Optional, if not OpenAI's default https://api.openai.com/v1/embeddings                                                                                                                                 |
+| embeddingsModel | Embeddings model | String | text-embedding-3-small | Optional model to use for the embeddings. The default is text-embedding-3-small.                                                                                                                       |
 
 If Sling Context Aware Configuration contains an entry for `com.composum.ai.backend.slingbase.model.OpenAIConfig`,
 then the OpenAI API Key is taken from the configuration `openAiApiKey` of that `Composum AI OpenAI Configuration` of

--- a/src/site/markdown/composum-variant/configuration.md
+++ b/src/site/markdown/composum-variant/configuration.md
@@ -41,26 +41,26 @@ For the OpenAI key there is a fallback hierarchy:
 
 For the OSGI configuration there are the following configurations:
 
-| id | name | type | default value | description |
-|----|------|------|---------------|-------------|
-| disabled | Disable | Boolean | false | Disable the GPT Chat Completion Service |
-| chatCompletionUrl | URL of the chat completion service | String |  | Optional, if not OpenAI's default https://api.openai.com/v1/chat/completions |
-| openAiApiKey | OpenAI API key | String |  | OpenAI API key from https://platform.openai.com/. If not given, we check the key file, the environment Variable OPENAI_API_KEY, and the system property openai.api.key . |
-| openAiOrganizationId | OpenAI Organization ID | String |  | Optionally, OpenAI Organization ID from https://platform.openai.com/account/organization . |
-| openAiApiKeyFile | OpenAI API key file | String |  | Key File containing the API key, as an alternative to Open AKI Key configuration and the variants described there. |
-| defaultModel | Default model | String | gpt-4o-mini | Default model to use for the chat completion. The default if not set is gpt-4o-mini. Please consider the varying prices https://openai.com/pricing . |
-| highIntelligenceModel | High intelligence model | String | gpt-4o | The model that is used for requests that need more reasoning performance. The default if not set is gpt-4o. Please consider the varying prices https://openai.com/pricing . |
-| imageModel | Vision model | String | gpt-4o | Optional, a model that is used if an image is given as input, e.g. gpt-4o. If not given, image recognition is rejected. |
-| temperature | Temperature | String |  | Optional temperature setting that determines variability and creativity as a floating point between 0.0 and 1.0 |
-| maximumTokensPerRequest | Maximum Tokens per Request | Integer | 50000 | If > 0 limit to the maximum number of tokens per request. That's about a twice the word count. Caution: Compare with the pricing - on GPT-4 models a thousand tokens might cost $0.01 or more. |
-| maximumTokensPerResponse | Maximum output tokens per request | Integer | 4096 | Maximum number of tokens to return in the response. Must not exceed the capabilities of the model - as of 10/03/24 this is 4096 for most OpenAI models - which is the default, so no need to set that. |
-| connectionTimeout | Connection timeout in seconds | Integer | 20 | Default 20 |
-| requestTimeout | Request timeout in seconds | Integer | 120 | Default 120 |
-| requestsPerMinute | Maximum requests per minute | Integer | 100 | Maximum count of requests to ChatGPT per minute - from the second half there will be a slowdown to avoid hitting the limit. Default 100 |
-| requestsPerHour | Maximum requests per hour | Integer | 1000 | Maximum count of requests to ChatGPT per hour - from the second half there will be a slowdown to avoid hitting the limit. Default 1000 |
-| requestsPerDay | Maximum requests per day | Integer | 3000 | Maximum count of requests to ChatGPT per day - from the second half there will be a slowdown to avoid hitting the limit. Default 3000 |
-| embeddingsUrl | URL of the embeddings service | String |  | Optional, if not OpenAI's default https://api.openai.com/v1/embeddings |
-| embeddingsModel | Embeddings model | String | text-embedding-3-small | Optional model to use for the embeddings. The default is text-embedding-3-small. |
+| id | name | type | default value          | description                                                                                                                                                                                            |
+|----|------|------|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| disabled | Disable | Boolean | false                  | Disable the GPT Chat Completion Service                                                                                                                                                                |
+| chatCompletionUrl | URL of the chat completion service | String |                        | Optional, if not OpenAI's default https://api.openai.com/v1/chat/completions                                                                                                                           |
+| openAiApiKey | OpenAI API key | String |                        | OpenAI API key from https://platform.openai.com/. If not given, we check the key file, the environment Variable OPENAI_API_KEY, and the system property openai.api.key .                               |
+| openAiOrganizationId | OpenAI Organization ID | String |                        | Optionally, OpenAI Organization ID from https://platform.openai.com/account/organization .                                                                                                             |
+| openAiApiKeyFile | OpenAI API key file | String |                        | Key File containing the API key, as an alternative to Open AKI Key configuration and the variants described there.                                                                                     |
+| defaultModel | Default model | String | gpt-4.1                | Default model to use for the chat completion. The default if not set is gpt-4.1. Please consider the varying prices https://openai.com/pricing .                                                       |
+| highIntelligenceModel | High intelligence model | String | gpt-4o                 | The model that is used for requests that need more reasoning performance. The default if not set is gpt-4o. Please consider the varying prices https://openai.com/pricing .                            |
+| imageModel | Vision model | String | gpt-4o                 | Optional, a model that is used if an image is given as input, e.g. gpt-4o. If not given, image recognition is rejected.                                                                                |
+| temperature | Temperature | String |                        | Optional temperature setting that determines variability and creativity as a floating point between 0.0 and 1.0                                                                                        |
+| maximumTokensPerRequest | Maximum Tokens per Request | Integer | 50000                  | If > 0 limit to the maximum number of tokens per request. That's about a twice the word count. Caution: Compare with the pricing - on GPT-4 models a thousand tokens might cost $0.01 or more.         |
+| maximumTokensPerResponse | Maximum output tokens per request | Integer | 4096                   | Maximum number of tokens to return in the response. Must not exceed the capabilities of the model - as of 10/03/24 this is 4096 for most OpenAI models - which is the default, so no need to set that. |
+| connectionTimeout | Connection timeout in seconds | Integer | 20                     | Default 20                                                                                                                                                                                             |
+| requestTimeout | Request timeout in seconds | Integer | 120                    | Default 120                                                                                                                                                                                            |
+| requestsPerMinute | Maximum requests per minute | Integer | 100                    | Maximum count of requests to ChatGPT per minute - from the second half there will be a slowdown to avoid hitting the limit. Default 100                                                                |
+| requestsPerHour | Maximum requests per hour | Integer | 1000                   | Maximum count of requests to ChatGPT per hour - from the second half there will be a slowdown to avoid hitting the limit. Default 1000                                                                 |
+| requestsPerDay | Maximum requests per day | Integer | 3000                   | Maximum count of requests to ChatGPT per day - from the second half there will be a slowdown to avoid hitting the limit. Default 3000                                                                  |
+| embeddingsUrl | URL of the embeddings service | String |                        | Optional, if not OpenAI's default https://api.openai.com/v1/embeddings                                                                                                                                 |
+| embeddingsModel | Embeddings model | String | text-embedding-3-small | Optional model to use for the embeddings. The default is text-embedding-3-small.                                                                                                                       |
 
 If Sling Context Aware Configuration contains an entry for `com.composum.ai.backend.slingbase.model.OpenAIConfig`,
 then the OpenAI API Key is taken from the configuration `openAiApiKey` of that `Composum AI OpenAI Configuration` of

--- a/src/site/resources/differentialReTranslationDemonstration/differentialReTranslation.js
+++ b/src/site/resources/differentialReTranslationDemonstration/differentialReTranslation.js
@@ -10,7 +10,7 @@ async function handleTranslate() {
   }
 
   const requestBody = {
-    model: "gpt-4o-mini",
+    model: "gpt-4.1",
     messages: [
       {
         role: "system",


### PR DESCRIPTION
The model gpt-4.1 seems considerably better than gpt-4o and of course gpt-4o-mini, so we switch this since price isn't really a topic for something like this anymore.

The Sling CA configurations are a bit dangerous: if somebody switches off property inheritance then the default model is used, so it's probably better to keep this up to date.